### PR TITLE
Remove GENIE v2 flag

### DIFF
--- a/fcl/gen/genie/prodgenie_bnb_nu_cosmic_sbn_icarus.fcl
+++ b/fcl/gen/genie/prodgenie_bnb_nu_cosmic_sbn_icarus.fcl
@@ -11,7 +11,6 @@ physics.producers.generator.TopVolume: "volDetEnclosure"
 physics.producers.generator.BeamName: "booster"
 physics.producers.generator.FluxSearchPaths: "/pnfs/sbn/persistent/users/mastbaum/flux/icarus/zarko-expires20171031/"
 physics.producers.generator.FluxFiles: [ "converted_beammc_icarus_*.root" ]
-physics.producers.generator.EventGeneratorList: "Default+CCMEC+NCMEC"
 
 physics.producers.corsika: {
   module_type: "CORSIKAGen"

--- a/fcl/gen/genie/prodgenie_bnb_nu_cosmic_sbn_sbnd.fcl
+++ b/fcl/gen/genie/prodgenie_bnb_nu_cosmic_sbn_sbnd.fcl
@@ -11,5 +11,4 @@ physics.producers.generator.TopVolume: "volCryostat"
 physics.producers.generator.BeamName: "booster"
 physics.producers.generator.FluxSearchPaths: "/pnfs/sbn/persistent/users/gputnam/flux/sbnd/configD-v1_april07_neutrinoMode"
 physics.producers.generator.FluxFiles: [ "gsimple_configB-v1_5e7POT*.root" ]
-physics.producers.generator.EventGeneratorList: "Default+CCMEC+NCMEC"
 

--- a/fcl/gen/genie/prodgenie_bnb_nu_cosmic_sbn_uboone.fcl
+++ b/fcl/gen/genie/prodgenie_bnb_nu_cosmic_sbn_uboone.fcl
@@ -12,6 +12,5 @@ physics.producers.generator.RandomTimeOffset: 1600.
 physics.producers.generator.EventsPerSpill: 0
 physics.producers.generator.TopVolume: "volCryostat"
 physics.producers.generator.BeamName: "booster"
-physics.producers.generator.EventGeneratorList: "Default+CCMEC+NCMEC"
 physics.producers.generator.FluxSearchPaths: "/pnfs/sbn/persistent/users/gputnam/flux/uboone/bnb_gsimple_fluxes_02.05.2018_463/"
 

--- a/fcl/gen/genie/prodgenie_bnb_nu_sbn_icarus.fcl
+++ b/fcl/gen/genie/prodgenie_bnb_nu_sbn_icarus.fcl
@@ -11,5 +11,4 @@ physics.producers.generator.TopVolume: "volDetEnclosure"
 physics.producers.generator.BeamName: "booster"
 physics.producers.generator.FluxSearchPaths: "/pnfs/sbn/persistent/users/mastbaum/flux/icarus/zarko-expires20171031/"
 physics.producers.generator.FluxFiles: [ "converted_beammc_icarus_*.root" ]
-physics.producers.generator.EventGeneratorList: "Default+CCMEC+NCMEC"
 

--- a/fcl/gen/genie/prodgenie_bnb_nu_sbn_sbnd.fcl
+++ b/fcl/gen/genie/prodgenie_bnb_nu_sbn_sbnd.fcl
@@ -11,5 +11,4 @@ physics.producers.generator.TopVolume: "volCryostat"
 physics.producers.generator.BeamName: "booster"
 physics.producers.generator.FluxSearchPaths: "/pnfs/sbn/persistent/users/gputnam/flux/sbnd/configD-v1_april07_neutrinoMode"
 physics.producers.generator.FluxFiles: [ "converted_beammc_sbnd*.root" ]
-physics.producers.generator.EventGeneratorList: "Default+CCMEC+NCMEC"
 

--- a/fcl/gen/genie/prodgenie_bnb_nu_sbn_uboone.fcl
+++ b/fcl/gen/genie/prodgenie_bnb_nu_sbn_uboone.fcl
@@ -12,6 +12,5 @@ physics.producers.generator.RandomTimeOffset: 1600.
 physics.producers.generator.EventsPerSpill: 0
 physics.producers.generator.TopVolume: "volCryostat"
 physics.producers.generator.BeamName: "booster"
-physics.producers.generator.EventGeneratorList: "Default+CCMEC+NCMEC"
 physics.producers.generator.FluxSearchPaths: "/pnfs/sbn/persistent/users/gputnam/flux/uboone/bnb_gsimple_fluxes_02.05.2018_463/"
 


### PR DESCRIPTION
While looking for something else, I stumbled upon some fcl files that still have GENIE v2 flags. They are still valid, but they should not be used as before.  
They are endemic and should be removed if found in general purpose fcl files. I had a look in the fcl file chain and these were the only one I found. 
