### PR TITLE
Restore the status quo from before the sbncaf_srproxy branch

### DIFF
--- a/sbncode/CAFAna/StandardRecord/Proxy/CMakeLists.txt
+++ b/sbncode/CAFAna/StandardRecord/Proxy/CMakeLists.txt
@@ -4,6 +4,10 @@ add_custom_command(# Rebuild if anything in StandardRecord/ changes
                    DEPENDS ${SR_DEPENDENCIES}
                    OUTPUT SRProxy.cxx SRProxy.h FwdDeclare.h
                    COMMAND gen_srproxy -i sbncode/StandardRecord/StandardRecord.h -o SRProxy --target caf::StandardRecord --include-path $ENV{SBNCODE_DIR}:$ENV{ROOT_INC} -op sbncode/CAFAna/StandardRecord/Proxy/ --prolog $ENV{SBNCODE_DIR}/sbncode/CAFAna/StandardRecord/Proxy/Prolog.h --epilog-fwd $ENV{SBNCODE_DIR}/sbncode/CAFAna/StandardRecord/Proxy/EpilogFwd.h
+                   # Couldn't figure out how to make install() install the
+                   # headers so do it directly here
+                   COMMAND mkdir -p ${${product}_inc_dir}/CAFAna/StandardRecord/Proxy/
+                   COMMAND cp SRProxy.h FwdDeclare.h ${${product}_inc_dir}/CAFAna/StandardRecord/Proxy/
   )
 
 include_directories($ENV{SRPROXY_INC})
@@ -15,5 +19,5 @@ art_make_library(LIBRARY_NAME StandardRecordProxy
                  SOURCE       SRProxy.cxx Instantiations.cxx
                  LIBRARIES    ${ROOT_BASIC_LIB_LIST} ${ROOT_TREEPLAYER})
 
-#install(FILES SRProxy.h
+#install(FILES SRProxy.h FwdDeclare.h
 #         DESTINATION ${${product}_inc_dir}/CAFAna/StandardRecord/Proxy/)


### PR DESCRIPTION
Restore the status quo from before the sbncaf_srproxy branch overwrote it. No interesting CAFAna macros will run without the SRProxy generated files installed.