### PR TITLE
Avoid crashing when there are no valid weights if StrictMode=false

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -366,6 +366,9 @@ void CAFMaker::beginRun(art::Run& run) {
     return; // Match, no need to refill into tree
   }
 
+  // If there were no weights available, return
+  if (!wgt_params.isValid()) return;
+
   fPrevWeightPSet = *wgt_params;
 
   SRGlobal global;


### PR DESCRIPTION
Title.