### PR TITLE
BackTracker messages are useless

### DIFF
--- a/sbncode/CAFMaker/cafmakerjob_sbnd.fcl
+++ b/sbncode/CAFMaker/cafmakerjob_sbnd.fcl
@@ -31,7 +31,7 @@ services:
   RandomNumberGenerator: {} #ART native random number generator
   TFileService: { fileName: "fullchain_production_hist_prod5.root" closeFileFast: false }
 #  scheduler:    { wantTracer: false wantSummary: true }
-  message:      { debugModules: ["*"] destinations: { debugmsg:{type: "cout" threshold: "INFO"  categories:{BackTracker: { limit: 0 }} } } }
+   message:     @local::sbnd_message_services_prod
   TimeTracker:  { printSummary: true }
   # #  @table::standard_services
 

--- a/sbncode/CAFMaker/cafmakerjob_sbnd.fcl
+++ b/sbncode/CAFMaker/cafmakerjob_sbnd.fcl
@@ -31,7 +31,7 @@ services:
   RandomNumberGenerator: {} #ART native random number generator
   TFileService: { fileName: "fullchain_production_hist_prod5.root" closeFileFast: false }
 #  scheduler:    { wantTracer: false wantSummary: true }
-  message:      { debugModules: ["*"] destinations: { debugmsg:{type: "cout" threshold: "INFO"} } }
+  message:      { debugModules: ["*"] destinations: { debugmsg:{type: "cout" threshold: "INFO"  categories:{BackTracker: { limit: 0 }} } } }
   TimeTracker:  { printSummary: true }
   # #  @table::standard_services
 


### PR DESCRIPTION
We have all experience the barrage of BackTracker messages...

```
%MSG
%MSG-w BackTracker:  MCParticleHitMatching:gaushitTruthMatch@BeginModule  24-Jun-2021 18:18:27 CDT run: 1 subRun: 0 event: 50
caught exception
---- BackTracker BEGIN
  No sim::SimChannel corresponding to channel: 8658
---- BackTracker END
```

This commits ignores them