### PR TITLE
Removed flawed check on hit index

### DIFF
--- a/sbncode/TPCReco/VertexStub/StubBuilder.cxx
+++ b/sbncode/TPCReco/VertexStub/StubBuilder.cxx
@@ -13,7 +13,7 @@ bool HitOnTrack(const art::Ptr<recob::Hit> &hit,
     // Found the hit on the track!
     if (hit == trk_hits[i]) { 
       // Is the hit part of the track Calo?
-      if (trk_thms[i]->Index() != std::numeric_limits<int>::max() && trk->HasValidPoint(trk_thms[i]->Index())) { 
+      if (trk->HasValidPoint(trk_thms[i]->Index())) { 
         return true;
       }
       break;


### PR DESCRIPTION
[Pandora assigns a wrong value to an unmatched hit](https://github.com/LArSoft/larpandora/blob/ce599557983592f6b6cf359960aa816304b8299a/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc#L265):
```cpp
const int index((hitIndex < hitsFromSpacePoints.size()) ? hitIndex : std::numeric_limits<int>::max());
recob::TrackHitMeta metadata(index, -std::numeric_limits<double>::max());
```
In short, that `std::numeric_limits<int>::max()` should have been `std::numeric_limits<unsigned int>::max()` (and that `index` an `unsigned int` too), but that's not what happened. Data has the wrong value in it, code is relying on that, and we have to work around it.
I am blaming Pandora, but I am not sure that is the only track maker making that mistake.

My proposed workaround is to let `recob::Track::HasValidPoint()` to implicitly do that check, since it is designed to.