### PR TITLE
feature/jzettleNewFMObject

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -154,7 +154,7 @@ class CAFMaker : public art::EDProducer {
 
   bool   fIsRealData;  // use this instead of evt.isRealData(), see init in
                      // produce(evt)
-                     
+
   bool fFirstInSubRun;
   bool fFirstInFile;
   int fFileNumber;
@@ -200,8 +200,8 @@ class CAFMaker : public art::EDProducer {
 
   template <class T, class D, class U>
   art::FindManyP<T, D> FindManyPDStrict(const U& from,
-                                            const art::Event& evt,
-                                            const art::InputTag& tag) const;
+                                        const art::Event& evt,
+                                        const art::InputTag& tag) const;
 
   /// \brief Retrieve an object from an association, with error handling
   ///
@@ -913,14 +913,10 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       slcHits = fmSlcHits.at(0);
     }
 
-    // art::FindManyP<anab::T0> fmT0 =
-    //   FindManyPStrict<anab::T0>(fmPFPart, evt,
-    //     fParams.FlashMatchLabel() + slice_tag_suff);
-    art::FindManyP<sbn::SimpleFlashMatch> fmT0 =
+    art::FindManyP<sbn::SimpleFlashMatch> fm_sFM =
       FindManyPStrict<sbn::SimpleFlashMatch>(fmPFPart, evt,
                                              fParams.FlashMatchLabel() + slice_tag_suff);
-    std::cout << "fParams.FlashMatchLabel() + slice_tag_suff:\t" << fParams.FlashMatchLabel() + slice_tag_suff << "\n";
-    
+
     art::FindManyP<larpandoraobj::PFParticleMetadata> fmPFPMeta =
       FindManyPStrict<larpandoraobj::PFParticleMetadata>(fmPFPart, evt,
                fParams.PFParticleLabel() + slice_tag_suff);
@@ -1028,12 +1024,9 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     const recob::PFParticle *primary = (iPart == fmPFPart.size()) ? NULL : fmPFPart[iPart].get();
     const larpandoraobj::PFParticleMetadata *primary_meta = (iPart == fmPFPart.size()) ? NULL : fmPFPMeta.at(iPart).at(0).get();
     // get the flash match
-    // const anab::T0 *fmatch = NULL;
-    const sbn::SimpleFlashMatch *fmatch = NULL;
-    if (fmT0.isValid() && primary != NULL) {
-      // std::vector<art::Ptr<anab::T0>> fmatches = fmT0.at(iPart);
-      std::vector<art::Ptr<sbn::SimpleFlashMatch>> fmatches = fmT0.at(iPart);
-      std::cout << "fmatches.size():\t" << fmatches.size() << "\n";
+    const sbn::SimpleFlashMatch* fmatch = nullptr;
+    if (fm_sFM.isValid() && primary != NULL) {
+      std::vector<art::Ptr<sbn::SimpleFlashMatch>> fmatches = fm_sFM.at(iPart);
       if (fmatches.size() != 0) {
         assert(fmatches.size() == 1);
         fmatch = fmatches[0].get();
@@ -1050,8 +1043,6 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     FillSliceFlashMatch(fmatch, recslc);
     FillSliceFlashMatchA(fmatch, recslc);
     FillSliceVertex(vertex, recslc);
-
-    std::cout << "recslc.fmatch.scr_y:\t" << recslc.fmatch.scr_y << "\n";
 
     // select slice
     if (!SelectSlice(recslc, fParams.CutClearCosmic())) continue;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -913,10 +913,14 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       slcHits = fmSlcHits.at(0);
     }
 
-    art::FindManyP<anab::T0> fmT0 =
-      FindManyPStrict<anab::T0>(fmPFPart, evt,
-        fParams.FlashMatchLabel() + slice_tag_suff);
-
+    // art::FindManyP<anab::T0> fmT0 =
+    //   FindManyPStrict<anab::T0>(fmPFPart, evt,
+    //     fParams.FlashMatchLabel() + slice_tag_suff);
+    art::FindManyP<sbn::SimpleFlashMatch> fmT0 =
+      FindManyPStrict<sbn::SimpleFlashMatch>(fmPFPart, evt,
+                                             fParams.FlashMatchLabel() + slice_tag_suff);
+    std::cout << "fParams.FlashMatchLabel() + slice_tag_suff:\t" << fParams.FlashMatchLabel() + slice_tag_suff << "\n";
+    
     art::FindManyP<larpandoraobj::PFParticleMetadata> fmPFPMeta =
       FindManyPStrict<larpandoraobj::PFParticleMetadata>(fmPFPart, evt,
                fParams.PFParticleLabel() + slice_tag_suff);
@@ -1024,9 +1028,12 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     const recob::PFParticle *primary = (iPart == fmPFPart.size()) ? NULL : fmPFPart[iPart].get();
     const larpandoraobj::PFParticleMetadata *primary_meta = (iPart == fmPFPart.size()) ? NULL : fmPFPMeta.at(iPart).at(0).get();
     // get the flash match
-    const anab::T0 *fmatch = NULL;
+    // const anab::T0 *fmatch = NULL;
+    const sbn::SimpleFlashMatch *fmatch = NULL;
     if (fmT0.isValid() && primary != NULL) {
-      std::vector<art::Ptr<anab::T0>> fmatches = fmT0.at(iPart);
+      // std::vector<art::Ptr<anab::T0>> fmatches = fmT0.at(iPart);
+      std::vector<art::Ptr<sbn::SimpleFlashMatch>> fmatches = fmT0.at(iPart);
+      std::cout << "fmatches.size():\t" << fmatches.size() << "\n";
       if (fmatches.size() != 0) {
         assert(fmatches.size() == 1);
         fmatch = fmatches[0].get();
@@ -1043,6 +1050,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     FillSliceFlashMatch(fmatch, recslc);
     FillSliceFlashMatchA(fmatch, recslc);
     FillSliceVertex(vertex, recslc);
+
+    std::cout << "recslc.fmatch.scr_y:\t" << recslc.fmatch.scr_y << "\n";
 
     // select slice
     if (!SelectSlice(recslc, fParams.CutClearCosmic())) continue;

--- a/sbncode/CAFMaker/FillFlashMatch.cxx
+++ b/sbncode/CAFMaker/FillFlashMatch.cxx
@@ -11,49 +11,47 @@ namespace caf
 
 
   //......................................................................
-  void FillSliceFlashMatchA(const sbn::SimpleFlashMatch* fmatch /* can be nullptr */,
-                            caf::SRSlice& srslice,
-                            bool allowEmpty)
+  void FillSliceFlashMatch(const sbn::SimpleFlashMatch* fmatch /* can be nullptr */,
+                           caf::SRSlice& srslice,
+                           bool allowEmpty)
   {
     if (fmatch == nullptr) {
       srslice.fmatch.present = false;
       return;
     }
-    srslice.fmatch.present   = fmatch->mPresent;
-    srslice.fmatch.time      = fmatch->mTime;
-    srslice.fmatch.charge_q  = fmatch->mChargeQ;
-    srslice.fmatch.light_pe  = fmatch->mLightPE;
-    srslice.fmatch.score     = fmatch->mScore;
-    srslice.fmatch.scr_y     = fmatch->mScr_y;
-    srslice.fmatch.scr_z     = fmatch->mScr_z;
-    srslice.fmatch.scr_rr    = fmatch->mScr_rr;
-    srslice.fmatch.scr_ratio = fmatch->mScr_ratio;
-    srslice.fmatch.chargeXYZ = fmatch->mChargeXYZ;
-    srslice.fmatch.lightXYZ  = fmatch->mLightXYZ;
+    srslice.fmatch.present     = fmatch->present;
+    srslice.fmatch.time        = fmatch->time;
+    srslice.fmatch.charge.q    = fmatch->charge.q;
+    srslice.fmatch.light.pe    = fmatch->light.pe;
+    srslice.fmatch.score.total = fmatch->score.total;
+    srslice.fmatch.score.y     = fmatch->score.y;
+    srslice.fmatch.score.z     = fmatch->score.z;
+    srslice.fmatch.score.rr    = fmatch->score.rr;
+    srslice.fmatch.score.ratio = fmatch->score.ratio;
+    srslice.fmatch.charge.center = fmatch->charge.center;
+    srslice.fmatch.light.center  = fmatch->light.center;
   }
 
   //......................................................................
-  void FillSliceFlashMatch(const sbn::SimpleFlashMatch* fmatch /* can be nullptr */,
-                           caf::SRSlice& srslice,
-                           bool allowEmpty)
+  void FillSliceFlashMatchA(const sbn::SimpleFlashMatch* fmatch /* can be nullptr */,
+                            caf::SRSlice& srslice,
+                            bool allowEmpty)
   {
-    caf::SRFlashMatch flashmatch;
     if (fmatch == nullptr) {
-      flashmatch.present = false;
+      srslice.fmatch_a.present = false;
       return;
     }
-    flashmatch.present   = fmatch->mPresent;
-    flashmatch.time      = fmatch->mTime;
-    flashmatch.charge_q  = fmatch->mChargeQ;
-    flashmatch.light_pe  = fmatch->mLightPE;
-    flashmatch.score     = fmatch->mScore;
-    flashmatch.scr_y     = fmatch->mScr_y;
-    flashmatch.scr_z     = fmatch->mScr_z;
-    flashmatch.scr_rr    = fmatch->mScr_rr;
-    flashmatch.scr_ratio = fmatch->mScr_ratio;
-    flashmatch.chargeXYZ = fmatch->mChargeXYZ;
-    flashmatch.lightXYZ  = fmatch->mLightXYZ;
-    srslice.fmatch_a = flashmatch;
+    srslice.fmatch_a.present     = fmatch->present;
+    srslice.fmatch_a.time        = fmatch->time;
+    srslice.fmatch_a.charge.q    = fmatch->charge.q;
+    srslice.fmatch_a.light.pe    = fmatch->light.pe;
+    srslice.fmatch_a.score.total = fmatch->score.total;
+    srslice.fmatch_a.score.y     = fmatch->score.y;
+    srslice.fmatch_a.score.z     = fmatch->score.z;
+    srslice.fmatch_a.score.rr    = fmatch->score.rr;
+    srslice.fmatch_a.score.ratio = fmatch->score.ratio;
+    srslice.fmatch_a.charge.center = fmatch->charge.center;
+    srslice.fmatch_a.light.center  = fmatch->light.center;
   }
 
   //......................................................................
@@ -65,17 +63,17 @@ namespace caf
       srslice.fmatch_b.present = false;
       return;
     }
-    srslice.fmatch_b.present   = fmatch->mPresent;
-    srslice.fmatch_b.time      = fmatch->mTime;
-    srslice.fmatch_b.charge_q  = fmatch->mChargeQ;
-    srslice.fmatch_b.light_pe  = fmatch->mLightPE;
-    srslice.fmatch_b.score     = fmatch->mScore;
-    srslice.fmatch_b.scr_y     = fmatch->mScr_y;
-    srslice.fmatch_b.scr_z     = fmatch->mScr_z;
-    srslice.fmatch_b.scr_rr    = fmatch->mScr_rr;
-    srslice.fmatch_b.scr_ratio = fmatch->mScr_ratio;
-    srslice.fmatch_b.chargeXYZ = fmatch->mChargeXYZ;
-    srslice.fmatch_b.lightXYZ  = fmatch->mLightXYZ;
+    srslice.fmatch_b.present     = fmatch->present;
+    srslice.fmatch_b.time        = fmatch->time;
+    srslice.fmatch_b.charge.q    = fmatch->charge.q;
+    srslice.fmatch_b.light.pe    = fmatch->light.pe;
+    srslice.fmatch_b.score.total = fmatch->score.total;
+    srslice.fmatch_b.score.y     = fmatch->score.y;
+    srslice.fmatch_b.score.z     = fmatch->score.z;
+    srslice.fmatch_b.score.rr    = fmatch->score.rr;
+    srslice.fmatch_b.score.ratio = fmatch->score.ratio;
+    srslice.fmatch_b.charge.center = fmatch->charge.center;
+    srslice.fmatch_b.light.center  = fmatch->light.center;
   }
 
   //......................................................................

--- a/sbncode/CAFMaker/FillFlashMatch.cxx
+++ b/sbncode/CAFMaker/FillFlashMatch.cxx
@@ -11,74 +11,68 @@ namespace caf
 
 
   //......................................................................
-  void FillSliceFlashMatchA(const sbn::SimpleFlashMatch &fmatch /* can be NULL */,
-                           caf::SRSlice &srslice,
+  void FillSliceFlashMatchA(const sbn::SimpleFlashMatch* fmatch /* can be nullptr */,
+                            caf::SRSlice& srslice,
+                            bool allowEmpty)
+  {
+    if (fmatch == nullptr) {
+      srslice.fmatch.present = false;
+      return;
+    }
+    srslice.fmatch.present = fmatch->mPresent;
+    srslice.fmatch.time    = fmatch->mTime;
+    srslice.fmatch.pe      = fmatch->mPE;
+    srslice.fmatch.score   = fmatch->mScore;
+    srslice.fmatch.scr_y   = fmatch->mScr_y;
+    srslice.fmatch.scr_z   = fmatch->mScr_z;
+    srslice.fmatch.scr_rr  = fmatch->mScr_rr;
+    srslice.fmatch.scr_ratio = fmatch->mScr_ratio;
+    srslice.fmatch.chargeXYZ = fmatch->mChargeXYZ;
+    srslice.fmatch.lightXYZ = fmatch->mLightXYZ;
+  }
+
+  //......................................................................
+  void FillSliceFlashMatch(const sbn::SimpleFlashMatch* fmatch /* can be nullptr */,
+                           caf::SRSlice& srslice,
                            bool allowEmpty)
   {
-    //if (fmatch.mPresent == true) {
-      //std::cout << fmatch.mPresent << " " << fmatch.mTime << " " << fmatch.mScore << " " << fmatch.mScr_y << " " << fmatch.mScr_z << " " << fmatch.mScr_rr << " " << fmatch.mScr_ratio << " " << fmatch.mPE << std::endl;  
-    srslice.fmatch.present = fmatch.mPresent;
-    srslice.fmatch.time    = fmatch.mTime;
-    srslice.fmatch.score   = fmatch.mScore;
-    srslice.fmatch.scr_y   = fmatch.mScr_y;
-    srslice.fmatch.scr_z   = fmatch.mScr_z;
-    srslice.fmatch.scr_rr  = fmatch.mScr_rr;
-    srslice.fmatch.scr_ratio = fmatch.mScr_ratio;
-    srslice.fmatch.pe      = fmatch.mPE;
-    srslice.fmatch.chargeXYZ = fmatch.mChargeXYZ;
-    srslice.fmatch.lightXYZ = fmatch.mLightXYZ;
-    //}
-    //else {
-    //srslice.fmatch.present = false;
-    //}
-  }
-
-  //......................................................................
-  void FillSliceFlashMatch(const sbn::SimpleFlashMatch &fmatch /* can be NULL */,
-			   caf::SRSlice &srslice,
-			   bool allowEmpty)
-  {
     caf::SRFlashMatch flashmatch;
-    
-    //if (fmatch.mPresent == true) {
-    flashmatch.present = fmatch.mPresent;
-    flashmatch.time    = fmatch.mTime;
-    flashmatch.score   = fmatch.mScore;
-    flashmatch.scr_y   = fmatch.mScr_y;
-    flashmatch.scr_z   = fmatch.mScr_z;
-    flashmatch.scr_rr  = fmatch.mScr_rr;
-    flashmatch.scr_ratio = fmatch.mScr_ratio;
-    flashmatch.pe      = fmatch.mPE;
-    flashmatch.chargeXYZ = fmatch.mChargeXYZ;
-    flashmatch.lightXYZ = fmatch.mLightXYZ;
-    //}
-    //else {
-    //flashmatch.present = false;
-    //}
+    if (fmatch == nullptr) {
+      flashmatch.present = false;
+      return;
+    }
+    flashmatch.present = fmatch->mPresent;
+    flashmatch.time    = fmatch->mTime;
+    flashmatch.pe      = fmatch->mPE;
+    flashmatch.score   = fmatch->mScore;
+    flashmatch.scr_y   = fmatch->mScr_y;
+    flashmatch.scr_z   = fmatch->mScr_z;
+    flashmatch.scr_rr  = fmatch->mScr_rr;
+    flashmatch.scr_ratio = fmatch->mScr_ratio;
+    flashmatch.chargeXYZ = fmatch->mChargeXYZ;
+    flashmatch.lightXYZ = fmatch->mLightXYZ;
     srslice.fmatch_a = flashmatch;
-
   }
 
   //......................................................................
-  void FillSliceFlashMatchB(const sbn::SimpleFlashMatch &fmatch /* can be NULL */,
-			    caf::SRSlice &srslice,
-			    bool allowEmpty)
+  void FillSliceFlashMatchB(const sbn::SimpleFlashMatch* fmatch /* can be nullptr */,
+                            caf::SRSlice& srslice,
+                            bool allowEmpty)
   {
-    //if (fmatch.mPresent == true) {
-    srslice.fmatch_b.present = fmatch.mPresent;
-    srslice.fmatch_b.time    = fmatch.mTime;
-    srslice.fmatch_b.score   = fmatch.mScore;
-    srslice.fmatch_b.scr_y   = fmatch.mScr_y;
-    srslice.fmatch_b.scr_z   = fmatch.mScr_z;
-    srslice.fmatch_b.scr_rr  = fmatch.mScr_rr;
-    srslice.fmatch_b.scr_ratio = fmatch.mScr_ratio;
-    srslice.fmatch_b.pe      = fmatch.mPE;
-    srslice.fmatch_b.chargeXYZ = fmatch.mChargeXYZ;
-    srslice.fmatch_b.lightXYZ = fmatch.mLightXYZ;
-    //}
-    //else {
-    //srslice.fmatch_b.present = false;
-    //}
+    if (fmatch == nullptr) {
+      srslice.fmatch_b.present = false;
+      return;
+    }
+    srslice.fmatch_b.present = fmatch->mPresent;
+    srslice.fmatch_b.time    = fmatch->mTime;
+    srslice.fmatch_b.pe      = fmatch->mPE;
+    srslice.fmatch_b.score   = fmatch->mScore;
+    srslice.fmatch_b.scr_y   = fmatch->mScr_y;
+    srslice.fmatch_b.scr_z   = fmatch->mScr_z;
+    srslice.fmatch_b.scr_rr  = fmatch->mScr_rr;
+    srslice.fmatch_b.scr_ratio = fmatch->mScr_ratio;
+    srslice.fmatch_b.chargeXYZ = fmatch->mChargeXYZ;
+    srslice.fmatch_b.lightXYZ = fmatch->mLightXYZ;
   }
 
   //......................................................................

--- a/sbncode/CAFMaker/FillFlashMatch.cxx
+++ b/sbncode/CAFMaker/FillFlashMatch.cxx
@@ -11,55 +11,73 @@ namespace caf
 
 
   //......................................................................
-  void FillSliceFlashMatchA(const anab::T0 *fmatch /* can be NULL */,
+  void FillSliceFlashMatchA(const sbn::SimpleFlashMatch &fmatch /* can be NULL */,
                            caf::SRSlice &srslice,
                            bool allowEmpty)
   {
-    if (fmatch != NULL) {
-      srslice.fmatch.present = true;
-      srslice.fmatch.time    = fmatch->Time();
-      srslice.fmatch.score   = fmatch->TriggerConfidence();
-      srslice.fmatch.pe      = fmatch->TriggerType();
-    }
-    else {
-      srslice.fmatch.present = false;
-    }
+    //if (fmatch != NULL) {
+    srslice.fmatch.present = fmatch.mPresent;
+    srslice.fmatch.time    = fmatch.mTime;
+    srslice.fmatch.score   = fmatch.mScore;
+    srslice.fmatch.scr_y   = fmatch.mScr_y;
+    srslice.fmatch.scr_z   = fmatch.mScr_z;
+    srslice.fmatch.scr_rr  = fmatch.mScr_rr;
+    srslice.fmatch.scr_ratio = fmatch.mScr_ratio;
+    srslice.fmatch.pe      = fmatch.mPE;
+    srslice.fmatch.chargeXYZ = fmatch.mChargeXYZ;
+    srslice.fmatch.lightXYZ = fmatch.mLightXYZ;
+    //}
+    //else {
+    //srslice.fmatch.present = false;
+    //}
   }
 
   //......................................................................
-  void FillSliceFlashMatch(const anab::T0 *fmatch /* can be NULL */,
+  void FillSliceFlashMatch(const sbn::SimpleFlashMatch &fmatch /* can be NULL */,
 			   caf::SRSlice &srslice,
 			   bool allowEmpty)
   {
     caf::SRFlashMatch flashmatch;
 
-    if (fmatch != NULL) {
-      flashmatch.present = true;
-      flashmatch.time    = fmatch->Time();
-      flashmatch.score   = fmatch->TriggerConfidence();
-      flashmatch.pe      = fmatch->TriggerType();
-    }
-    else {
-      flashmatch.present = false;
-    }
+    //if (fmatch != NULL) {
+    flashmatch.present = fmatch.mPresent;
+    flashmatch.time    = fmatch.mTime;
+    flashmatch.score   = fmatch.mScore;
+    flashmatch.scr_y   = fmatch.mScr_y;
+    flashmatch.scr_z   = fmatch.mScr_z;
+    flashmatch.scr_rr  = fmatch.mScr_rr;
+    flashmatch.scr_ratio = fmatch.mScr_ratio;
+    flashmatch.pe      = fmatch.mPE;
+    flashmatch.chargeXYZ = fmatch.mChargeXYZ;
+    flashmatch.lightXYZ = fmatch.mLightXYZ;
+    //}
+    //  else {
+    //  flashmatch.present = false;
+    //}
     srslice.fmatch_a = flashmatch;
 
   }
 
   //......................................................................
-  void FillSliceFlashMatchB(const anab::T0 *fmatch /* can be NULL */,
+  void FillSliceFlashMatchB(const sbn::SimpleFlashMatch &fmatch /* can be NULL */,
 			    caf::SRSlice &srslice,
 			    bool allowEmpty)
   {
-    if (fmatch != NULL) {
-      srslice.fmatch_b.present = true;
-      srslice.fmatch_b.time    = fmatch->Time();
-      srslice.fmatch_b.score   = fmatch->TriggerConfidence();
-      srslice.fmatch_b.pe      = fmatch->TriggerType();
-    }
-    else {
-      srslice.fmatch_b.present = false;
-    }
+    //if (fmatch != NULL) {
+      srslice.fmatch_b.present = fmatch.mPresent;
+      srslice.fmatch_b.time    = fmatch.mTime;
+      srslice.fmatch_b.score   = fmatch.mScore;
+      srslice.fmatch_b.scr_y   = fmatch.mScr_y;
+      srslice.fmatch_b.scr_z   = fmatch.mScr_z;
+      srslice.fmatch_b.scr_rr  = fmatch.mScr_rr;
+      srslice.fmatch_b.scr_ratio = fmatch.mScr_ratio;
+      srslice.fmatch_b.pe      = fmatch.mPE;
+      srslice.fmatch_b.chargeXYZ = fmatch.mChargeXYZ;
+      srslice.fmatch_b.lightXYZ = fmatch.mLightXYZ;
+      //}
+      //else {
+      //srslice.fmatch_b.present = false;
+      //}
   }
 
   //......................................................................

--- a/sbncode/CAFMaker/FillFlashMatch.cxx
+++ b/sbncode/CAFMaker/FillFlashMatch.cxx
@@ -23,7 +23,7 @@ namespace caf
     srslice.fmatch.time       = fmatch->time;
     srslice.fmatch.chargeQ    = fmatch->charge.q;
     srslice.fmatch.lightPE    = fmatch->light.pe;
-    srslice.fmatch.scoreTotal = fmatch->score.total;
+    srslice.fmatch.score      = fmatch->score.total;
     srslice.fmatch.scoreY     = fmatch->score.y;
     srslice.fmatch.scoreZ     = fmatch->score.z;
     srslice.fmatch.scoreRR    = fmatch->score.rr;
@@ -45,7 +45,7 @@ namespace caf
     srslice.fmatch_a.time       = fmatch->time;
     srslice.fmatch_a.chargeQ    = fmatch->charge.q;
     srslice.fmatch_a.lightPE    = fmatch->light.pe;
-    srslice.fmatch_a.scoreTotal = fmatch->score.total;
+    srslice.fmatch_a.score      = fmatch->score.total;
     srslice.fmatch_a.scoreY     = fmatch->score.y;
     srslice.fmatch_a.scoreZ     = fmatch->score.z;
     srslice.fmatch_a.scoreRR    = fmatch->score.rr;
@@ -67,7 +67,7 @@ namespace caf
     srslice.fmatch_b.time       = fmatch->time;
     srslice.fmatch_b.chargeQ    = fmatch->charge.q;
     srslice.fmatch_b.lightPE    = fmatch->light.pe;
-    srslice.fmatch_b.scoreTotal = fmatch->score.total;
+    srslice.fmatch_b.score      = fmatch->score.total;
     srslice.fmatch_b.scoreY     = fmatch->score.y;
     srslice.fmatch_b.scoreZ     = fmatch->score.z;
     srslice.fmatch_b.scoreRR    = fmatch->score.rr;

--- a/sbncode/CAFMaker/FillFlashMatch.cxx
+++ b/sbncode/CAFMaker/FillFlashMatch.cxx
@@ -15,7 +15,8 @@ namespace caf
                            caf::SRSlice &srslice,
                            bool allowEmpty)
   {
-    //if (fmatch != NULL) {
+    //if (fmatch.mPresent == true) {
+      //std::cout << fmatch.mPresent << " " << fmatch.mTime << " " << fmatch.mScore << " " << fmatch.mScr_y << " " << fmatch.mScr_z << " " << fmatch.mScr_rr << " " << fmatch.mScr_ratio << " " << fmatch.mPE << std::endl;  
     srslice.fmatch.present = fmatch.mPresent;
     srslice.fmatch.time    = fmatch.mTime;
     srslice.fmatch.score   = fmatch.mScore;
@@ -38,8 +39,8 @@ namespace caf
 			   bool allowEmpty)
   {
     caf::SRFlashMatch flashmatch;
-
-    //if (fmatch != NULL) {
+    
+    //if (fmatch.mPresent == true) {
     flashmatch.present = fmatch.mPresent;
     flashmatch.time    = fmatch.mTime;
     flashmatch.score   = fmatch.mScore;
@@ -51,8 +52,8 @@ namespace caf
     flashmatch.chargeXYZ = fmatch.mChargeXYZ;
     flashmatch.lightXYZ = fmatch.mLightXYZ;
     //}
-    //  else {
-    //  flashmatch.present = false;
+    //else {
+    //flashmatch.present = false;
     //}
     srslice.fmatch_a = flashmatch;
 
@@ -63,21 +64,21 @@ namespace caf
 			    caf::SRSlice &srslice,
 			    bool allowEmpty)
   {
-    //if (fmatch != NULL) {
-      srslice.fmatch_b.present = fmatch.mPresent;
-      srslice.fmatch_b.time    = fmatch.mTime;
-      srslice.fmatch_b.score   = fmatch.mScore;
-      srslice.fmatch_b.scr_y   = fmatch.mScr_y;
-      srslice.fmatch_b.scr_z   = fmatch.mScr_z;
-      srslice.fmatch_b.scr_rr  = fmatch.mScr_rr;
-      srslice.fmatch_b.scr_ratio = fmatch.mScr_ratio;
-      srslice.fmatch_b.pe      = fmatch.mPE;
-      srslice.fmatch_b.chargeXYZ = fmatch.mChargeXYZ;
-      srslice.fmatch_b.lightXYZ = fmatch.mLightXYZ;
-      //}
-      //else {
-      //srslice.fmatch_b.present = false;
-      //}
+    //if (fmatch.mPresent == true) {
+    srslice.fmatch_b.present = fmatch.mPresent;
+    srslice.fmatch_b.time    = fmatch.mTime;
+    srslice.fmatch_b.score   = fmatch.mScore;
+    srslice.fmatch_b.scr_y   = fmatch.mScr_y;
+    srslice.fmatch_b.scr_z   = fmatch.mScr_z;
+    srslice.fmatch_b.scr_rr  = fmatch.mScr_rr;
+    srslice.fmatch_b.scr_ratio = fmatch.mScr_ratio;
+    srslice.fmatch_b.pe      = fmatch.mPE;
+    srslice.fmatch_b.chargeXYZ = fmatch.mChargeXYZ;
+    srslice.fmatch_b.lightXYZ = fmatch.mLightXYZ;
+    //}
+    //else {
+    //srslice.fmatch_b.present = false;
+    //}
   }
 
   //......................................................................

--- a/sbncode/CAFMaker/FillFlashMatch.cxx
+++ b/sbncode/CAFMaker/FillFlashMatch.cxx
@@ -19,16 +19,17 @@ namespace caf
       srslice.fmatch.present = false;
       return;
     }
-    srslice.fmatch.present = fmatch->mPresent;
-    srslice.fmatch.time    = fmatch->mTime;
-    srslice.fmatch.pe      = fmatch->mPE;
-    srslice.fmatch.score   = fmatch->mScore;
-    srslice.fmatch.scr_y   = fmatch->mScr_y;
-    srslice.fmatch.scr_z   = fmatch->mScr_z;
-    srslice.fmatch.scr_rr  = fmatch->mScr_rr;
+    srslice.fmatch.present   = fmatch->mPresent;
+    srslice.fmatch.time      = fmatch->mTime;
+    srslice.fmatch.charge_q  = fmatch->mChargeQ;
+    srslice.fmatch.light_pe  = fmatch->mLightPE;
+    srslice.fmatch.score     = fmatch->mScore;
+    srslice.fmatch.scr_y     = fmatch->mScr_y;
+    srslice.fmatch.scr_z     = fmatch->mScr_z;
+    srslice.fmatch.scr_rr    = fmatch->mScr_rr;
     srslice.fmatch.scr_ratio = fmatch->mScr_ratio;
     srslice.fmatch.chargeXYZ = fmatch->mChargeXYZ;
-    srslice.fmatch.lightXYZ = fmatch->mLightXYZ;
+    srslice.fmatch.lightXYZ  = fmatch->mLightXYZ;
   }
 
   //......................................................................
@@ -41,16 +42,17 @@ namespace caf
       flashmatch.present = false;
       return;
     }
-    flashmatch.present = fmatch->mPresent;
-    flashmatch.time    = fmatch->mTime;
-    flashmatch.pe      = fmatch->mPE;
-    flashmatch.score   = fmatch->mScore;
-    flashmatch.scr_y   = fmatch->mScr_y;
-    flashmatch.scr_z   = fmatch->mScr_z;
-    flashmatch.scr_rr  = fmatch->mScr_rr;
+    flashmatch.present   = fmatch->mPresent;
+    flashmatch.time      = fmatch->mTime;
+    flashmatch.charge_q  = fmatch->mChargeQ;
+    flashmatch.light_pe  = fmatch->mLightPE;
+    flashmatch.score     = fmatch->mScore;
+    flashmatch.scr_y     = fmatch->mScr_y;
+    flashmatch.scr_z     = fmatch->mScr_z;
+    flashmatch.scr_rr    = fmatch->mScr_rr;
     flashmatch.scr_ratio = fmatch->mScr_ratio;
     flashmatch.chargeXYZ = fmatch->mChargeXYZ;
-    flashmatch.lightXYZ = fmatch->mLightXYZ;
+    flashmatch.lightXYZ  = fmatch->mLightXYZ;
     srslice.fmatch_a = flashmatch;
   }
 
@@ -63,16 +65,17 @@ namespace caf
       srslice.fmatch_b.present = false;
       return;
     }
-    srslice.fmatch_b.present = fmatch->mPresent;
-    srslice.fmatch_b.time    = fmatch->mTime;
-    srslice.fmatch_b.pe      = fmatch->mPE;
-    srslice.fmatch_b.score   = fmatch->mScore;
-    srslice.fmatch_b.scr_y   = fmatch->mScr_y;
-    srslice.fmatch_b.scr_z   = fmatch->mScr_z;
-    srslice.fmatch_b.scr_rr  = fmatch->mScr_rr;
+    srslice.fmatch_b.present   = fmatch->mPresent;
+    srslice.fmatch_b.time      = fmatch->mTime;
+    srslice.fmatch_b.charge_q  = fmatch->mChargeQ;
+    srslice.fmatch_b.light_pe  = fmatch->mLightPE;
+    srslice.fmatch_b.score     = fmatch->mScore;
+    srslice.fmatch_b.scr_y     = fmatch->mScr_y;
+    srslice.fmatch_b.scr_z     = fmatch->mScr_z;
+    srslice.fmatch_b.scr_rr    = fmatch->mScr_rr;
     srslice.fmatch_b.scr_ratio = fmatch->mScr_ratio;
     srslice.fmatch_b.chargeXYZ = fmatch->mChargeXYZ;
-    srslice.fmatch_b.lightXYZ = fmatch->mLightXYZ;
+    srslice.fmatch_b.lightXYZ  = fmatch->mLightXYZ;
   }
 
   //......................................................................

--- a/sbncode/CAFMaker/FillFlashMatch.cxx
+++ b/sbncode/CAFMaker/FillFlashMatch.cxx
@@ -19,17 +19,17 @@ namespace caf
       srslice.fmatch.present = false;
       return;
     }
-    srslice.fmatch.present     = fmatch->present;
-    srslice.fmatch.time        = fmatch->time;
-    srslice.fmatch.charge.q    = fmatch->charge.q;
-    srslice.fmatch.light.pe    = fmatch->light.pe;
-    srslice.fmatch.score.total = fmatch->score.total;
-    srslice.fmatch.score.y     = fmatch->score.y;
-    srslice.fmatch.score.z     = fmatch->score.z;
-    srslice.fmatch.score.rr    = fmatch->score.rr;
-    srslice.fmatch.score.ratio = fmatch->score.ratio;
-    srslice.fmatch.charge.center = fmatch->charge.center;
-    srslice.fmatch.light.center  = fmatch->light.center;
+    srslice.fmatch.present    = fmatch->present;
+    srslice.fmatch.time       = fmatch->time;
+    srslice.fmatch.chargeQ    = fmatch->charge.q;
+    srslice.fmatch.lightPE    = fmatch->light.pe;
+    srslice.fmatch.scoreTotal = fmatch->score.total;
+    srslice.fmatch.scoreY     = fmatch->score.y;
+    srslice.fmatch.scoreZ     = fmatch->score.z;
+    srslice.fmatch.scoreRR    = fmatch->score.rr;
+    srslice.fmatch.scoreRatio = fmatch->score.ratio;
+    srslice.fmatch.chargeCenter = fmatch->charge.center;
+    srslice.fmatch.lightCenter  = fmatch->light.center;
   }
 
   //......................................................................
@@ -41,17 +41,17 @@ namespace caf
       srslice.fmatch_a.present = false;
       return;
     }
-    srslice.fmatch_a.present     = fmatch->present;
-    srslice.fmatch_a.time        = fmatch->time;
-    srslice.fmatch_a.charge.q    = fmatch->charge.q;
-    srslice.fmatch_a.light.pe    = fmatch->light.pe;
-    srslice.fmatch_a.score.total = fmatch->score.total;
-    srslice.fmatch_a.score.y     = fmatch->score.y;
-    srslice.fmatch_a.score.z     = fmatch->score.z;
-    srslice.fmatch_a.score.rr    = fmatch->score.rr;
-    srslice.fmatch_a.score.ratio = fmatch->score.ratio;
-    srslice.fmatch_a.charge.center = fmatch->charge.center;
-    srslice.fmatch_a.light.center  = fmatch->light.center;
+    srslice.fmatch_a.present    = fmatch->present;
+    srslice.fmatch_a.time       = fmatch->time;
+    srslice.fmatch_a.chargeQ    = fmatch->charge.q;
+    srslice.fmatch_a.lightPE    = fmatch->light.pe;
+    srslice.fmatch_a.scoreTotal = fmatch->score.total;
+    srslice.fmatch_a.scoreY     = fmatch->score.y;
+    srslice.fmatch_a.scoreZ     = fmatch->score.z;
+    srslice.fmatch_a.scoreRR    = fmatch->score.rr;
+    srslice.fmatch_a.scoreRatio = fmatch->score.ratio;
+    srslice.fmatch_a.chargeCenter = fmatch->charge.center;
+    srslice.fmatch_a.lightCenter  = fmatch->light.center;
   }
 
   //......................................................................
@@ -63,17 +63,17 @@ namespace caf
       srslice.fmatch_b.present = false;
       return;
     }
-    srslice.fmatch_b.present     = fmatch->present;
-    srslice.fmatch_b.time        = fmatch->time;
-    srslice.fmatch_b.charge.q    = fmatch->charge.q;
-    srslice.fmatch_b.light.pe    = fmatch->light.pe;
-    srslice.fmatch_b.score.total = fmatch->score.total;
-    srslice.fmatch_b.score.y     = fmatch->score.y;
-    srslice.fmatch_b.score.z     = fmatch->score.z;
-    srslice.fmatch_b.score.rr    = fmatch->score.rr;
-    srslice.fmatch_b.score.ratio = fmatch->score.ratio;
-    srslice.fmatch_b.charge.center = fmatch->charge.center;
-    srslice.fmatch_b.light.center  = fmatch->light.center;
+    srslice.fmatch_b.present    = fmatch->present;
+    srslice.fmatch_b.time       = fmatch->time;
+    srslice.fmatch_b.chargeQ    = fmatch->charge.q;
+    srslice.fmatch_b.lightPE    = fmatch->light.pe;
+    srslice.fmatch_b.scoreTotal = fmatch->score.total;
+    srslice.fmatch_b.scoreY     = fmatch->score.y;
+    srslice.fmatch_b.scoreZ     = fmatch->score.z;
+    srslice.fmatch_b.scoreRR    = fmatch->score.rr;
+    srslice.fmatch_b.scoreRatio = fmatch->score.ratio;
+    srslice.fmatch_b.chargeCenter = fmatch->charge.center;
+    srslice.fmatch_b.lightCenter  = fmatch->light.center;
   }
 
   //......................................................................

--- a/sbncode/CAFMaker/FillFlashMatch.h
+++ b/sbncode/CAFMaker/FillFlashMatch.h
@@ -10,7 +10,6 @@
 #include "larcore/Geometry/Geometry.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 
-#include "lardataobj/AnalysisBase/T0.h"
 //Include new flash match class
 #include "sbnobj/Common/Reco/SimpleFlashMatchVars.h"
 #include "sbnanaobj/StandardRecord/StandardRecord.h"
@@ -19,17 +18,17 @@
 namespace caf
 {
 
-  void FillSliceFlashMatch(const sbn::SimpleFlashMatch &fmatch,
-                           caf::SRSlice &srslice,
+  void FillSliceFlashMatch(const sbn::SimpleFlashMatch* fmatch,
+                           caf::SRSlice& srslice,
                            bool allowEmpty = false);
 
-  void FillSliceFlashMatchA(const sbn::SimpleFlashMatch &fmatch,
-			    caf::SRSlice &srslice,
-			    bool allowEmpty = false);
+  void FillSliceFlashMatchA(const sbn::SimpleFlashMatch* fmatch,
+                            caf::SRSlice& srslice,
+                            bool allowEmpty = false);
 
-  void FillSliceFlashMatchB(const sbn::SimpleFlashMatch &fmatch,
-			    caf::SRSlice &srslice,
-			    bool allowEmpty = false);
+  void FillSliceFlashMatchB(const sbn::SimpleFlashMatch* fmatch,
+                            caf::SRSlice& srslice,
+                            bool allowEmpty = false);
 }
 
 #endif

--- a/sbncode/CAFMaker/FillFlashMatch.h
+++ b/sbncode/CAFMaker/FillFlashMatch.h
@@ -11,21 +11,22 @@
 #include "larcorealg/Geometry/GeometryCore.h"
 
 #include "lardataobj/AnalysisBase/T0.h"
+//Include new flash match class
+#include "sbnobj/Common/Reco/SimpleFlashMatchVars.h"
 #include "sbnanaobj/StandardRecord/StandardRecord.h"
-
 
 namespace caf
 {
 
-  void FillSliceFlashMatch(const anab::T0 *fmatch,
+  void FillSliceFlashMatch(const sbn::SimpleFlashMatch &fmatch,
                            caf::SRSlice &srslice,
                            bool allowEmpty = false);
 
-  void FillSliceFlashMatchA(const anab::T0 *fmatch,
+  void FillSliceFlashMatchA(const sbn::SimpleFlashMatch &fmatch,
 			    caf::SRSlice &srslice,
 			    bool allowEmpty = false);
 
-  void FillSliceFlashMatchB(const anab::T0 *fmatch,
+  void FillSliceFlashMatchB(const sbn::SimpleFlashMatch &fmatch,
 			    caf::SRSlice &srslice,
 			    bool allowEmpty = false);
 }

--- a/sbncode/CAFMaker/FillFlashMatch.h
+++ b/sbncode/CAFMaker/FillFlashMatch.h
@@ -14,6 +14,7 @@
 //Include new flash match class
 #include "sbnobj/Common/Reco/SimpleFlashMatchVars.h"
 #include "sbnanaobj/StandardRecord/StandardRecord.h"
+#include "sbnanaobj/StandardRecord/SRFlashMatch.h"
 
 namespace caf
 {

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -146,13 +146,14 @@ private:
   detinfo::DetectorClocksData const fClockData;
   const double fTickPeriod;
   const double fBeamWindowStart, fBeamWindowEnd;
-  const double fLightWindowStart, fLightWindowEnd;
+  const double fFlashStart, fFlashEnd;
   const unsigned fTimeBins;
-  const bool fSelectNeutrino, fUseUncoatedPMT, fUseOppVolMetric;//, fUseCalo;
+  const bool fSelectNeutrino, fOnlyPrimaries;
+  const bool fUseUncoatedPMT, fUseOppVolMetric;//, fUseCalo;
   const bool fUseARAPUCAS;
   const std::string fInputFilename;
   const bool fNoAvailableMetrics, fMakeTree;
-  const double fMinFlashPE, fMinOpHPE, fPEscale,
+  const double fMinFlashPE, fMinOpHPE, fQScale, fPEScale,
     fChargeToNPhotonsShower, fChargeToNPhotonsTrack;
   std::string fDetector; // SBND or ICARUS
   bool fSBND, fICARUS;
@@ -165,7 +166,7 @@ private:
   size_t fNTPC;
   unsigned fDriftVolumes;
   unsigned fTPCPerDriftVolume;
-  const unsigned fVUVToVIS;
+  const unsigned fOpDetNormalizer;
   const double fTermThreshold;
   std::list<double> fWiresX_gl;
   // std::vector<double> fPMTChannelCorrection;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -95,7 +95,7 @@ private:
   bool computeFlashMetrics(const std::set<unsigned>& tpcWithHits);
   bool computeScore(const std::set<unsigned>& tpcWithHits, const int pdgc);
   double hypoFlashX_splines() const;
-  double hypoFlashX_fits() const;
+  double hypoFlashX_fits();
   // ::flashmatch::Flash_t GetFlashPESpectrum(const recob::OpFlash& opflash);
   // void CollectDownstreamPFParticles(const lar_pandora::PFParticleMap& pfParticleMap,
   //                                   const art::Ptr<recob::PFParticle>& particle,
@@ -125,6 +125,7 @@ private:
                         const std::set<unsigned>& tpcWithHits) const;
   unsigned sbndPDinTPC(const int pdChannel) const;
   unsigned icarusPDinTPC(const int pdChannel) const;
+  double flashXGl(const double hypo_x, const double flash_x) const;
   double driftDistance(const double x) const;
   unsigned driftVolume(const double x) const;
   // bool isPDInCryoTPC(double pd_x, size_t itpc);
@@ -194,12 +195,12 @@ private:
   // Tree variables
   double _charge_x_gl, _charge_x,
     _charge_y, _charge_z, _charge_q;
-  double _flash_x, _flash_y, _flash_z,
+  double _flash_x, _flash_x_gl, _flash_y, _flash_z,
     _flash_r, _flash_pe, _flash_unpe, _flash_ratio;
   // TODO: why not charge_time?
   double _flash_time;
   double _score, _scr_y, _scr_z, _scr_rr, _scr_ratio;
-  double _hypo_x;//, _hypo_x_fit;
+  double _hypo_x, _hypo_x_rr, _hypo_x_ratio;//, _hypo_x_fit;
   unsigned _evt, _run, _sub, _countPE; //_slices;
 
   std::vector<double> dy_means, dz_means, rr_means, pe_means;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -153,8 +153,9 @@ private:
   const bool fUseARAPUCAS;
   const std::string fInputFilename;
   const bool fNoAvailableMetrics, fMakeTree;
-  const double fMinFlashPE, fMinOpHPE, fQScale, fPEScale,
-    fChargeToNPhotonsShower, fChargeToNPhotonsTrack;
+  const double fChargeToNPhotonsShower, fChargeToNPhotonsTrack;
+  const double fMinHitQ, fMinSliceQ, fQScale;
+  const double fMinOpHPE, fMinFlashPE, fPEScale;
   std::string fDetector; // SBND or ICARUS
   bool fSBND, fICARUS;
   std::unique_ptr<opdet::PDMapAlg> fPDMapAlgPtr;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -105,14 +105,14 @@ private:
   //                                   lar_pandora::PFParticleVector& downstreamPFParticles) const;
   void AddDaughters(const std::map<size_t, size_t>& pfpMap,
                     const art::Ptr<recob::PFParticle>& pfp_ptr,
-                    const art::ValidHandle<std::vector<recob::PFParticle>>& pfp_h,
+                    const art::ValidHandle<std::vector<recob::PFParticle>>& pfps_h,
                     std::vector<art::Ptr<recob::PFParticle>>& pfp_v) const;
   double scoreTerm(const double m, const double n,
                    const double mean, const double spread) const;
   double scoreTerm(const double m,
                    const double mean, const double spread) const;
   bool pfpNeutrinoOnEvent(
-    const art::ValidHandle<std::vector<recob::PFParticle>>& pfp_h) const;
+    const art::ValidHandle<std::vector<recob::PFParticle>>& pfps_h) const;
   void copyOpHitsInBeamWindow(
     std::vector<recob::OpHit>& opHits,
     const art::Handle<std::vector<recob::OpHit>>& ophit_h) const;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -194,6 +194,12 @@ private:
 
   // std::vector<double> _pe_reco_v, _pe_hypo_v;
 
+  // aliases for the objects that are stored
+  using sFM    = sbn::SimpleFlashMatch;
+  using Charge = sbn::SimpleFlashMatch::Charge;
+  using Flash  = sbn::SimpleFlashMatch::Flash;
+  using Score  = sbn::SimpleFlashMatch::Score;
+
   // Tree variables
   double _charge_x_gl, _charge_x,
     _charge_y, _charge_z, _charge_q;
@@ -209,11 +215,11 @@ private:
   std::vector<double> dy_spreads, dz_spreads, rr_spreads, pe_spreads;
 
   struct ChargeDigest {
-     size_t pId;
-     int pfpPDGC;
-     art::Ptr<recob::PFParticle> pfp_ptr;
-     flashmatch::QCluster_t qClusters;
-     std::set<unsigned> tpcWithHits;
+    size_t pId;
+    int pfpPDGC;
+    art::Ptr<recob::PFParticle> pfp_ptr;
+    flashmatch::QCluster_t qClusters;
+    std::set<unsigned> tpcWithHits;
     ChargeDigest() = default;
     ChargeDigest(const size_t pId_, const int pfpPDGC_,
                  const art::Ptr<recob::PFParticle>& pfp_ptr_,

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -52,6 +52,7 @@
 
 #include "sbncode/OpT0Finder/flashmatch/Base/OpT0FinderTypes.h"
 #include "sbncode/OpDet/PDMapAlg.h"
+#include "sbnobj/Common/Reco/SimpleFlashMatchVars.h"
 
 // turn the warnings back on
 //#pragma GCC diagnostic pop

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -202,7 +202,7 @@ private:
   double _flash_time;
   double _score, _scr_y, _scr_z, _scr_rr, _scr_ratio;
   double _hypo_x, _hypo_x_rr, _hypo_x_ratio;//, _hypo_x_fit;
-  unsigned _evt, _run, _sub, _countPE; //_slices;
+  unsigned _evt, _run, _sub; //_slices;
 
   std::vector<double> dy_means, dz_means, rr_means, pe_means;
   std::vector<double> dy_spreads, dz_spreads, rr_spreads, pe_spreads;
@@ -225,6 +225,7 @@ private:
 
   const bool kNoScr = false;
   const double kNoScrTime = -9999.;
+  const double kNoScrQ  = -9999.;
   const double kNoScrPE = -9999.;
   const int kQNoOpHScr = -1;
   const int kNoChrgScr = -2;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -78,7 +78,7 @@ public:
   FlashPredict& operator=(FlashPredict const&) = delete;
   FlashPredict& operator=(FlashPredict&&) = delete;
   // Required functions.
-  void produce(art::Event& e) override;
+  void produce(art::Event& evt) override;
   // Selected optional functions.
   void beginJob() override;
   void endJob() override;
@@ -221,9 +221,15 @@ private:
       {}
   };
 
+  const bool kNoScr = false;
+  const double kNoScrTime = -9999.;
+  const double kNoScrPE = -9999.;
   const int kQNoOpHScr = -1;
   const int kNoChrgScr = -2;
   const int k0VUVPEScr = -3;
+  const int kNoOpHInEvt = -11;
+  const int kNoPFPInEvt = -12;
+  // const int kNoSlcInEvt = -13;
   struct BookKeeping {
     int job_bookkeeping, events_processed;
     unsigned events, nopfpneutrino,// noslice,

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -115,10 +115,11 @@ FlashPredict::FlashPredict(fhicl::ParameterSet const& p)
 
 void FlashPredict::produce(art::Event& evt)
 {
-  std::unique_ptr< std::vector<sbn::SimpleFlashMatch> >
-    sFM_v(new std::vector<sbn::SimpleFlashMatch>);
-  std::unique_ptr< art::Assns <recob::PFParticle, sbn::SimpleFlashMatch> >
-    pfp_sFM_assn_v(new art::Assns<recob::PFParticle, sbn::SimpleFlashMatch>);
+  // sFM is an alias for sbn::SimpleFlashMatch
+  std::unique_ptr< std::vector<sFM> >
+    sFM_v(new std::vector<sFM>);
+  std::unique_ptr< art::Assns <recob::PFParticle, sFM> >
+    pfp_sFM_assn_v(new art::Assns<recob::PFParticle, sFM>);
 
   // reset TTree variables
   _evt = evt.event();
@@ -146,8 +147,8 @@ void FlashPredict::produce(art::Event& evt)
     updateBookKeeping();
     for (size_t pId=0; pId<pfp_h->size(); pId++) {
       const art::Ptr<recob::PFParticle> pfp_ptr(pfp_h, pId);
-      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
-                                             kNoScrPE, kNoPFPInEvt));
+      sFM_v->push_back(sFM(kNoScr, kNoScrTime, Charge(kNoScrQ),
+                           Flash(kNoScrPE), Score(kNoPFPInEvt)));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
     }
     evt.put(std::move(sFM_v));
@@ -164,8 +165,8 @@ void FlashPredict::produce(art::Event& evt)
   //   updateBookKeeping();
   //   for (size_t pId=0; pId<pfp_h->size(); pId++) {
   //     const art::Ptr<recob::PFParticle> pfp_ptr(pfp_h, pId);
-  //     sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
-  //                                            kNoScrPE, kNoSlcInEvt));
+  //     sFM_v->push_back(sFM(kNoScr, kNoScrTime, Charge(kNoScrQ),
+  //                          Flash(kNoScrPE), Score(kNoSlcInEvt)));
   //     util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
   //   }
   //   evt.put(std::move(sFM_v));
@@ -203,8 +204,8 @@ void FlashPredict::produce(art::Event& evt)
     updateBookKeeping();
     for (size_t pId=0; pId<pfp_h->size(); pId++) {
       const art::Ptr<recob::PFParticle> pfp_ptr(pfp_h, pId);
-      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
-                                             kNoScrPE, kNoOpHInEvt));
+      sFM_v->push_back(sFM(kNoScr, kNoScrTime, Charge(kNoScrQ),
+                           Flash(kNoScrPE), Score(kNoOpHInEvt)));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
     }
     evt.put(std::move(sFM_v));
@@ -243,8 +244,8 @@ void FlashPredict::produce(art::Event& evt)
     updateBookKeeping();
     for (size_t pId=0; pId<pfp_h->size(); pId++) {
       const art::Ptr<recob::PFParticle> pfp_ptr(pfp_h, pId);
-      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
-                                             kNoScrPE, kNoOpHInEvt));
+      sFM_v->push_back(sFM(kNoScr, kNoScrTime, Charge(kNoScrQ),
+                           Flash(kNoScrPE), Score(kNoOpHInEvt)));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
     }
     evt.put(std::move(sFM_v));
@@ -362,8 +363,8 @@ void FlashPredict::produce(art::Event& evt)
         mf::LogWarning("FlashPredict") << "No OpHits where there's charge. Skipping...";
         bk.no_oph_hits++;
         mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
-        sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
-                                               kNoScrPE, kQNoOpHScr));
+        sFM_v->push_back(sFM(kNoScr, kNoScrTime, Charge(kNoScrQ),
+                             Flash(kNoScrPE), Score(kQNoOpHScr)));
         util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
         continue;
       }
@@ -373,8 +374,8 @@ void FlashPredict::produce(art::Event& evt)
       mf::LogWarning("FlashPredict") << "Clusters with No Charge. Skipping...";
       bk.no_charge++;
       mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
-      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
-                                             kNoScrPE, kNoChrgScr));
+      sFM_v->push_back(sFM(kNoScr, kNoScrTime, Charge(kNoScrQ),
+                           Flash(kNoScrPE), Score(kNoChrgScr)));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
       continue;
     }
@@ -383,8 +384,8 @@ void FlashPredict::produce(art::Event& evt)
       printMetrics("ERROR", pfpPDGC, tpcWithHits, 0, mf::LogError("FlashPredict"));
       bk.no_flash_pe++;
       mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
-      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
-                                             kNoScrPE, k0VUVPEScr));
+      sFM_v->push_back(sFM(kNoScr, kNoScrTime, Charge(kNoScrQ),
+                           Flash(kNoScrPE), Score(k0VUVPEScr)));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
       continue;
     }
@@ -393,11 +394,10 @@ void FlashPredict::produce(art::Event& evt)
       if (fMakeTree) {_flashmatch_nuslice_tree->Fill();}
       bk.scored_pfp++;
       mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
-      sFM_v->push_back(
-        sbn::SimpleFlashMatch(true, _flash_time, _charge_q, _flash_pe, _score,
-                              _scr_y, _scr_z, _scr_rr, _scr_ratio,
-                              TVector3(_charge_x_gl, _charge_y, _charge_z),
-                              TVector3(_flash_x_gl, _flash_y, _flash_z)));
+      Charge charge{_charge_q, TVector3(_charge_x_gl, _charge_y, _charge_z)};
+      Flash flash{_flash_pe, TVector3(_flash_x_gl, _flash_y, _flash_z)};
+      Score score{_score, _scr_y, _scr_z, _scr_rr, _scr_ratio};
+      sFM_v->push_back(sFM(true, _flash_time, charge, flash, score));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
     }
     else{

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -323,7 +323,7 @@ void FlashPredict::produce(art::Event & e)
         mf::LogWarning("FlashPredict") << "No OpHits where there's charge. Skipping...";
         bk.no_oph_hits++;
         mf::LogDebug("FlashPredict") << "Creating T0 and PFP-T0 association";
-        T0_v->push_back(sbn::SimpleFlashMatch(false,-9999., kQNoOpHScr, kQNoOpHScr, kQNoOpHScr, kQNoOpHScr, kQNoOpHScr, 0.));
+        T0_v->push_back(sbn::SimpleFlashMatch(false,-9999., kQNoOpHScr, kQNoOpHScr, kQNoOpHScr, kQNoOpHScr, kQNoOpHScr, 0.,TVector3(-999.0,-999.0, -999.0), TVector3(-999.0, -999.0, -999.0)));
         util::CreateAssn(*this, e, *T0_v, pfp_ptr, *pfp_t0_assn_v);
         continue;
       }
@@ -333,7 +333,7 @@ void FlashPredict::produce(art::Event & e)
       mf::LogWarning("FlashPredict") << "Clusters with No Charge. Skipping...";
       bk.no_charge++;
       mf::LogDebug("FlashPredict") << "Creating T0 and PFP-T0 association";
-      T0_v->push_back(sbn::SimpleFlashMatch(false,-9999., kNoChrgScr, kNoChrgScr, kNoChrgScr, kNoChrgScr, kNoChrgScr, 0.));
+      T0_v->push_back(sbn::SimpleFlashMatch(false,-9999., kNoChrgScr, kNoChrgScr, kNoChrgScr, kNoChrgScr, kNoChrgScr, 0.,TVector3(-999.0,-999.0, -999.0), TVector3(-999.0, -999.0, -999.0)));
       util::CreateAssn(*this, e, *T0_v, pfp_ptr, *pfp_t0_assn_v);
       continue;
     }
@@ -342,7 +342,7 @@ void FlashPredict::produce(art::Event & e)
       printMetrics("ERROR", pfpPDGC, tpcWithHits, 0, mf::LogError("FlashPredict"));
       bk.no_flash_pe++;
       mf::LogDebug("FlashPredict") << "Creating T0 and PFP-T0 association";
-      T0_v->push_back(sbn::SimpleFlashMatch(false,-9999., k0VUVPEScr, k0VUVPEScr, k0VUVPEScr, k0VUVPEScr, k0VUVPEScr, 0.));
+      T0_v->push_back(sbn::SimpleFlashMatch(false,-9999., k0VUVPEScr, k0VUVPEScr, k0VUVPEScr, k0VUVPEScr, k0VUVPEScr, 0.,TVector3(-999.0,-999.0, -999.0), TVector3(-999.0, -999.0, -999.0)));
       util::CreateAssn(*this, e, *T0_v, pfp_ptr, *pfp_t0_assn_v);
       continue;
     }
@@ -351,7 +351,20 @@ void FlashPredict::produce(art::Event & e)
       if (fMakeTree) {_flashmatch_nuslice_tree->Fill();}
       bk.scored_pfp++;
       mf::LogDebug("FlashPredict") << "Creating T0 and PFP-T0 association";
-      T0_v->push_back(sbn::SimpleFlashMatch(true,_flash_time, _score, _scr_y, _scr_z, _scr_rr, _scr_ratio, _countPE, TVector3(_charge_x,_charge_y, _charge_z), TVector3(_flash_x, _flash_y, _flash_z)));
+      sbn::SimpleFlashMatch fm = new sbn::SimpleFlashMatch();
+      fm.mPresent = true;
+      fm.mTime = _flash_time;
+      fm.mScore = _score;
+      fm.mScr_y = _scr_y;
+      fm.mScr_z = _scr_z;
+      fm.mScr_rr = _scr_rr;
+      fm.mScr_ratio = _scr_ratio;
+      fm.mPE = _countPE;
+      fm.mChargeXYZ = TVector3(_charge_x,_charge_y, _charge_z);
+      fm.mLightXYZ = TVector3(_flash_x, _flash_y, _flash_z);
+      std::cout << fm.mPresent << " " << fm.mTime << " " << fm.mScore << " " << fm.mScr_y << " " << fm.mScr_z << " " << fm.mScr_rr << " " << fm.mScr_ratio << " " << fm.mPE << " " << std::endl; 
+      //T0_v->push_back(sbn::SimpleFlashMatch(true,_flash_time, _score, _scr_y, _scr_z, _scr_rr, _scr_ratio, _countPE, TVector3(_charge_x,_charge_y, _charge_z), TVector3(_flash_x, _flash_y, _flash_z)));
+      T0_v->push_back(fm);
       util::CreateAssn(*this, e, *T0_v, pfp_ptr, *pfp_t0_assn_v);
     }
   } // chargeDigestMap: PFparticles that pass criteria

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -33,12 +33,14 @@ FlashPredict::FlashPredict(fhicl::ParameterSet const& p)
   , fInputFilename(p.get<std::string>("InputFileName")) // root file with score metrics
   , fNoAvailableMetrics(p.get<bool>("NoAvailableMetrics", false))
   , fMakeTree(p.get<bool>("MakeTree", false))
-  , fMinFlashPE(p.get<double>("MinFlashPE", 0.0))
-  , fMinOpHPE(p.get<double>("MinOpHPE", 0.0))
-  , fQScale(p.get<double>("QScale", 1.0))
-  , fPEScale(p.get<double>("PEScale", 1.0))
   , fChargeToNPhotonsShower(p.get<double>("ChargeToNPhotonsShower", 1.0))  // ~40000/1600
   , fChargeToNPhotonsTrack(p.get<double>("ChargeToNPhotonsTrack", 1.0))  // ~40000/1600
+  , fMinHitQ(p.get<double>("MinHitQ", 0.0))
+  , fMinSliceQ(p.get<double>("MinSliceQ", 0.0))
+  , fQScale(p.get<double>("QScale", 1.0))
+  , fMinOpHPE(p.get<double>("MinOpHPE", 0.0))
+  , fMinFlashPE(p.get<double>("MinFlashPE", 0.0))
+  , fPEScale(p.get<double>("PEScale", 1.0))
   , fCryostat(p.get<int>("Cryostat", 0)) //set =0 ot =1 for ICARUS to match reco chain selection
   , fNBins(p.get<int>("n_bins"))
   , fDriftDistance(p.get<double>("DriftDistance"))// rounded up for binning
@@ -331,12 +333,14 @@ void FlashPredict::produce(art::Event& evt)
           auto itpc = wid.TPC;
           tpcWithHits.insert(itpc);
           const auto charge(hit->Integral());
+          if (charge < fMinHitQ) continue;
           totalCharge += charge;
           qClusters.emplace_back(pos[0], pos[1], pos[2], charge * chargeToNPhotons);
         } // for all hits associated to this spacepoint
       } // for all spacepoints
       //      }  // if track or shower
     } // for all pfp pointers
+    if (totalCharge < fMinSliceQ) continue;
     chargeDigestMap[totalCharge] = ChargeDigest(pId, pfpPDGC, pfp_ptr,
                                                 qClusters, tpcWithHits);
     }//TODO: pack this into a function

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -123,7 +123,6 @@ void FlashPredict::produce(art::Event& evt)
   _sub = evt.subRun();
   _run = evt.run();
   // _slices        = 0;
-  _countPE       = 0;
   _flash_time    = -9999.;
   _flash_pe      = -9999.;
   _flash_unpe    = -9999.;
@@ -145,7 +144,7 @@ void FlashPredict::produce(art::Event& evt)
     updateBookKeeping();
     for (size_t pId=0; pId<pfp_h->size(); pId++) {
       const art::Ptr<recob::PFParticle> pfp_ptr(pfp_h, pId);
-      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime,
+      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
                                              kNoScrPE, kNoPFPInEvt));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
     }
@@ -163,7 +162,7 @@ void FlashPredict::produce(art::Event& evt)
   //   updateBookKeeping();
   //   for (size_t pId=0; pId<pfp_h->size(); pId++) {
   //     const art::Ptr<recob::PFParticle> pfp_ptr(pfp_h, pId);
-  //     sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime,
+  //     sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
   //                                            kNoScrPE, kNoSlcInEvt));
   //     util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
   //   }
@@ -202,7 +201,7 @@ void FlashPredict::produce(art::Event& evt)
     updateBookKeeping();
     for (size_t pId=0; pId<pfp_h->size(); pId++) {
       const art::Ptr<recob::PFParticle> pfp_ptr(pfp_h, pId);
-      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime,
+      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
                                              kNoScrPE, kNoOpHInEvt));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
     }
@@ -242,7 +241,7 @@ void FlashPredict::produce(art::Event& evt)
     updateBookKeeping();
     for (size_t pId=0; pId<pfp_h->size(); pId++) {
       const art::Ptr<recob::PFParticle> pfp_ptr(pfp_h, pId);
-      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime,
+      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
                                              kNoScrPE, kNoOpHInEvt));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
     }
@@ -359,7 +358,7 @@ void FlashPredict::produce(art::Event& evt)
         mf::LogWarning("FlashPredict") << "No OpHits where there's charge. Skipping...";
         bk.no_oph_hits++;
         mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
-        sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime,
+        sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
                                                kNoScrPE, kQNoOpHScr));
         util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
         continue;
@@ -370,7 +369,7 @@ void FlashPredict::produce(art::Event& evt)
       mf::LogWarning("FlashPredict") << "Clusters with No Charge. Skipping...";
       bk.no_charge++;
       mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
-      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime,
+      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
                                              kNoScrPE, kNoChrgScr));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
       continue;
@@ -380,7 +379,7 @@ void FlashPredict::produce(art::Event& evt)
       printMetrics("ERROR", pfpPDGC, tpcWithHits, 0, mf::LogError("FlashPredict"));
       bk.no_flash_pe++;
       mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
-      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime,
+      sFM_v->push_back(sbn::SimpleFlashMatch(kNoScr, kNoScrTime, kNoScrQ,
                                              kNoScrPE, k0VUVPEScr));
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
       continue;
@@ -391,7 +390,7 @@ void FlashPredict::produce(art::Event& evt)
       bk.scored_pfp++;
       mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
       sFM_v->push_back(
-        sbn::SimpleFlashMatch(true, _flash_time, _countPE, _score,
+        sbn::SimpleFlashMatch(true, _flash_time, _charge_q, _flash_pe, _score,
                               _scr_y, _scr_z, _scr_rr, _scr_ratio,
                               TVector3(_charge_x_gl, _charge_y, _charge_z),
                               TVector3(_flash_x_gl, _flash_y, _flash_z)));
@@ -734,7 +733,6 @@ bool FlashPredict::computeFlashMetrics(const std::set<unsigned>& tpcWithHits)
     // _hypo_x = hypoFlashX_splines();
     _hypo_x = hypoFlashX_fits();
     _flash_x_gl = flashXGl(_hypo_x, _flash_x);
-    _countPE = std::round(_flash_pe);
     return true;
   }
   else {
@@ -1307,7 +1305,7 @@ void FlashPredict::printBookKeeping(Stream&& out)
   if(bk.nullophittime) {
     m << "\tNo OpHits in-time:\t -" << bk.nullophittime
       << ", scored as: " << kNoOpHInEvt << "\n";
-  }      
+  }
   m << "\t----------------------\n";
   if(bk.job_bookkeeping != bk.events_processed)
     m << "\tJob Bookkeeping:  \t" << bk.job_bookkeeping << " ERROR!\n";

--- a/sbncode/FlashMatch/template_generators/generate_simple_weighted_template.py
+++ b/sbncode/FlashMatch/template_generators/generate_simple_weighted_template.py
@@ -33,9 +33,15 @@ from ROOT import TStyle, TCanvas, TColor, TGraph, TGraphErrors
 from ROOT import TH1D, TH2D, TProfile, TFile, TF1
 from ROOT import gROOT
 import ROOT
-# import project_utilities
-import larbatch_posix
-import fhicl
+
+try:
+    # import project_utilities
+    import larbatch_posix
+    import fhicl
+except ImportError:
+    print("Failed to import 'larbatch_posix' or 'fhicl' modules")
+    print("Setup 'fhiclpy' first:\n\tsetup fhiclpy vV_VV_VV -q QQQ:QQQQ")
+    exit(1)
 
 
 class dotDict(dict):


### PR DESCRIPTION
Pull request for the addition of a new sbn::SimpleFlashMatch data product replacing the anab::T0 object that was used previously. This is largely done to improve the amount of stored information from the simple flash match object in the CAF files.  Tested on SBND and ICARUS simulations and shown to fill the correct object in the CAF files. 