### PR TITLE
Save true visible energy per-plane. Clarify naming of visible energy …

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -90,6 +90,12 @@ namespace caf
       "fmatch" // same for icarus and sbnd
     };
 
+    Atom<string> HitLabel {
+      Name("HitLabel"),
+      Comment("Base label of the TPC Hit producer."),
+      "gaushit"
+    };
+
     Atom<string> RecoTrackLabel {
       Name("RecoTrackLabel"),
       Comment("Base label of reco-base track producer."),

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -639,7 +639,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 
     srneutrinos.push_back(SRTrueInteraction());
 
-    FillTrueNeutrino(mctruth, mcflux, true_particles, srneutrinos.back(), i);
+    FillTrueNeutrino(mctruth, mcflux, true_particles, id_to_truehit_map, srneutrinos.back(), i);
 
     srtruthbranch.nu  = srneutrinos;
     srtruthbranch.nnu = srneutrinos.size();

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -559,8 +559,6 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     art::fill_ptr_vector(simchannels, simchannel_handle);
   }
 
-  std::map<int, std::vector<const sim::IDE*>> id_to_ide_map = PrepSimChannels(simchannels);
-
   art::Handle<std::vector<simb::MCFlux>> mcflux_handle;
   GetByLabelStrict(evt, "generator", mcflux_handle);
 
@@ -586,6 +584,27 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   art::ServiceHandle<cheat::ParticleInventoryService> pi_serv;
   art::ServiceHandle<cheat::BackTrackerService> bt_serv;
   auto const clock_data = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
+  const geo::GeometryCore *geometry = lar::providerFrom<geo::Geometry>();
+
+  // Collect the input TPC reco tags
+  std::vector<std::string> pandora_tag_suffixes;
+  fParams.PandoraTagSuffixes(pandora_tag_suffixes);
+  if (pandora_tag_suffixes.size() == 0) pandora_tag_suffixes.push_back("");
+
+  // collect the TPC hits
+  std::vector<art::Ptr<recob::Hit>> hits;
+  for (unsigned i_tag = 0; i_tag < pandora_tag_suffixes.size(); i_tag++) {
+    const std::string &pandora_tag_suffix = pandora_tag_suffixes[i_tag];
+    art::Handle<std::vector<recob::Hit>> thisHits;
+    GetByLabelStrict(evt, fParams.HitLabel() + pandora_tag_suffix, thisHits);
+    if (thisHits.isValid()) {
+      art::fill_ptr_vector(hits, thisHits);
+    }
+  }
+
+  // Prep truth-to-reco-matching info
+  std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> id_to_ide_map = PrepSimChannels(simchannels, *geometry);
+  std::map<int, std::vector<art::Ptr<recob::Hit>>> id_to_truehit_map = PrepTrueHits(hits, clock_data, *bt_serv.get()); 
 
   //#######################################################
   // Fill truths & fake reco
@@ -602,6 +621,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
                          fActiveVolumes,
                          fTPCVolumes,
                          id_to_ide_map,
+                         id_to_truehit_map,
                          *bt_serv.get(),
                          *pi_serv.get(),
                          mctruths,
@@ -687,10 +707,6 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   }
 
   // collect the TPC slices
-  std::vector<std::string> pandora_tag_suffixes;
-  fParams.PandoraTagSuffixes(pandora_tag_suffixes);
-  if (pandora_tag_suffixes.size() == 0) pandora_tag_suffixes.push_back("");
-
   std::vector<art::Ptr<recob::Slice>> slices;
   std::vector<std::string> slice_tag_suffixes;
   std::vector<unsigned> slice_tag_indices;

--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -151,8 +151,8 @@ namespace caf {
       }
 
       srneutrino.plane0nhitprim = planehitIDs[0].size();
-      srneutrino.plane0nhitprim = planehitIDs[1].size();
-      srneutrino.plane0nhitprim = planehitIDs[2].size();
+      srneutrino.plane1nhitprim = planehitIDs[1].size();
+      srneutrino.plane2nhitprim = planehitIDs[2].size();
     }
 
     // Set of hits per-plane: all particles
@@ -171,8 +171,8 @@ namespace caf {
       }
 
       srneutrino.plane0nhit = planehitIDs[0].size();
-      srneutrino.plane0nhit = planehitIDs[1].size();
-      srneutrino.plane0nhit = planehitIDs[2].size();
+      srneutrino.plane1nhit = planehitIDs[1].size();
+      srneutrino.plane2nhit = planehitIDs[2].size();
     }
 
     // Set the MCFlux stuff

--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -117,7 +117,9 @@ namespace caf {
 
     srneutrino.index = i;
 
-    srneutrino.visE = 0.;
+    srneutrino.plane0VisE = 0.;
+    srneutrino.plane1VisE = 0.;
+    srneutrino.plane2VisE = 0.;
     for (unsigned i_part = 0; i_part < srparticles.size(); i_part++) {
       // save the G4 particles that came from this interaction
       if (srparticles[i_part].start_process == caf::kG4primary && srparticles[i_part].interaction_id == (int)i) {
@@ -125,7 +127,9 @@ namespace caf {
       }
       // total up the deposited energy
       if (srparticles[i_part].interaction_id == (int)i) {
-        srneutrino.visE += srparticles[i_part].planeVisE;
+        srneutrino.plane0VisE += srparticles[i_part].plane0VisE;
+        srneutrino.plane1VisE += srparticles[i_part].plane1VisE;
+        srneutrino.plane2VisE += srparticles[i_part].plane2VisE;
       }
     }
     srneutrino.nprim = srneutrino.prim.size();
@@ -187,23 +191,58 @@ namespace caf {
   void FillTrueG4Particle(const simb::MCParticle &particle,
         const std::vector<geo::BoxBoundedGeo> &active_volumes,
         const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
-                          const std::map<int, std::vector<const sim::IDE *>> &id_to_ide_map,
+        const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE *>>> &id_to_ide_map,
+        const std::map<int, std::vector<art::Ptr<recob::Hit>>> &id_to_truehit_map,
         const cheat::BackTrackerService &backtracker,
         const cheat::ParticleInventoryService &inventory_service,
         const std::vector<art::Ptr<simb::MCTruth>> &neutrinos,
                           caf::SRTrueParticle &srparticle) {
 
-    std::vector<const sim::IDE*> empty;
-    const std::vector<const sim::IDE*> &particle_ides = id_to_ide_map.count(particle.TrackId()) ? id_to_ide_map.at(particle.TrackId()) : empty;
+    std::vector<std::pair<geo::WireID, const sim::IDE *>> empty;
+    const std::vector<std::pair<geo::WireID, const sim::IDE *>> &particle_ides = id_to_ide_map.count(particle.TrackId()) ? id_to_ide_map.at(particle.TrackId()) : empty;
+
+    std::vector<art::Ptr<recob::Hit>> emptyHits;
+    const std::vector<art::Ptr<recob::Hit>> &particle_hits = id_to_truehit_map.count(particle.TrackId()) ? id_to_truehit_map.at(particle.TrackId()) : emptyHits;
 
     srparticle.length = 0.;
     srparticle.crosses_tpc = false;
     srparticle.wallin = caf::kWallNone;
     srparticle.wallout = caf::kWallNone;
-    srparticle.planeVisE = 0.;
-    for (auto const ide: particle_ides) {
-      srparticle.planeVisE += ide->energy / 1000. /* MeV -> GeV*/;
+    srparticle.plane0VisE = 0.;
+    srparticle.plane1VisE = 0.;
+    srparticle.plane2VisE = 0.;
+    srparticle.plane0nhit = 0;
+    srparticle.plane1nhit = 0;
+    srparticle.plane2nhit = 0;
+    for (auto const &ide_pair: particle_ides) {
+      const geo::WireID &w = ide_pair.first;
+      const sim::IDE *ide = ide_pair.second;
+
+      if (w.Plane == 0) {
+        srparticle.plane0VisE += ide->energy / 1000. /* MeV -> GeV*/;
+      }
+      else if (w.Plane == 1) {
+        srparticle.plane1VisE += ide->energy / 1000. /* MeV -> GeV*/;
+      }
+      else if (w.Plane == 2) {
+        srparticle.plane2VisE += ide->energy / 1000. /* MeV -> GeV*/;
+      }
     }
+
+    for (const art::Ptr<recob::Hit> h: particle_hits) {
+      const geo::WireID &w = h->WireID();
+
+      if (w.Plane == 0) {
+        srparticle.plane0nhit ++;
+      }
+      else if (w.Plane == 1) {
+        srparticle.plane1nhit ++;
+      }
+      else if (w.Plane == 2) {
+        srparticle.plane2nhit ++;
+      }
+
+    } 
 
     // if no trajectory points, then assume outside AV
     srparticle.cont_tpc = particle.NumberTrajectoryPoints() > 0;
@@ -331,6 +370,11 @@ namespace caf {
     srparticle.G4ID = particle.TrackId();
     srparticle.parent = particle.Mother();
 
+    // Save the daughter particles
+    for (int i_d = 0; i_d < particle.NumberDaughters(); i_d++) {
+      srparticle.daughters.push_back(particle.Daughter(i_d));
+    }
+
     // See if this MCParticle matches a genie truth
     srparticle.interaction_id = -1;
 
@@ -361,13 +405,31 @@ namespace caf {
     }
   }
 
-  std::map<int, std::vector<const sim::IDE*>> PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels) {
-    std::map<int, std::vector<const sim::IDE*>> ret;
+  std::map<int, std::vector<art::Ptr<recob::Hit>>> PrepTrueHits(const std::vector<art::Ptr<recob::Hit>> &allHits, 
+    const detinfo::DetectorClocksData &clockData, const cheat::BackTrackerService &backtracker) {
+    std::map<int, std::vector<art::Ptr<recob::Hit>>> ret;
+    for (const art::Ptr<recob::Hit> h: allHits) {
+      for (int ID: backtracker.HitToTrackIds(clockData, *h)) {
+        ret[abs(ID)].push_back(h);
+      }
+    }
+    return ret;
+  }
+
+  std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels, const geo::GeometryCore &geo) {
+    std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> ret;
+
     for (const art::Ptr<sim::SimChannel> sc : simchannels) {
+      // Lookup the wire of this channel
+      raw::ChannelID_t channel = sc->Channel();
+      std::vector<geo::WireID> maybewire = geo.ChannelToWire(channel);
+      geo::WireID thisWire; // Default constructor makes invalid wire
+      if (maybewire.size()) thisWire = maybewire[0];
+
       for (const auto &item : sc->TDCIDEMap()) {
         for (const sim::IDE &ide: item.second) {
           // indexing initializes empty vector
-          ret[abs(ide.trackID)].push_back(&ide);
+          ret[abs(ide.trackID)].push_back({thisWire, &ide});
         }
       }
     }
@@ -847,7 +909,7 @@ caf::SRTruthMatch MatchSlice2Truth(const std::vector<art::Ptr<recob::Hit>> &hits
     ret.visEinslc = total_energy / 1000. /* MeV -> GeV */;
     ret.visEcosmic = cosmic_energy / 1000. /* MeV -> GeV */;
     ret.pur = matching_energy[index] / total_energy;
-    ret.eff = (matching_energy[index] / 1000.) / srneutrinos[index].visE;
+    ret.eff = (matching_energy[index] / 1000.) / (srneutrinos[index].plane0VisE + srneutrinos[index].plane1VisE + srneutrinos[index].plane2VisE);
   }
   else {
     ret.pur = -1;

--- a/sbncode/CAFMaker/FillTrue.h
+++ b/sbncode/CAFMaker/FillTrue.h
@@ -52,6 +52,7 @@ namespace caf
   void FillTrueNeutrino(const art::Ptr<simb::MCTruth> mctruth, 
 			const simb::MCFlux &mcflux, 
 			const std::vector<caf::SRTrueParticle> &srparticles,
+                        const std::map<int, std::vector<art::Ptr<recob::Hit>>> &id_to_truehit_map,
 			caf::SRTrueInteraction &srneutrino, size_t i);
 
   void FillTrackTruth(const std::vector<art::Ptr<recob::Hit>> &hits,

--- a/sbncode/CAFMaker/FillTrue.h
+++ b/sbncode/CAFMaker/FillTrue.h
@@ -38,14 +38,15 @@ namespace caf
                       caf::SRSlice &srslice, caf::SRTruthBranch &srmc,
                       bool allowEmpty = false);
 
-  void FillTrueG4Particle(const simb::MCParticle &mcparticle, 
-			  const std::vector<geo::BoxBoundedGeo> &active_volumes,
-			  const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
-                          const std::map<int, std::vector<const sim::IDE *>> &id_to_ide_map,
-			  const cheat::BackTrackerService &backtracker,
-			  const cheat::ParticleInventoryService &inventory_service,
-			  const std::vector<art::Ptr<simb::MCTruth>> &neutrinos,
-                          caf::SRTrueParticle &srparticle); 
+  void FillTrueG4Particle(const simb::MCParticle &particle,
+        const std::vector<geo::BoxBoundedGeo> &active_volumes,
+        const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
+        const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE *>>> &id_to_ide_map,
+        const std::map<int, std::vector<art::Ptr<recob::Hit>>> &id_to_truehit_map,
+        const cheat::BackTrackerService &backtracker,
+        const cheat::ParticleInventoryService &inventory_service,
+        const std::vector<art::Ptr<simb::MCTruth>> &neutrinos,
+                          caf::SRTrueParticle &srparticle);
 
   // TODO: implement
   void FillTrueNeutrino(const art::Ptr<simb::MCTruth> mctruth, 
@@ -71,7 +72,9 @@ namespace caf
                     TRandom &rand,
                     std::vector<caf::SRFakeReco> &srfakereco);
 
-  std::map<int, std::vector<const sim::IDE*>> PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels);
+  std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels, const geo::GeometryCore &geo);
+  std::map<int, std::vector<art::Ptr<recob::Hit>>> PrepTrueHits(const std::vector<art::Ptr<recob::Hit>> &allHits, 
+    const detinfo::DetectorClocksData &clockData, const cheat::BackTrackerService &backtracker);
 
 }
 

--- a/sbncode/CAFMaker/cafmakerjob_icarus.fcl
+++ b/sbncode/CAFMaker/cafmakerjob_icarus.fcl
@@ -113,7 +113,7 @@ physics.producers.mycafmaker: @local::standard_cafmaker
 physics.producers.mycafmaker.CalorimetryConstants: @local::icarus_calorimetryalgmc.CalAreaConstants
 
 physics.producers.mycafmaker.PandoraTagSuffixes: ["Cryo0", "Cryo1"]
-physics.producers.mycafmaker.HitLabel: "pandoraGaus"
+physics.producers.mycafmaker.HitLabel: "cluster3D"
 physics.producers.mycafmaker.PFParticleLabel:   "pandoraGaus"
 physics.producers.mycafmaker.RecoShowerLabel:   "SBNShowerGaus"
 physics.producers.mycafmaker.RecoTrackLabel:    "pandoraTrackGaus"

--- a/sbncode/CAFMaker/cafmakerjob_icarus.fcl
+++ b/sbncode/CAFMaker/cafmakerjob_icarus.fcl
@@ -113,6 +113,7 @@ physics.producers.mycafmaker: @local::standard_cafmaker
 physics.producers.mycafmaker.CalorimetryConstants: @local::icarus_calorimetryalgmc.CalAreaConstants
 
 physics.producers.mycafmaker.PandoraTagSuffixes: ["Cryo0", "Cryo1"]
+physics.producers.mycafmaker.HitLabel: "pandoraGaus"
 physics.producers.mycafmaker.PFParticleLabel:   "pandoraGaus"
 physics.producers.mycafmaker.RecoShowerLabel:   "SBNShowerGaus"
 physics.producers.mycafmaker.RecoTrackLabel:    "pandoraTrackGaus"


### PR DESCRIPTION
…between TrueParticle/TrueInteraction. Save number of hits of each true particle per plane.

Depends on https://github.com/SBNSoftware/sbnanaobj/pull/6.

Also -- to preempt one possible issue. I have tested how long it takes to collect all of the hits of each MCParticle. For a few test overlay events from SBND MCP2020A, the process takes ~40ms/event. This does not significantly change the amount of time it takes to process an event through CAFMaker. The total time is still ~1s/event, which is about equal to other heavy-ish modules in the cafmaking step (like, e.g., MCS momentum fitting). 