### PR TITLE
Fill the ParameterSet info in beginRun()

### DIFF
--- a/sbncode/SBNEventWeight/App/SBNEventWeight_module.cc
+++ b/sbncode/SBNEventWeight/App/SBNEventWeight_module.cc
@@ -39,7 +39,7 @@ public:
 
 private:
   void produce(art::Event& e) override;
-  void endRun(art::Run& run) override;
+  void beginRun(art::Run& run) override;
 
 private:
   WeightManager fWeightManager;
@@ -84,7 +84,7 @@ void SBNEventWeight::produce(art::Event& e) {
 }
 
 
-void SBNEventWeight::endRun(art::Run& run) {
+void SBNEventWeight::beginRun(art::Run& run) {
   auto p = std::make_unique<std::vector<EventWeightParameterSet> >();
   
   for (auto const& it : fWeightManager.GetWeightCalcMap()) {


### PR DESCRIPTION
so that it's soon enough for downstream modules (CAFMaker) to use it.

Turns out that we had eventweight+cafmaker working, but only in separate jobs. If you run them in a single job, which is the plan, then you run into this need for time travel.