### PR TITLE
feature/bckhouse_diff_cafs

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -382,10 +382,6 @@ void CAFMaker::AddEnvToFile()
 
   fFile->mkdir("env")->cd();
 
-  for(const auto& keyval: envmap){
-    TObjString(keyval.second.c_str()).Write(keyval.first.c_str());
-  }
-
   TTree* trenv = new TTree("envtree", "envtree");
   std::string key, value;
   trenv->Branch("key", &key);
@@ -415,10 +411,6 @@ void CAFMaker::AddMetadataToFile(const std::map<std::string, std::string>& metad
     trmeta->Fill();
   }
   trmeta->Write();
-
-  for(const auto& keyval: metadata) {
-    TObjString(keyval.second.c_str()).Write(keyval.first.c_str());
-  }
 }
 
 //......................................................................

--- a/sbncode/CAFMaker/CMakeLists.txt
+++ b/sbncode/CAFMaker/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories ( ${CMAKE_CURRENT_SOURCE_DIR} )
 FILE( GLOB src_files *.cxx )
 
 add_subdirectory(RecoUtils)
+add_subdirectory(bin)
 
 art_make_library( LIBRARY_NAME sbncode_CAFMaker
                   SOURCE ${src_files}

--- a/sbncode/CAFMaker/CMakeLists.txt
+++ b/sbncode/CAFMaker/CMakeLists.txt
@@ -37,6 +37,7 @@ art_make_library( LIBRARY_NAME sbncode_CAFMaker
                   sbnobj_Common_Reco
                   sbnobj_Common_Analysis
                   art_Framework_Services_System_TriggerNamesService_service
+                  sbncode_Metadata_MetadataSBN_service
                   )
 
 SET(ENV{IFHDC_LIB}   "$ENV{IFDHC_FQ_DIR}/lib")

--- a/sbncode/CAFMaker/bin/CMakeLists.txt
+++ b/sbncode/CAFMaker/bin/CMakeLists.txt
@@ -3,5 +3,7 @@ cet_make_exec( extractCAFMetadata
                LIBRARIES ${ROOT_BASIC_LIB_LIST}
                )
 
+cet_script(diff_cafs)
+
 install_headers()
 install_source()

--- a/sbncode/CAFMaker/bin/CMakeLists.txt
+++ b/sbncode/CAFMaker/bin/CMakeLists.txt
@@ -1,0 +1,7 @@
+cet_make_exec( extractCAFMetadata
+               SOURCE extractCAFMetadata.cc
+               LIBRARIES ${ROOT_BASIC_LIB_LIST}
+               )
+
+install_headers()
+install_source()

--- a/sbncode/CAFMaker/bin/diff_cafs
+++ b/sbncode/CAFMaker/bin/diff_cafs
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Prints out all fields that differ")
+parser.add_argument("files", metavar="<FILE>.caf.root", nargs=2, help="2 files to compare")
+parser.add_argument("-t", "--tolerance",   default=1e-20,  help="Tolerance for float comparison", metavar="TOL", type=float)
+parser.add_argument("-i", "--ignore",  dest="ignore",      help="Regex pattern to ignore",        metavar="PAT", default=False)
+parser.add_argument("-n", "--nevents", dest="nevents",     help="Number of events to compare",    metavar="NEVT", default=-1, type=int)
+
+args = parser.parse_args()
+
+import os, sys
+import re
+from ROOT import *
+
+import inspect
+import math
+
+if args.ignore:
+    ignorepat = re.compile(args.ignore)
+else:
+    ignorepat = None
+
+fA = TFile.Open(args.files[0], 'READ')
+fB = TFile.Open(args.files[1], 'READ')
+
+trA = fA.Get('recTree')
+trB = fB.Get('recTree')
+
+
+def GetMembers(obj, prefix, res):
+    for var in inspect.getmembers(obj):
+        if var[0].startswith('__') or callable(var[1]): continue
+
+        key = prefix+'.'+var[0]
+        val = var[1]
+
+        if callable(val): continue
+
+        # Debug stack overflows by uncommenting this
+        #    print(key, val, type(val))
+
+        if isinstance(val, (int, long, float)):
+            res[key] = val
+        elif 'vector' in str(type(val)):
+            res[key+'.size()'] = val.size()
+            for i in range(0, val.size()):
+                GetMembers(val.at(i), key+'['+str(i)+']', res)
+        elif isinstance(val, TVector3):
+            res[key] = (val.X(), val.Y(), val.Z())
+        elif isinstance(val, TLorentzVector):
+            res[key] = (val.E(), val.X(), val.Y(), val.Z())
+        else:
+            GetMembers(val, key, res)
+
+
+def Equiv(a, b):
+    if isinstance(a, float) and isinstance(b, float):
+        if math.isnan(a) and math.isnan(b): return True
+        if math.isinf(a) and math.isinf(b) and (a > 0) == (b > 0): return True
+        return math.fabs(a-b) < args.tolerance
+
+    if isinstance(a, tuple) and isinstance(b, tuple):
+        if len(a) != len(b): return False
+        for i in range(0, len(a)):
+            if not Equiv(a[i], b[i]): return False
+        return True
+
+    return a == b
+
+
+ret = 0 # zero exit code = success
+
+if trA.GetEntries() != trB.GetEntries():
+    print('Files have different numbers of entries:', trA.GetEntries(), 'vs', trB.GetEntries())
+    ret = 1 # count differing lengths as failure
+
+count = min(trA.GetEntries(), trB.GetEntries())
+if args.nevents > 0:
+    count = min(count, args.nevents)
+
+for i in range(0, count):
+    trA.GetEntry(i)
+    trB.GetEntry(i)
+
+    print('Checking record', i)
+
+    resA = {}
+    GetMembers(trA.rec, 'rec', resA)
+    resB = {}
+    GetMembers(trB.rec, 'rec', resB)
+
+    for key in resB:
+        if ignorepat and ignorepat.search(key): continue
+        if not key in resA:
+            print(' ', key, 'in file B not found in file A')
+
+    for key in resA:
+        if ignorepat and ignorepat.search(key): continue
+        if not key in resB:
+            print(' ', key, 'in file A not found in file B')
+            continue
+
+        valA = resA[key]
+        valB = resB[key]
+        if not Equiv(valA, valB):
+            print(' ', key, 'differs:', valA, 'vs', valB)
+            ret = 1 # return failure exit code
+
+exit(ret)

--- a/sbncode/CAFMaker/bin/extractCAFMetadata.cc
+++ b/sbncode/CAFMaker/bin/extractCAFMetadata.cc
@@ -1,0 +1,93 @@
+#include <iostream>
+#include <string>
+
+#include <sys/stat.h>
+
+#include "TError.h"
+#include "TFile.h"
+#include "TTree.h"
+
+std::string escapeQuotes(std::string str)
+{
+  size_t pos = 0;
+  while(true){
+    pos = str.find("\"", pos);
+    if(pos == std::string::npos) return str;
+    str.replace(pos, 1, "\\\"");
+    pos += 2; // Where to start looking next time
+  }
+}
+
+int main(int argc, char** argv)
+{
+  gErrorIgnoreLevel = 100000;
+
+  if(argc < 2){
+    std::cerr << "Usage: must supply at least one filename as an argument"
+              << std::endl;
+    exit(1);
+  }
+
+  std::cout << "{" << std::endl;
+
+  for(int i = 1; i < argc; ++i){
+    const std::string filePath = argv[i];
+
+    struct stat buf;
+    if(stat(filePath.c_str(), &buf) != 0){
+      std::cerr << "ERROR: File does not exist: " << filePath << std::endl;
+      continue;
+    }
+    
+    const char* base = basename(filePath.c_str());
+
+    std::unique_ptr<TFile> f(TFile::Open(filePath.c_str(), "READ"));
+    
+    if(!f->IsOpen()){
+      std::cerr << "ERROR: Unable to open " << filePath
+                << " as a TFile, is this a proper ROOT file?" << std::endl;
+      continue;
+    }
+
+    std::cout << "  \"" << base << "\": {" << std::endl;
+
+    TDirectory* metadata = f->GetDirectory("metadata");
+    if(!metadata){
+      std::cerr << "ERROR: Unable to access metadata in " << filePath
+                << " is this a proper CAF with metadata?" << std::endl;
+      continue;
+    }
+
+    TTree* tr = (TTree*)metadata->Get("metatree");
+    if(!tr){
+      std::cerr << "ERROR: Unable to access metadata tree in " << filePath
+                << " is this a proper CAF with metadata?" << std::endl;
+      continue;
+    }
+
+    std::string key, value;
+    std::string* pkey = &key;
+    std::string* pvalue = &value;
+    tr->SetBranchAddress("key", &pkey);
+    tr->SetBranchAddress("value", &pvalue);
+
+    bool first = true;
+    for(int i = 0; i < tr->GetEntries(); ++i){
+      if(!first) std::cout << "," << std::endl;
+      first = false;
+
+      tr->GetEntry(i);
+
+      std::cout << "    \"" << key << "\": ";
+      //      if(value.empty()) value = "none";
+      std::cout << "\"" << escapeQuotes(value) << "\"";
+    }
+    std::cout << "\n  }";
+    if(i < argc-1) std::cout << ",";
+    std::cout << std::endl;
+  } // end for i
+
+  std::cout << "}" << std::endl;
+
+  return 0;
+}

--- a/sbncode/CAFMaker/bin/extractCAFMetadata.cc
+++ b/sbncode/CAFMaker/bin/extractCAFMetadata.cc
@@ -7,87 +7,67 @@
 #include "TFile.h"
 #include "TTree.h"
 
-std::string escapeQuotes(std::string str)
-{
-  size_t pos = 0;
-  while(true){
-    pos = str.find("\"", pos);
-    if(pos == std::string::npos) return str;
-    str.replace(pos, 1, "\\\"");
-    pos += 2; // Where to start looking next time
-  }
-}
-
 int main(int argc, char** argv)
 {
   gErrorIgnoreLevel = 100000;
 
-  if(argc < 2){
-    std::cerr << "Usage: must supply at least one filename as an argument"
-              << std::endl;
+  if(argc != 2){
+    std::cerr << "Usage: must supply one filename as an argument" << std::endl;
     exit(1);
   }
 
-  std::cout << "{" << std::endl;
+  const std::string filePath = argv[1];
 
-  for(int i = 1; i < argc; ++i){
-    const std::string filePath = argv[i];
+  struct stat buf;
+  if(stat(filePath.c_str(), &buf) != 0){
+    std::cerr << "ERROR: File does not exist: " << filePath << std::endl;
+    exit(1);
+  }
 
-    struct stat buf;
-    if(stat(filePath.c_str(), &buf) != 0){
-      std::cerr << "ERROR: File does not exist: " << filePath << std::endl;
-      continue;
-    }
-    
-    const char* base = basename(filePath.c_str());
+  std::unique_ptr<TFile> f(TFile::Open(filePath.c_str(), "READ"));
 
-    std::unique_ptr<TFile> f(TFile::Open(filePath.c_str(), "READ"));
-    
-    if(!f->IsOpen()){
-      std::cerr << "ERROR: Unable to open " << filePath
-                << " as a TFile, is this a proper ROOT file?" << std::endl;
-      continue;
-    }
+  if(!f->IsOpen()){
+    std::cerr << "ERROR: Unable to open " << filePath
+              << " as a TFile, is this a proper ROOT file?" << std::endl;
+    exit(1);
+  }
 
-    std::cout << "  \"" << base << "\": {" << std::endl;
+  TDirectory* metadata = f->GetDirectory("metadata");
+  if(!metadata){
+    std::cerr << "ERROR: Unable to access metadata in " << filePath
+              << " is this a proper CAF with metadata?" << std::endl;
+    exit(1);
+  }
 
-    TDirectory* metadata = f->GetDirectory("metadata");
-    if(!metadata){
-      std::cerr << "ERROR: Unable to access metadata in " << filePath
-                << " is this a proper CAF with metadata?" << std::endl;
-      continue;
-    }
+  TTree* tr = (TTree*)metadata->Get("metatree");
+  if(!tr){
+    std::cerr << "ERROR: Unable to access metadata tree in " << filePath
+              << " is this a proper CAF with metadata?" << std::endl;
+    exit(1);
+  }
 
-    TTree* tr = (TTree*)metadata->Get("metatree");
-    if(!tr){
-      std::cerr << "ERROR: Unable to access metadata tree in " << filePath
-                << " is this a proper CAF with metadata?" << std::endl;
-      continue;
-    }
+  std::cout << "{\n";
 
-    std::string key, value;
-    std::string* pkey = &key;
-    std::string* pvalue = &value;
-    tr->SetBranchAddress("key", &pkey);
-    tr->SetBranchAddress("value", &pvalue);
+  std::string key, value;
+  std::string* pkey = &key;
+  std::string* pvalue = &value;
+  tr->SetBranchAddress("key", &pkey);
+  tr->SetBranchAddress("value", &pvalue);
 
-    bool first = true;
-    for(int i = 0; i < tr->GetEntries(); ++i){
-      if(!first) std::cout << "," << std::endl;
-      first = false;
+  bool first = true;
+  for(int i = 0; i < tr->GetEntries(); ++i){
+    if(!first) std::cout << "," << std::endl;
+    first = false;
 
-      tr->GetEntry(i);
+    tr->GetEntry(i);
 
-      std::cout << "    \"" << key << "\": ";
-      //      if(value.empty()) value = "none";
-      std::cout << "\"" << escapeQuotes(value) << "\"";
-    }
-    std::cout << "\n  }";
-    if(i < argc-1) std::cout << ",";
-    std::cout << std::endl;
-  } // end for i
-
-  std::cout << "}" << std::endl;
+    std::cout << "  \"" << key << "\": ";
+    //      if(value.empty()) value = "\"none\"";
+    // The convention is that values are already suitably escaped inside the
+    // CAF file.
+    std::cout << value;
+  }
+  std::cout << "\n}" << std::endl;
 
   return 0;
 }

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -27,6 +27,7 @@ add_subdirectory(OpDet)
 add_subdirectory(OpT0Finder)
 
 add_subdirectory(CAFMaker)
+add_subdirectory(Metadata)
 
 add_subdirectory(FlashMatch)
 add_subdirectory(LArRecoProducer)

--- a/sbncode/Metadata/CMakeLists.txt
+++ b/sbncode/Metadata/CMakeLists.txt
@@ -1,0 +1,25 @@
+cet_enable_asserts()
+
+set( sbn_meta_lib_list   ${ART_FRAMEWORK_CORE}
+                         ${ART_FRAMEWORK_PRINCIPAL}
+                         ${ART_FRAMEWORK_SERVICES_REGISTRY}
+                         ${ART_FRAMEWORK_SERVICES_BASIC}
+                         ${ART_FRAMEWORK_SERVICES_SYSTEM_FILECATALOGMETADATA_SERVICE}
+                         art_Framework_Services_System_TriggerNamesService_service
+                         ${MF_MESSAGELOGGER}
+                         ${ROOT_BASIC_LIB_LIST}
+    )
+
+simple_plugin( FileCatalogMetadataSBN  "service"
+               ${sbn_meta_lib_list}
+        )
+
+simple_plugin( MetadataSBN "service"
+               ${sbn_meta_lib_list}
+               art_Framework_IO
+               art_Framework_IO_detail
+        )
+
+install_headers()
+install_fhicl()
+install_source()

--- a/sbncode/Metadata/FileCatalogMetadataSBN.h
+++ b/sbncode/Metadata/FileCatalogMetadataSBN.h
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////////////////
+//
+// Name:  FileCatalogMetadataSBN.h.  
+//
+// Purpose:  Art service adds microboone-specific per-job sam metadata.
+//
+//           FCL parameters:
+//
+//           FCLName        - FCL file name.
+//           FCLVersion     - FCL file version.
+//           ProjectName    - Project name.
+//           ProjectStage   - Project stage.
+//           ProjectVersion - Project version.
+//
+//           Above values will be added in internal metadata of artroot
+//           output files whenever this service is included in job
+//           configuration (service does not need to be called).  The
+//           public interface of this service consists of accessors that
+//           allow other code to discover above metadata parameters.
+//
+// Created:  28-Oct-2014,  H. Greenlee
+//
+////////////////////////////////////////////////////////////////////////
+
+#ifndef FILECATALOGMETADATASBN_H
+#define FILECATALOGMETADATASBN_H
+
+#include "fhiclcpp/ParameterSet.h"
+#include "art/Framework/Services/Registry/ActivityRegistry.h"
+#include "art/Framework/Services/Registry/ServiceMacros.h"
+
+namespace util {
+
+  class FileCatalogMetadataSBN
+  {
+  public:
+
+    // Constructor, destructor.
+
+    FileCatalogMetadataSBN(fhicl::ParameterSet const& pset, art::ActivityRegistry& reg);
+    ~FileCatalogMetadataSBN() = default;
+
+    // Accessors.
+
+    const std::string& GetFCLName() const {return fFCLName;}
+    const std::string& GetProjectName() const {return fProjectName;}
+    const std::string& GetProjectStage() const {return fProjectStage;}
+    const std::string& GetProjectVersion() const {return fProjectVersion;}
+    const std::string& GetProjectSoftware() const {return fProjectSoftware;}
+    const std::string& GetProductionName() const {return fProductionName;}
+    const std::string& GetProductionType() const {return fProductionType;}
+
+
+  private:
+
+    // Callbacks.
+
+    void postBeginJob();
+
+    // Data members.
+
+    std::string fFCLName;
+    std::string fProjectName;
+    std::string fProjectStage;
+    std::string fProjectVersion;
+    std::string fProjectSoftware;
+    std::string fProductionName; //Production parameter, do not use if not running a production
+    std::string fProductionType; //Production parameter, do not use if not running a production
+  };
+
+} // namespace util
+
+DECLARE_ART_SERVICE(util::FileCatalogMetadataSBN, LEGACY)
+
+#endif

--- a/sbncode/Metadata/FileCatalogMetadataSBN_service.cc
+++ b/sbncode/Metadata/FileCatalogMetadataSBN_service.cc
@@ -1,0 +1,57 @@
+////////////////////////////////////////////////////////////////////////
+// Name:  FileCatalogMetadataSBN_service.cc.  
+//
+// Purpose:  Implementation for FileCatalogMetadataSBN.
+//
+// Created:  28-Oct-2014,  H. Greenlee
+//
+////////////////////////////////////////////////////////////////////////
+
+#include "sbncode/Metadata/FileCatalogMetadataSBN.h"
+
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Framework/Services/System/FileCatalogMetadata.h"
+
+//--------------------------------------------------------------------
+// Constructor.
+
+util::FileCatalogMetadataSBN::
+FileCatalogMetadataSBN(fhicl::ParameterSet const& pset, art::ActivityRegistry& reg)
+{
+  // Get parameters.
+
+  fFCLName = pset.get<std::string>("FCLName");
+  fProjectName = pset.get<std::string>("ProjectName");
+  fProjectStage = pset.get<std::string>("ProjectStage");
+  fProjectVersion = pset.get<std::string>("ProjectVersion");    
+  fProjectSoftware = pset.get<std::string>("ProjectSoftware","");    
+  fProductionName = pset.get<std::string>("ProductionName","");  //Leave as default value if not running a production   
+  fProductionType = pset.get<std::string>("ProductionType",""); //Leave as default value if not running a production
+
+
+  // Register for callbacks.
+
+  reg.sPostBeginJob.watch(this, &FileCatalogMetadataSBN::postBeginJob);
+}
+
+//--------------------------------------------------------------------
+// PostBeginJob callback.
+// Insert per-job metadata via FileCatalogMetadata service.
+void util::FileCatalogMetadataSBN::postBeginJob()
+{
+  // Get art metadata service.
+
+  art::ServiceHandle<art::FileCatalogMetadata> mds;
+
+  // Add metadata.
+
+  mds->addMetadata("fcl.name", fFCLName);
+  mds->addMetadata("sbnd_project.name", fProjectName);
+  mds->addMetadata("sbnd_project.stage", fProjectStage);
+  mds->addMetadata("sbnd_project.version", fProjectVersion);
+  mds->addMetadata("sbnd_project.software", fProjectSoftware);
+  mds->addMetadata("production.name", fProductionName);
+  mds->addMetadata("production.type", fProductionType);
+}
+
+DEFINE_ART_SERVICE(util::FileCatalogMetadataSBN)

--- a/sbncode/Metadata/MetadataSBN.h
+++ b/sbncode/Metadata/MetadataSBN.h
@@ -1,0 +1,97 @@
+////////////////////////////////////////////////////////////////////////
+// Name: MetadataSBN.h
+//
+// A struct datatype to hold the metadata information as it is extracted
+// from various places.
+//
+// Created: 21-Feb-2017,  D. Brailsford
+//   Based on the DUNE version T. Junk which is based on the MicroBooNE
+//   version by S. Gollapinni
+//
+////////////////////////////////////////////////////////////////////////
+#ifndef TFILEMETADATASBN_H
+#define TFILEMETADATASBN_H
+
+#include "art/Framework/Services/Registry/ActivityRegistry.h"
+#include "art/Framework/Services/Registry/ServiceMacros.h"
+#include "art/Framework/Principal/fwd.h"
+#include "art/Framework/IO/PostCloseFileRenamer.h"
+#include "art/Framework/IO/FileStatsCollector.h"
+#include "art/Persistency/Provenance/ScheduleContext.h"
+#include "canvas/Persistency/Provenance/IDNumber.h"
+#include "fhiclcpp/ParameterSet.h"
+
+#include <time.h>
+#include <fstream>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace util{
+
+  class MetadataSBN
+  {
+  public:
+    MetadataSBN(fhicl::ParameterSet const& pset, art::ActivityRegistry& reg);
+
+    struct metadata {
+      std::tuple<std::string, std::string, std::string> fapplication;
+      //no crc information yet
+      //std::vector<std::string> fcrcs;
+      std::string fdata_tier;
+      time_t fend_time;
+      unsigned int fevent_count=0;
+      std::string ffile_format;
+      std::string ffile_type;
+      art::EventNumber_t ffirst_event=0;
+      std::string fgroup;
+      art::EventNumber_t flast_event=0;
+      std::set<std::string> fParents;
+      std::vector<std::tuple<art::RunNumber_t,art::SubRunNumber_t,std::string>> fruns;
+      time_t fstart_time=0;
+      std::string fFCLName;
+      std::string fProjectName;
+      std::string fProjectStage;
+      std::string fProjectVersion;
+      std::string fProjectSoftware;
+      std::string fProductionName; //Production parameter, do not use if not running a production
+      std::string fProductionType; //Production parameter, do not use if not running a production
+    };
+
+    metadata md;
+    std::set<art::SubRunID> fSubRunNumbers;
+
+    void GetMetadataMaps(std::map<std::string, std::string>& strs,
+                         std::map<std::string, int>& ints,
+                         std::map<std::string, std::string>& objs);
+
+  private:
+
+    // Callbacks.
+    void postBeginJob();
+    void postOpenInputFile(std::string const& fn);
+    void postEvent(art::Event const& ev, art::ScheduleContext);
+    void postBeginSubRun(art::SubRun const& subrun);
+    void postCloseInputFile();
+
+    std::string GetParentsString() const;
+    std::string GetRunsString() const;
+
+    std::map<std::string,std::string> mdmapStr;
+    std::map<std::string, int> mdmapInt;
+    std::map<std::string, std::string> mdmapObj;
+
+    // Fcl parameters.
+    std::string fExperiment;
+    std::string frunType;
+    std::string fJSONFileName;
+    art::FileStatsCollector fFileStats;
+    art::PostCloseFileRenamer fRenamer{fFileStats};
+  }; // class MetadataSBN
+
+} //namespace utils
+
+DECLARE_ART_SERVICE(util::MetadataSBN, LEGACY)
+
+#endif

--- a/sbncode/Metadata/MetadataSBN_service.cc
+++ b/sbncode/Metadata/MetadataSBN_service.cc
@@ -245,7 +245,7 @@ std::string util::MetadataSBN::GetRunsString() const
   std::string ret = "[\n";
   for(auto&t :md.fruns){
     c++;
-    ret += "    [\n     " + std::to_string(std::get<0>(t)) + ",\n     " + std::to_string(std::get<1>(t)) + ",\n     " + std::get<2>(t) + "\n    ]";
+    ret += "    [\n     " + std::to_string(std::get<0>(t)) + ",\n     " + std::to_string(std::get<1>(t)) + ",\n     \"" + std::get<2>(t) + "\"\n    ]";
     if(md.fruns.size() == 1 || c == md.fruns.size()) ret += "\n";
     else ret += ",\n";
   }
@@ -293,7 +293,6 @@ void util::MetadataSBN::GetMetadataMaps(std::map<std::string, std::string>& strs
 
   MaybeCopyToMap(md.fgroup, "group", strs);
   MaybeCopyToMap(md.ffile_type, "file_type", strs);
-  MaybeCopyToMap(frunType, "art.run_type", strs);
 }
 
 //--------------------------------------------------------------------

--- a/sbncode/Metadata/MetadataSBN_service.cc
+++ b/sbncode/Metadata/MetadataSBN_service.cc
@@ -1,0 +1,344 @@
+////////////////////////////////////////////////////////////////////////
+// Name:  MetadataSBN_service.cc.
+//
+// Purpose:  generate SBN-specific sam metadata for root Tfiles (histogram or ntuple files).
+//
+// FCL parameters: dataTier: Currrently this needs to be parsed by the user
+//		     	     for ntuples, dataTier = root-tuple;
+//		             for histos, dataTier = root-histogram
+//		             (default value: root-tuple)
+//	           fileFormat: This is currently specified by the user,
+//			       the fileFormat for Tfiles is "root" (default value: root)
+//
+// Other notes: 1. This service uses the ART's standard file_catalog_metadata service
+//		to extract some of the common (common to both ART and TFile outputs)
+//	        job-specific metadata parameters, so, it is important to call this
+//  		service in your fcl file
+//		stick this line in your "services" section of fcl file:
+//		FileCatalogMetadata:  @local::art_file_catalog_mc
+//
+//              2. When you call FileCatalogMetadata service in your fcl file, and if
+//		you have (art) root Output section in your fcl file, and if you do not
+//		have "dataTier" specified in that section, then this service will throw
+//		an exception. To avoid this, either remove the entire root Output section
+//		in your fcl file (and remove art stream output from your end_paths) or
+//		include appropriate dataTier information in the section.If you are only
+//		running analysis job, best way is to not include any art root Output section.
+//
+//	        3. This service is exclusively written to work with production (in other
+//		words for jobs submitted through grid). Some of the metadata parameters
+//		(output TFileName, filesize, Project related details) are captured/updated
+//		during and/or after the workflow.
+//
+//
+// Created:  21-Feb-2018,  D. Brailsford
+//  based on the SBND version by T. Junk which is based on the
+//  based on the MicroBooNE example by S. Gollapinni
+//
+////////////////////////////////////////////////////////////////////////
+
+#include <algorithm>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <stdio.h>
+#include <string>
+#include <vector>
+
+#include "sbncode/Metadata/MetadataSBN.h"
+#include "sbncode/Metadata/FileCatalogMetadataSBN.h"
+
+#include "art_root_io/RootDB/SQLite3Wrapper.h"
+#include "art_root_io/RootDB/SQLErrMsg.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Framework/Services/System/FileCatalogMetadata.h"
+#include "art/Framework/Services/System/TriggerNamesService.h"
+#include "art/Utilities/OutputFileInfo.h"
+#include "cetlib_except/exception.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "TROOT.h"
+#include "TFile.h"
+#include "TTimeStamp.h"
+
+using namespace std;
+
+//--------------------------------------------------------------------
+
+// Constructor.
+util::MetadataSBN::MetadataSBN(fhicl::ParameterSet const& pset,
+					   art::ActivityRegistry& reg):
+  fJSONFileName{pset.get<std::string>("JSONFileName")},
+  fFileStats{"", art::ServiceHandle<art::TriggerNamesService const>{}->getProcessName()}
+{
+  // Insist on configuring Experiment from the fcl file (ideally) or the
+  // environment.
+  const char* expt = getenv("EXPERIMENT");
+  if(expt) fExperiment = pset.get<std::string>("Experiment", expt); else fExperiment = pset.get<std::string>("Experiment");
+  std::transform(fExperiment.begin(), fExperiment.end(), fExperiment.begin(), [](unsigned char c){return std::tolower(c);});
+
+  md.fdata_tier   = pset.get<std::string>("dataTier");
+  md.ffile_format = pset.get<std::string>("fileFormat");
+
+  reg.sPostBeginJob.watch(this, &MetadataSBN::postBeginJob);
+  reg.sPostOpenFile.watch(this, &MetadataSBN::postOpenInputFile);
+  reg.sPostCloseFile.watch(this, &MetadataSBN::postCloseInputFile);
+  reg.sPostProcessEvent.watch(this, &MetadataSBN::postEvent);
+  reg.sPostBeginSubRun.watch(this, &MetadataSBN::postBeginSubRun);
+
+  // get metadata from the FileCatalogMetadataSBN service, which is filled on its construction
+  art::ServiceHandle<util::FileCatalogMetadataSBN> paramhandle;
+  md.fFCLName = paramhandle->GetFCLName();
+  md.fProjectName = paramhandle->GetProjectName();
+  md.fProjectStage = paramhandle->GetProjectStage();
+  md.fProjectVersion = paramhandle->GetProjectVersion();
+  md.fProjectSoftware = paramhandle->GetProjectSoftware();
+  md.fProductionName = paramhandle->GetProductionName();
+  md.fProductionType = paramhandle->GetProductionType();
+}
+
+/// Un-quote quoted strings
+std::string UnQuoteString(std::string s)
+{
+  if(s.size() < 2 || s[0] != '\"' || s[s.size()-1] != '\"') return s;
+  s.erase(0, 1);
+  s.erase(s.size()-1, 1);
+  return s;
+}
+
+void MaybeCopyFromMap(const std::map<std::string, std::string>& in,
+                      const std::string& key,
+                      std::string& out)
+{
+  const auto it = in.find(key);
+  if(it == in.end()){
+    out = "";
+  }
+  else{
+    out = UnQuoteString(it->second);
+  }
+}
+
+void MaybeCopyToMap(const std::string& in,
+                    const std::string& key,
+                    std::map<std::string, std::string>& out)
+{
+  if(!in.empty()) out[key] = UnQuoteString(in);
+}
+
+//--------------------------------------------------------------------
+// PostBeginJob callback.
+// Insert per-job metadata via Metadata service.
+void util::MetadataSBN::postBeginJob()
+{
+  // get the start time
+  md.fstart_time = time(0);
+
+  // Get art metadata service and extract paramters from there
+  art::ServiceHandle<art::FileCatalogMetadata> artmds;
+
+  art::FileCatalogMetadata::collection_type artmd;
+  artmds->getMetadata(artmd);
+
+  std::map<std::string, std::string> mdmap;
+  for(const auto& d: artmd)
+    mdmap[d.first] = UnQuoteString(d.second);
+
+  // if a certain paramter/key is not found, assign an empty string value to it
+  MaybeCopyFromMap(mdmap, "application.family",  std::get<0>(md.fapplication));
+  MaybeCopyFromMap(mdmap, "art.process_name",    std::get<1>(md.fapplication));
+  MaybeCopyFromMap(mdmap, "application.version", std::get<2>(md.fapplication));
+  MaybeCopyFromMap(mdmap, "group",        md.fgroup);
+  MaybeCopyFromMap(mdmap, "file_type",    md.ffile_type);
+  MaybeCopyFromMap(mdmap, "art.run_type", frunType);
+}
+
+
+//--------------------------------------------------------------------
+// PostOpenFile callback.
+void util::MetadataSBN::postOpenInputFile(std::string const& fn)
+{
+  // save parent input files here
+  // 08/06 DBrailsford: Only save the parent string if the string is filled.  The string still exists (with 0 characters) for generation stage files.  See redmine issue 20124
+  if (fn.length() > 0) md.fParents.insert(fn);
+  fFileStats.recordInputFile(fn);
+}
+
+//--------------------------------------------------------------------
+// PostEvent callback.
+void util::MetadataSBN::postEvent(art::Event const& evt, art::ScheduleContext)
+{
+  art::RunNumber_t run = evt.run();
+  art::SubRunNumber_t subrun = evt.subRun();
+  art::EventNumber_t event = evt.event();
+  art::SubRunID srid = evt.id().subRunID();
+
+  // save run, subrun and runType information once every subrun
+  if (fSubRunNumbers.count(srid) == 0){
+    fSubRunNumbers.insert(srid);
+    md.fruns.push_back(make_tuple(run, subrun, frunType));
+  }
+
+  // save the first event
+  if (md.fevent_count == 0) md.ffirst_event = event;
+  md.flast_event = event;
+  // event counter
+  ++md.fevent_count;
+
+}
+
+//--------------------------------------------------------------------
+// PostSubRun callback.
+void util::MetadataSBN::postBeginSubRun(art::SubRun const& sr)
+{
+  art::RunNumber_t run = sr.run();
+  art::SubRunNumber_t subrun = sr.subRun();
+  art::SubRunID srid = sr.id();
+
+  // save run, subrun and runType information once every subrun
+  if (fSubRunNumbers.count(srid) == 0){
+    fSubRunNumbers.insert(srid);
+    md.fruns.push_back(make_tuple(run, subrun, frunType));
+  }
+}
+
+std::string Escape(const std::string& s)
+{
+  // If it's formatted as a dict or list, trust it's already formatted
+  if(s.size() >= 2 && ((s[0] == '{' && s.back() == '}') || (s[0] == '[' && s.back() == ']'))) return s;
+
+  // otherwise quote it
+  return "\""+s+"\"";
+}
+
+//--------------------------------------------------------------------
+std::string util::MetadataSBN::GetParentsString() const
+{
+  if(md.fParents.empty()) return "";
+
+  unsigned int c = 0;
+
+  std::string ret = "[\n";
+  for(auto parent: md.fParents) {
+    std::cout<<"Parent " << c << ": " << parent << std::endl;
+    c++;
+    size_t n = parent.find_last_of('/');
+    size_t f1 = (n == std::string::npos ? 0 : n+1);
+    ret += "    {\n     \"file_name\": \"" + parent.substr(f1) + "\"\n    }";
+    if(md.fParents.size() == 1 || c == md.fParents.size()) ret += "\n";
+    else ret += ",\n";
+  }
+
+  ret += "  ]";
+  return ret;
+}
+
+//--------------------------------------------------------------------
+std::string util::MetadataSBN::GetRunsString() const
+{
+  unsigned int c = 0;
+
+  std::string ret = "[\n";
+  for(auto&t :md.fruns){
+    c++;
+    ret += "    [\n     " + std::to_string(std::get<0>(t)) + ",\n     " + std::to_string(std::get<1>(t)) + ",\n     " + std::get<2>(t) + "\n    ]";
+    if(md.fruns.size() == 1 || c == md.fruns.size()) ret += "\n";
+    else ret += ",\n";
+  }
+  ret += "  ]";
+  return ret;
+}
+
+//--------------------------------------------------------------------
+void util::MetadataSBN::GetMetadataMaps(std::map<std::string, std::string>& strs,
+                                        std::map<std::string, int>& ints,
+                                        std::map<std::string, std::string>& objs)
+{
+  strs.clear(); ints.clear(); objs.clear();
+
+  objs["application"] = "{\"family\": \""+std::get<0>(md.fapplication)+"\", \"name\": \""+std::get<1>(md.fapplication)+"\", \"version\": \""+std::get<2>(md.fapplication)+"\"}";
+
+  if(!md.fParents.empty()) objs["parents"] = GetParentsString();
+  if(!md.fruns.empty()) objs["runs"] = GetRunsString();
+
+  // convert start and end times into time format: Year-Month-DayTHours:Minutes:Seconds
+  char endbuf[80], startbuf[80];
+  struct tm tstruct;
+  tstruct = *localtime(&md.fend_time);
+  strftime(endbuf,sizeof(endbuf),"%Y-%m-%dT%H:%M:%S",&tstruct);
+  tstruct = *localtime(&md.fstart_time);
+  strftime(startbuf,sizeof(startbuf),"%Y-%m-%dT%H:%M:%S",&tstruct);
+
+  strs["start_time"] = startbuf;
+  strs["end_time"] = endbuf;
+
+  strs["data_tier"] = md.fdata_tier;
+  ints["event_count"] = md.fevent_count;
+  strs["file_format"] = md.ffile_format;
+  ints["first_event"] = md.ffirst_event;
+  ints["last_event"] = md.flast_event;
+
+  const std::string proj = fExperiment+"_project";
+  MaybeCopyToMap(md.fFCLName, "fcl.name", strs);
+  MaybeCopyToMap(md.fProjectName, proj+".name", strs);
+  MaybeCopyToMap(md.fProjectStage, proj+".stage", strs);
+  MaybeCopyToMap(md.fProjectVersion, proj+".version", strs);
+  MaybeCopyToMap(md.fProjectSoftware, proj+".software", strs);
+  MaybeCopyToMap(md.fProductionName, "production.name", strs);
+  MaybeCopyToMap(md.fProductionType, "production.type", strs);
+
+  MaybeCopyToMap(md.fgroup, "group", strs);
+  MaybeCopyToMap(md.ffile_type, "file_type", strs);
+  MaybeCopyToMap(frunType, "art.run_type", strs);
+}
+
+//--------------------------------------------------------------------
+// PostCloseFile callback.
+void util::MetadataSBN::postCloseInputFile()
+{
+  //update end time
+  md.fend_time = time(0);
+
+  std::map<std::string, std::string> strs;
+  std::map<std::string, int> ints;
+  std::map<std::string, std::string> objs;
+  GetMetadataMaps(strs, ints, objs);
+
+  // open a json file and write everything from the struct md complying to the
+  // samweb json format. This json file holds the below information temporarily.
+  // If you submitted a grid job invoking this service, the information from
+  // this file is appended to a final json file and this file will be removed
+
+  if(!fJSONFileName.empty()){
+    std::ofstream jsonfile;
+    jsonfile.open(fJSONFileName);
+    jsonfile << "{\n";
+
+    bool once = true;
+    for(auto& it: objs){
+      if(!once) jsonfile << ",\n";
+      once = false;
+      jsonfile << "  \"" << it.first << "\": " << it.second;
+    }
+    for(auto& it: strs){
+      // Have to escape string outputs
+      jsonfile << ",\n  \"" << it.first << "\": \"" << it.second << "\"";
+    }
+    for(auto& it: ints){
+      jsonfile << ",\n  \"" << it.first << "\": " << it.second;
+    }
+
+    jsonfile<<"\n}\n";
+    jsonfile.close();
+  }
+
+  fFileStats.recordFileClose();
+  //TODO figure out how to make the name identical to the TFile
+  //std::string new_name = fRenamer.maybeRenameFile("myjson.json",fJSONFileName);
+}
+
+DEFINE_ART_SERVICE(util::MetadataSBN)


### PR DESCRIPTION
A script for diffing cafs.

This is based on `feature/bckhouse_caf_metadata` just because that is where CAFMaker/bin/ was introduced and we would probably get conflicts otherwise. So save it until after the other branches.