### PR TITLE
Updates to Track Skimming. Add in end-point-hit information and truth information

### DIFF
--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -7,11 +7,6 @@
 #include <algorithm>
 
 // helper function declarations
-caf::Wall_t GetWallCross( const geo::BoxBoundedGeo &volume,
-        const TVector3 p0,
-        const TVector3 p1);
-
-caf::g4_process_ GetG4ProcessID(const std::string &name);
 
 caf::SRTrackTruth MatchTrack2Truth(const detinfo::DetectorClocksData &clockData, const std::vector<caf::SRTrueParticle> &particles, const std::vector<art::Ptr<recob::Hit>> &hits);
 
@@ -673,7 +668,7 @@ bool FRFillNumuCC(const simb::MCTruth &mctruth,
   return true;
 }
 
-caf::Wall_t GetWallCross(const geo::BoxBoundedGeo &volume, const TVector3 p0, const TVector3 p1) {
+caf::Wall_t caf::GetWallCross(const geo::BoxBoundedGeo &volume, const TVector3 p0, const TVector3 p1) {
   TVector3 direction = (p1 - p0) * ( 1. / (p1 - p0).Mag());
   std::vector<TVector3> intersections = volume.GetIntersections(p0, direction);
 
@@ -715,7 +710,7 @@ caf::Wall_t GetWallCross(const geo::BoxBoundedGeo &volume, const TVector3 p0, co
 
 //------------------------------------------
 
-caf::g4_process_ GetG4ProcessID(const std::string &process_name) {
+caf::g4_process_ caf::GetG4ProcessID(const std::string &process_name) {
 #define MATCH_PROCESS(name) if (process_name == #name) {return caf::kG4 ## name;}
 #define MATCH_PROCESS_NAMED(strname, id) if (process_name == #strname) {return caf::kG4 ## id;}
   MATCH_PROCESS(primary)

--- a/sbncode/CAFMaker/FillTrue.h
+++ b/sbncode/CAFMaker/FillTrue.h
@@ -28,7 +28,12 @@
 
 namespace caf
 {
+  // Helpers
+  caf::Wall_t GetWallCross( const geo::BoxBoundedGeo &volume,
+        const TVector3 p0,
+        const TVector3 p1);
 
+  caf::g4_process_ GetG4ProcessID(const std::string &name);
 
   void FillSliceTruth(const std::vector<art::Ptr<recob::Hit>> &hits,
                       const std::vector<art::Ptr<simb::MCTruth>> &neutrinos,

--- a/sbncode/Calibration/CMakeLists.txt
+++ b/sbncode/Calibration/CMakeLists.txt
@@ -29,6 +29,7 @@ simple_plugin( TrackCaloSkimmer module
 	lardata_DetectorInfoServices_DetectorPropertiesServiceStandard_service
 	lardataalg_DetectorInfo
 	Minuit
+	sbncode_CAFMaker
 )
 
 simple_plugin(TrackCaloSkimmerSelectStoppingTrack tool

--- a/sbncode/Calibration/TrackCaloSkimmer.h
+++ b/sbncode/Calibration/TrackCaloSkimmer.h
@@ -123,6 +123,11 @@ private:
     const std::map<geo::WireID, art::Ptr<raw::RawDigit>> &rawdigits,
     const std::vector<GlobalTrackInfo> &tracks);
 
+  void FillTrackDaughterRays(const recob::Track &trk,
+    const recob::PFParticle &pfp, 
+    const std::vector<art::Ptr<recob::PFParticle>> &PFParticleList, 
+    const art::FindManyP<recob::SpacePoint> &PFParticleSPs);
+
   void FillTrackEndHits(const geo::GeometryCore *geometry,
     const detinfo::DetectorPropertiesData &dprop,
     const recob::Track &track,

--- a/sbncode/Calibration/TrackCaloSkimmer.h
+++ b/sbncode/Calibration/TrackCaloSkimmer.h
@@ -57,6 +57,10 @@
 #include "larcore/Geometry/Geometry.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 
+#include "nusimdata/SimulationBase/MCParticle.h"
+#include "larsim/MCCheater/BackTrackerService.h"
+#include "larsim/MCCheater/ParticleInventoryService.h"
+
 #include "sbnobj/Common/Calibration/TrackCaloSkimmerObj.h"
 #include "ITCSSelectionTool.h"
 
@@ -119,7 +123,21 @@ private:
     const std::map<geo::WireID, art::Ptr<raw::RawDigit>> &rawdigits,
     const std::vector<GlobalTrackInfo> &tracks);
 
-  HitInfo MakeHit(const recob::Hit &hit,
+  void FillTrackEndHits(const geo::GeometryCore *geometry,
+    const detinfo::DetectorPropertiesData &dprop,
+    const recob::Track &track,
+    const std::vector<art::Ptr<recob::Hit>> &allHits,
+    const art::FindManyP<recob::SpacePoint> &allHitSPs);
+
+  void FillTrackTruth(const detinfo::DetectorClocksData &clock_data,
+    const std::vector<art::Ptr<recob::Hit>> &trkHits,
+    const std::vector<art::Ptr<simb::MCParticle>> &mcparticles,
+    const std::vector<geo::BoxBoundedGeo> &active_volumes,
+    const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
+    const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> id_to_ide_map,
+    const std::map<int, std::vector<art::Ptr<recob::Hit>>> id_to_truehit_map);
+
+  TrackHitInfo MakeHit(const recob::Hit &hit,
     unsigned hkey,
     const recob::TrackHitMeta &thm,
     const recob::Track &trk,
@@ -134,7 +152,10 @@ private:
   art::InputTag fT0Producer;
   art::InputTag fCALOproducer;
   art::InputTag fTRKproducer;
+  art::InputTag fHITproducer;
   std::vector<art::InputTag> fRawDigitproducers;
+  std::string fG4producer;
+  std::string fSimChannelproducer;
   bool fRequireT0;
   bool fDoTailFit;
   bool fVerbose;
@@ -142,6 +163,9 @@ private:
   double fHitRawDigitsTickCollectWidth;
   double fTailFitResidualRange;
   int fHitRawDigitsWireCollectWidth;
+  bool fFillTrackEndHits;
+  float fTrackEndHitWireBox;
+  float fTrackEndHitTimeBox;
 
   // tools
   std::vector<std::unique_ptr<sbn::ITCSSelectionTool>> fSelectionTools;

--- a/sbncode/Calibration/TrackCaloSkimmerSelectStoppingTrack_tool.cc
+++ b/sbncode/Calibration/TrackCaloSkimmerSelectStoppingTrack_tool.cc
@@ -120,11 +120,11 @@ TrackCaloSkimmerSelectStoppingTrack::TrackCaloSkimmerSelectStoppingTrack(const f
 }
 
 bool TrackCaloSkimmerSelectStoppingTrack::Select(const TrackInfo &t) {
-  bool downwards = (t.dir_y < 0.) || !fRequireDownwards;
+  bool downwards = (t.dir.y < 0.) || !fRequireDownwards;
 
   bool end_is_fid = false;
   for (const geo::BoxBoundedGeo &g: fFiducialVolumes) {
-    geo::Point_t end {t.end_x, t.end_y, t.end_z};
+    geo::Point_t end {t.end.x, t.end.y, t.end.z};
 
     if (g.ContainsPosition(end)) {
       end_is_fid = true;
@@ -141,7 +141,7 @@ bool TrackCaloSkimmerSelectStoppingTrack::Select(const TrackInfo &t) {
 
   // compute the median dqdx of the last 5 cm
   std::vector<double> endp_dqdx;
-  for (const sbn::HitInfo &h: t.hits2) {
+  for (const sbn::TrackHitInfo &h: t.hits2) {
     if (h.oncalo && h.rr < 5.) endp_dqdx.push_back(h.dqdx);
   }
   double med_dqdx = -1;

--- a/sbncode/Calibration/TrackCaloSkimmer_module.cc
+++ b/sbncode/Calibration/TrackCaloSkimmer_module.cc
@@ -558,7 +558,7 @@ void sbn::TrackCaloSkimmer::FillTrackEndHits(const geo::GeometryCore *geometry,
   float closest_wire_dist = -1.;
   // Get the hit closest to the end to get the end time 
   for (const TrackHitInfo &h: fTrack->hits2) {
-    if (closest_wire_dist < 0. || abs(h.h.wire - end_w) < closest_wire_dist) {
+    if (h.oncalo && (closest_wire_dist < 0. || abs(h.h.wire - end_w) < closest_wire_dist)) {
       closest_wire_dist = abs(h.h.wire - end_w);
       end_t = h.h.time;
     }

--- a/sbncode/Calibration/TrackCaloSkimmer_module.cc
+++ b/sbncode/Calibration/TrackCaloSkimmer_module.cc
@@ -80,8 +80,8 @@ sbn::TrackCaloSkimmer::TrackCaloSkimmer(fhicl::ParameterSet const& p)
     std::cout << "sbn::TrackCaloSkimmer: Bad tail fit residual range config :(" << fTailFitResidualRange << "). Fits will not be meaningful.\n";
   }
   fFillTrackEndHits = p.get<bool>("FillTrackEndHits", true);
-  fTrackEndHitWireBox = p.get<float>("TrackEndHitWireBox", 30); // 10 cm
-  fTrackEndHitTimeBox = p.get<float>("TrackEndHitTimeBox", 150); // about 10cm
+  fTrackEndHitWireBox = p.get<float>("TrackEndHitWireBox", 60); // 20 cm
+  fTrackEndHitTimeBox = p.get<float>("TrackEndHitTimeBox", 300); // about 20cm
 
   fRawDigitproducers = p.get<std::vector<art::InputTag>>("RawDigitproducers", {});
 

--- a/sbncode/Calibration/TrackCaloSkimmer_module.cc
+++ b/sbncode/Calibration/TrackCaloSkimmer_module.cc
@@ -14,6 +14,10 @@
 
 #include "art/Utilities/make_tool.h"
 
+// Useful functions
+#include "sbncode/CAFMaker/FillTrue.h"
+#include "sbncode/CAFMaker/RecoUtils/RecoUtils.h"
+
 // Global functions / data for fitting
 const size_t MAX_N_FIT_DATA = 30;
 
@@ -62,6 +66,9 @@ sbn::TrackCaloSkimmer::TrackCaloSkimmer(fhicl::ParameterSet const& p)
   fT0Producer   = p.get< art::InputTag > ("T0producer", "pandoraGausCryo0");
   fCALOproducer = p.get< art::InputTag > ("CALOproducer");
   fTRKproducer  = p.get< art::InputTag > ("TRKproducer" );
+  fHITproducer  = p.get< art::InputTag > ("HITproducer" );
+  fG4producer  = p.get< std::string > ("G4producer" );
+  fSimChannelproducer  = p.get< std::string > ("SimChannelproducer" );
   fRequireT0 = p.get<bool>("RequireT0", false);
   fDoTailFit = p.get<bool>("DoTailFit", true);
   fVerbose = p.get<bool>("Verbose", false);
@@ -72,6 +79,9 @@ sbn::TrackCaloSkimmer::TrackCaloSkimmer(fhicl::ParameterSet const& p)
   if (fTailFitResidualRange > 10.) {
     std::cout << "sbn::TrackCaloSkimmer: Bad tail fit residual range config :(" << fTailFitResidualRange << "). Fits will not be meaningful.\n";
   }
+  fFillTrackEndHits = p.get<bool>("FillTrackEndHits", true);
+  fTrackEndHitWireBox = p.get<float>("TrackEndHitWireBox", 30); // 10 cm
+  fTrackEndHitTimeBox = p.get<float>("TrackEndHitTimeBox", 150); // about 10cm
 
   fRawDigitproducers = p.get<std::vector<art::InputTag>>("RawDigitproducers", {});
 
@@ -111,7 +121,57 @@ void sbn::TrackCaloSkimmer::analyze(art::Event const& e)
   fMeta.evt = evt;
   fMeta.subrun = sub;
   fMeta.run = run;
+  fMeta.time = e.time().value();
 
+  // Services
+  const geo::GeometryCore *geometry = lar::providerFrom<geo::Geometry>();
+  auto const clock_data = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(e);
+  auto const dprop =
+    art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(e, clock_data);
+
+  // Setup the volumes
+  std::vector<std::vector<geo::BoxBoundedGeo>> TPCVols;
+  std::vector<geo::BoxBoundedGeo> AVs;
+
+  // First the TPC
+  for (auto const &cryo: geometry->IterateCryostats()) {
+    geo::GeometryCore::TPC_iterator iTPC = geometry->begin_TPC(cryo.ID()),
+                                    tend = geometry->end_TPC(cryo.ID());
+    std::vector<geo::BoxBoundedGeo> this_tpc_volumes;
+    while (iTPC != tend) {
+      geo::TPCGeo const& TPC = *iTPC;
+      this_tpc_volumes.push_back(TPC.ActiveBoundingBox());
+      iTPC++;
+    }
+     TPCVols.push_back(std::move(this_tpc_volumes));
+  }
+
+  for (const std::vector<geo::BoxBoundedGeo> &tpcs: TPCVols) {
+    double XMin = std::min_element(tpcs.begin(), tpcs.end(), [](auto &lhs, auto &rhs) { return lhs.MinX() < rhs.MinX(); })->MinX();
+    double YMin = std::min_element(tpcs.begin(), tpcs.end(), [](auto &lhs, auto &rhs) { return lhs.MinY() < rhs.MinY(); })->MinY();
+    double ZMin = std::min_element(tpcs.begin(), tpcs.end(), [](auto &lhs, auto &rhs) { return lhs.MinZ() < rhs.MinZ(); })->MinZ();
+
+    double XMax = std::max_element(tpcs.begin(), tpcs.end(), [](auto &lhs, auto &rhs) { return lhs.MaxX() < rhs.MaxX(); })->MaxX();
+    double YMax = std::max_element(tpcs.begin(), tpcs.end(), [](auto &lhs, auto &rhs) { return lhs.MaxY() < rhs.MaxY(); })->MaxY();
+    double ZMax = std::max_element(tpcs.begin(), tpcs.end(), [](auto &lhs, auto &rhs) { return lhs.MaxZ() < rhs.MaxZ(); })->MaxZ();
+
+    AVs.emplace_back(XMin, XMax, YMin, YMax, ZMin, ZMax);
+  }
+
+  // Truth information
+  std::vector<art::Ptr<simb::MCParticle>> mcparticles;
+  if (fG4producer.size()) {
+    art::ValidHandle<std::vector<simb::MCParticle>> mcparticle_handle = e.getValidHandle<std::vector<simb::MCParticle>>(fG4producer);
+    art::fill_ptr_vector(mcparticles, mcparticle_handle);
+  }
+
+  std::vector<art::Ptr<sim::SimChannel>> simchannels;
+  if (fSimChannelproducer.size()) {
+    art::ValidHandle<std::vector<sim::SimChannel>> simchannel_handle = e.getValidHandle<std::vector<sim::SimChannel>>(fSimChannelproducer);
+    art::fill_ptr_vector(simchannels, simchannel_handle);
+  }
+
+  // Reconstructed Information
   std::vector<art::Ptr<recob::PFParticle>> PFParticleList;
   try {
     art::ValidHandle<std::vector<recob::PFParticle>> pfparticles = e.getValidHandle<std::vector<recob::PFParticle>>(fPFPproducer);
@@ -141,8 +201,6 @@ void sbn::TrackCaloSkimmer::analyze(art::Event const& e)
     art::fill_ptr_vector(rawdigitlist, thisdigits);
   }
 
-  const geo::GeometryCore *geometry = lar::providerFrom<geo::Geometry>();
-
   // The raw digit list is not sorted, so make it into a map on the WireID
   std::map<geo::WireID, art::Ptr<raw::RawDigit>> rawdigits;
   for (const art::Ptr<raw::RawDigit> &d: rawdigitlist) {
@@ -164,6 +222,25 @@ void sbn::TrackCaloSkimmer::analyze(art::Event const& e)
 
     rawdigits[wids[0]] = d;
   } 
+
+  // Collect all hits
+  art::ValidHandle<std::vector<recob::Hit>> allhit_handle = e.getValidHandle<std::vector<recob::Hit>>(fHITproducer);
+  std::vector<art::Ptr<recob::Hit>> allHits;
+  art::fill_ptr_vector(allHits, allhit_handle);
+
+  // And lookup the SP's
+  art::FindManyP<recob::SpacePoint> allHitSPs(allHits, e, fPFPproducer);
+
+  // Prep truth-to-reco-matching info
+  //
+  // Use helper functions from CAFMaker/FillTrue
+  std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> id_to_ide_map;
+  std::map<int, std::vector<art::Ptr<recob::Hit>>> id_to_truehit_map;
+  if (simchannels.size()) {
+    art::ServiceHandle<cheat::BackTrackerService> bt_serv;
+    id_to_ide_map = caf::PrepSimChannels(simchannels, *geometry);
+    id_to_truehit_map = caf::PrepTrueHits(allHits, clock_data, *bt_serv.get());
+  }
 
   // service data
 
@@ -202,7 +279,42 @@ void sbn::TrackCaloSkimmer::analyze(art::Event const& e)
 
     if (fVerbose) std::cout << "Processing new track! ID: " << trkPtr->ID() << " time: " << t0 << std::endl;
 
+    // Reset the track object
+    *fTrack = sbn::TrackInfo();
+
+    // Reset other persistent info
+    fSnippetCount.clear();
+    fWiresToSave.clear();
+
+    // Fill the track!
     FillTrack(*trkPtr, pfp, t0, trkHits, trkHitMetas, calo, rawdigits, track_infos);
+
+    if (fFillTrackEndHits) FillTrackEndHits(geometry, dprop, *trkPtr, allHits, allHitSPs);
+
+    // Fill the truth information if configured
+    if (simchannels.size()) FillTrackTruth(clock_data, trkHits, mcparticles, AVs, TPCVols, id_to_ide_map, id_to_truehit_map); 
+
+    // Save?
+    bool select = false;
+    if (!fSelectionTools.size()) select = true;
+
+    // Take the OR of each selection tool
+    int i_select = 0;
+    for (const std::unique_ptr<sbn::ITCSSelectionTool> &t: fSelectionTools) {
+      if (t->DoSelect(*fTrack)) {
+        select = true;
+        fTrack->selected = i_select;
+        fTrack->nprescale = t->GetPrescale();
+        break;
+      }
+      i_select ++;
+    }
+  
+    // Save!
+    if (select) {
+      if (fVerbose) std::cout << "Track Selected!\n";
+      fTree->Fill();
+    }
   }
 }
 
@@ -210,15 +322,15 @@ void sbn::TrackCaloSkimmer::analyze(art::Event const& e)
 
 // Returns the minimum hit time for hits in either TPC E (TPCE==true)
 // or TPC W (TPCE==false)
-float HitMinTime(const std::vector<sbn::HitInfo> &hits, bool TPCE) {
+float HitMinTime(const std::vector<sbn::TrackHitInfo> &hits, bool TPCE) {
   double min = -1;
 
-  for (const sbn::HitInfo &h: hits) {
+  for (const sbn::TrackHitInfo &h: hits) {
     // TODO: what about SBND?
     // In ICARUS, TPC E is 0, 1 and TPC W is 2, 3
-    bool hit_is_TPCE = h.tpc <= 1;
+    bool hit_is_TPCE = h.h.tpc <= 1;
     if (h.oncalo && hit_is_TPCE == TPCE) {
-      if (min < 0. || h.time < min) min = h.time;
+      if (min < 0. || h.h.time < min) min = h.h.time;
     } 
   }
 
@@ -227,19 +339,321 @@ float HitMinTime(const std::vector<sbn::HitInfo> &hits, bool TPCE) {
 
 // Returns the maximum hit time for hits in either TPC E (TPCE==true)
 // or TPC W (TPCE==false)
-float HitMaxTime(const std::vector<sbn::HitInfo> &hits, bool TPCE) {
+float HitMaxTime(const std::vector<sbn::TrackHitInfo> &hits, bool TPCE) {
   double max = -1;
 
-  for (const sbn::HitInfo &h: hits) {
+  for (const sbn::TrackHitInfo &h: hits) {
     // TODO: what about SBND?
     // In ICARUS, TPC E is 0, 1 and TPC W is 2, 3
-    bool hit_is_TPCE = h.tpc <= 1;
+    bool hit_is_TPCE = h.h.tpc <= 1;
     if (h.oncalo && hit_is_TPCE == TPCE) {
-      if (max < 0. || h.time > max) max = h.time;
+      if (max < 0. || h.h.time > max) max = h.h.time;
     } 
   }
 
   return max;
+}
+
+sbn::Vector3D ConvertTVector(const TVector3 &tv) {
+  sbn::Vector3D v;
+  v.x = tv.X();
+  v.y = tv.Y();
+  v.z = tv.Z();
+
+  return v;
+}
+
+// Collect MCParticle information
+sbn::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
+    const std::vector<geo::BoxBoundedGeo> &active_volumes,
+    const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
+    const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE *>>> &id_to_ide_map,
+    const std::map<int, std::vector<art::Ptr<recob::Hit>>> &id_to_truehit_map) {
+
+  std::vector<std::pair<geo::WireID, const sim::IDE *>> empty;
+  const std::vector<std::pair<geo::WireID, const sim::IDE *>> &particle_ides = id_to_ide_map.count(particle.TrackId()) ? id_to_ide_map.at(particle.TrackId()) : empty;
+  
+  std::vector<art::Ptr<recob::Hit>> emptyHits;
+  const std::vector<art::Ptr<recob::Hit>> &particle_hits = id_to_truehit_map.count(particle.TrackId()) ? id_to_truehit_map.at(particle.TrackId()) : emptyHits;
+
+  sbn::TrueParticle trueparticle;
+
+  trueparticle.length = 0.;
+  trueparticle.crosses_tpc = false;
+  trueparticle.wallin = (int)caf::kWallNone;
+  trueparticle.wallout = (int)caf::kWallNone;
+  trueparticle.plane0VisE = 0.;
+  trueparticle.plane1VisE = 0.;
+  trueparticle.plane2VisE = 0.;
+  trueparticle.plane0nhit = 0;
+  trueparticle.plane1nhit = 0;
+  trueparticle.plane2nhit = 0;
+  for (auto const &ide_pair: particle_ides) {
+    const geo::WireID &w = ide_pair.first;
+    const sim::IDE *ide = ide_pair.second;
+    
+    if (w.Plane == 0) {
+      trueparticle.plane0VisE += ide->energy / 1000. /* MeV -> GeV*/;
+    }
+    else if (w.Plane == 1) {
+      trueparticle.plane1VisE += ide->energy / 1000. /* MeV -> GeV*/;
+    }
+    else if (w.Plane == 2) {
+      trueparticle.plane2VisE += ide->energy / 1000. /* MeV -> GeV*/;
+    }
+  }
+
+  for (const art::Ptr<recob::Hit> h: particle_hits) {
+    const geo::WireID &w = h->WireID();
+
+    if (w.Plane == 0) {
+      trueparticle.plane0nhit ++;
+    }
+    else if (w.Plane == 1) {
+      trueparticle.plane1nhit ++;
+    }
+    else if (w.Plane == 2) {
+      trueparticle.plane2nhit ++;
+    }
+
+  }
+
+  // if no trajectory points, then assume outside AV
+  trueparticle.cont_tpc = particle.NumberTrajectoryPoints() > 0;
+  trueparticle.contained = particle.NumberTrajectoryPoints() > 0;
+
+  // Get the entry and exit points
+  int entry_point = -1;
+  
+  int cryostat_index = -1;
+  int tpc_index = -1;
+
+  for (unsigned j = 0; j < particle.NumberTrajectoryPoints(); j++) {
+    for (unsigned i = 0; i < active_volumes.size(); i++) {
+      if (active_volumes.at(i).ContainsPosition(particle.Position(j).Vect())) {
+        entry_point = j;
+        cryostat_index = i;
+        break;
+      }
+    }
+    if (entry_point != -1) break;
+  }
+
+  // get the wall
+  if (entry_point > 0) {
+    trueparticle.wallin = (int)caf::GetWallCross(active_volumes.at(cryostat_index), particle.Position(entry_point).Vect(), particle.Position(entry_point-1).Vect());
+  }
+
+  int exit_point = -1;
+
+  // now setup the cryostat the particle is in
+  std::vector<geo::BoxBoundedGeo> volumes;
+  if (entry_point >= 0) {
+    volumes = tpc_volumes.at(cryostat_index);
+    for (unsigned i = 0; i < volumes.size(); i++) {
+      if (volumes[i].ContainsPosition(particle.Position(entry_point).Vect())) {
+        tpc_index = i;
+        trueparticle.cont_tpc = entry_point == 0;
+        break;
+      }
+    }
+    trueparticle.contained = entry_point == 0;
+  }
+  // if we couldn't find the initial point, set not contained
+  else {
+    trueparticle.contained = false;
+  }
+
+  if (tpc_index < 0) {
+    trueparticle.cont_tpc = false;
+  }
+
+  // Get the length and determine if any point leaves the active volume
+  // Use every trajectory point if possible
+  if (entry_point >= 0) {
+    // particle trajectory
+    const simb::MCTrajectory &trajectory = particle.Trajectory();
+    TVector3 pos = trajectory.Position(entry_point).Vect();
+    for (unsigned i = entry_point+1; i < particle.NumberTrajectoryPoints(); i++) {
+      TVector3 this_point = trajectory.Position(i).Vect();
+      // get the exit point
+      // update if particle is contained
+      // check if particle has crossed TPC
+      if (!trueparticle.crosses_tpc) {
+        for (unsigned j = 0; j < volumes.size(); j++) {
+          if (volumes[j].ContainsPosition(this_point) && tpc_index >= 0 && j != ((unsigned)tpc_index)) {
+            trueparticle.crosses_tpc = true;
+            break;
+          }
+        }
+      }
+      // check if particle has left tpc
+      if (trueparticle.cont_tpc) {
+        trueparticle.cont_tpc = volumes[tpc_index].ContainsPosition(this_point);
+      }
+
+      if (trueparticle.contained) {
+        trueparticle.contained = active_volumes.at(cryostat_index).ContainsPosition(this_point);
+      }
+
+     trueparticle.length += (this_point - pos).Mag();
+
+      if (!active_volumes.at(cryostat_index).ContainsPosition(this_point) && active_volumes.at(cryostat_index).ContainsPosition(pos)) {
+        exit_point = i-1;
+      }
+
+      pos = trajectory.Position(i).Vect();
+    }
+  }
+  if (exit_point < 0 && entry_point >= 0) {
+    exit_point = particle.NumberTrajectoryPoints() - 1;
+  }
+  if (exit_point >= 0 && ((unsigned)exit_point) < particle.NumberTrajectoryPoints() - 1) {
+    trueparticle.wallout = (int)caf::GetWallCross(active_volumes.at(cryostat_index), particle.Position(exit_point).Vect(), particle.Position(exit_point+1).Vect());
+  }
+
+  // other truth information
+  trueparticle.pdg = particle.PdgCode();
+  
+  trueparticle.gen = ConvertTVector(particle.NumberTrajectoryPoints() ? particle.Position().Vect() : TVector3(-9999, -9999, -9999));
+  trueparticle.genT = particle.NumberTrajectoryPoints() ? particle.Position().T() / 1000. /* ns -> us*/: -9999;
+  trueparticle.genp = ConvertTVector(particle.NumberTrajectoryPoints() ? particle.Momentum().Vect(): TVector3(-9999, -9999, -9999));
+  trueparticle.genE = particle.NumberTrajectoryPoints() ? particle.Momentum().E(): -9999;
+  
+  trueparticle.start = ConvertTVector((entry_point >= 0) ? particle.Position(entry_point).Vect(): TVector3(-9999, -9999, -9999));
+  trueparticle.startT = (entry_point >= 0) ? particle.Position(entry_point).T() / 1000. /* ns-> us*/: -9999;
+  trueparticle.end = ConvertTVector((exit_point >= 0) ? particle.Position(exit_point).Vect(): TVector3(-9999, -9999, -9999));
+  trueparticle.endT = (exit_point >= 0) ? particle.Position(exit_point).T() / 1000. /* ns -> us */ : -9999;
+  
+  trueparticle.startp = ConvertTVector((entry_point >= 0) ? particle.Momentum(entry_point).Vect() : TVector3(-9999, -9999, -9999));
+  trueparticle.startE = (entry_point >= 0) ? particle.Momentum(entry_point).E() : -9999.;
+  trueparticle.endp = ConvertTVector((exit_point >= 0) ? particle.Momentum(exit_point).Vect() : TVector3(-9999, -9999, -9999));
+  trueparticle.endE = (exit_point >= 0) ? particle.Momentum(exit_point).E() : -9999.;
+  
+  trueparticle.start_process = (int)caf::GetG4ProcessID(particle.Process());
+  trueparticle.end_process = (int)caf::GetG4ProcessID(particle.EndProcess());
+  
+  trueparticle.G4ID = particle.TrackId();
+  trueparticle.parent = particle.Mother();
+
+  return trueparticle;
+}
+
+void sbn::TrackCaloSkimmer::FillTrackEndHits(const geo::GeometryCore *geometry,
+    const detinfo::DetectorPropertiesData &dprop,
+    const recob::Track &track,
+    const std::vector<art::Ptr<recob::Hit>> &allHits,
+    const art::FindManyP<recob::SpacePoint> &allHitSPs) {
+
+  (void) dprop; // TODO: use??
+
+  geo::TPCID tpc_end = geometry->FindTPCAtPosition(track.End());
+  if (!tpc_end) return;
+
+  geo::PlaneID plane_end(tpc_end, 2 /* collection */);
+
+  float end_w = geometry->WireCoordinate(track.End(), plane_end);
+
+  float end_t = -1000.;
+  float closest_wire_dist = -1.;
+  // Get the hit closest to the end to get the end time 
+  for (const TrackHitInfo &h: fTrack->hits2) {
+    if (closest_wire_dist < 0. || abs(h.h.wire - end_w) < closest_wire_dist) {
+      closest_wire_dist = abs(h.h.wire - end_w);
+      end_t = h.h.time;
+    }
+  }
+
+  for (const art::Ptr<recob::Hit> &hit: allHits) {
+    geo::PlaneID h_p = hit->WireID();
+    if (h_p != plane_end) continue;
+
+    // Inside the box?
+    float h_w = (float)hit->WireID().Wire;
+    float h_t = hit->PeakTime();
+
+    if (abs(h_w - end_w) < fTrackEndHitWireBox &&
+        abs(h_t - end_t) < fTrackEndHitTimeBox) {
+
+      // HitInfo to save
+      sbn::HitInfo hinfo;
+      
+      // information from the hit object
+      hinfo.integral = hit->Integral();
+      hinfo.sumadc = hit->SummedADC();
+      hinfo.width = hit->RMS();
+      hinfo.time = hit->PeakTime();
+      hinfo.mult = hit->Multiplicity();
+      hinfo.wire = hit->WireID().Wire;
+      hinfo.plane = hit->WireID().Plane;
+      hinfo.tpc = hit->WireID().TPC;
+      hinfo.end = hit->EndTick();
+      hinfo.start = hit->StartTick();
+      hinfo.id = hit.key();
+
+      const std::vector<art::Ptr<recob::SpacePoint>> &h_sp = allHitSPs.at(hit.key());
+      if (h_sp.size()) {
+        const recob::SpacePoint &sp = *h_sp[0];
+        hinfo.p.x = sp.position().x();
+        hinfo.p.y = sp.position().y();
+        hinfo.p.z = sp.position().z();
+      }
+
+      fTrack->endhits.push_back(hinfo);
+      
+    } 
+  }
+
+}
+
+void sbn::TrackCaloSkimmer::FillTrackTruth(const detinfo::DetectorClocksData &clock_data,
+    const std::vector<art::Ptr<recob::Hit>> &trkHits,
+    const std::vector<art::Ptr<simb::MCParticle>> &mcparticles,
+    const std::vector<geo::BoxBoundedGeo> &active_volumes,
+    const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
+    const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> id_to_ide_map,
+    const std::map<int, std::vector<art::Ptr<recob::Hit>>> id_to_truehit_map) {
+
+  // Lookup the true-particle match -- use utils in CAF
+  std::vector<std::pair<int, float>> matches = CAFRecoUtils::AllTrueParticleIDEnergyMatches(clock_data, trkHits, true);
+  float total_energy = CAFRecoUtils::TotalHitEnergy(clock_data, trkHits);
+
+  fTrack->truth.depE = total_energy / 1000. /* MeV -> GeV */;
+  
+  // sort highest energy match to lowest
+  std::sort(matches.begin(), matches.end(),
+      [](const auto &a, const auto &b) {
+        return a.second > b.second;
+      }
+  );
+
+  // Save the best match
+  if (matches.size()) {
+    std::pair<int, float> bestmatch = matches[0];
+
+    fTrack->truth.pur = bestmatch.second / total_energy;
+
+    for (const art::Ptr<simb::MCParticle> &p_mcp: mcparticles) {
+      if (p_mcp->TrackId() == bestmatch.first) {
+        if (fVerbose) std::cout << "Matched! Track ID: " << p_mcp->TrackId() << " pdg: " << p_mcp->PdgCode() << " process: " << p_mcp->EndProcess() << std::endl;
+        fTrack->truth.p = TrueParticleInfo(*p_mcp, active_volumes, tpc_volumes, id_to_ide_map, id_to_truehit_map);
+        fTrack->truth.eff = fTrack->truth.depE / (fTrack->truth.p.plane0VisE + fTrack->truth.p.plane1VisE + fTrack->truth.p.plane2VisE);
+
+        // Lookup any Michel
+        for (const art::Ptr<simb::MCParticle> &d_mcp: mcparticles) {
+          if (d_mcp->Mother() == p_mcp->TrackId() && // correct parent
+              (d_mcp->Process() == "Decay" || d_mcp->Process() == "muMinusCaptureAtRest") && // correct process
+              abs(d_mcp->PdgCode()) == 11) { // correct PDG code
+
+            fTrack->truth.michel = TrueParticleInfo(*d_mcp, active_volumes, tpc_volumes, id_to_ide_map, id_to_truehit_map);
+            break;
+          }
+        }
+
+        break;
+      } 
+    }
+  }
 }
 
 void sbn::TrackCaloSkimmer::FillTrack(const recob::Track &track, 
@@ -250,13 +664,6 @@ void sbn::TrackCaloSkimmer::FillTrack(const recob::Track &track,
     const std::map<geo::WireID, art::Ptr<raw::RawDigit>> &rawdigits,
     const std::vector<GlobalTrackInfo> &tracks) {
 
-  // Reset the track object
-  *fTrack = sbn::TrackInfo();
-
-  // Reset other persistent info
-  fSnippetCount.clear();
-  fWiresToSave.clear();
-
   // Fill top level stuff
   fTrack->meta = fMeta;
   fTrack->t0 = t0;
@@ -265,15 +672,15 @@ void sbn::TrackCaloSkimmer::FillTrack(const recob::Track &track,
   fTrack->ndaughters = pfp.Daughters().size();
 
   fTrack->length = track.Length();
-  fTrack->start_x = track.Start().X();
-  fTrack->start_y = track.Start().Y();
-  fTrack->start_z = track.Start().Z();
-  fTrack->end_x = track.End().X();
-  fTrack->end_y = track.End().Y();
-  fTrack->end_z = track.End().Z();
-  fTrack->dir_x = track.StartDirection().X();
-  fTrack->dir_y = track.StartDirection().Y();
-  fTrack->dir_z = track.StartDirection().Z();
+  fTrack->start.x = track.Start().X();
+  fTrack->start.y = track.Start().Y();
+  fTrack->start.z = track.Start().Z();
+  fTrack->end.x = track.End().X();
+  fTrack->end.y = track.End().Y();
+  fTrack->end.z = track.End().Z();
+  fTrack->dir.x = track.StartDirection().X();
+  fTrack->dir.y = track.StartDirection().Y();
+  fTrack->dir.z = track.StartDirection().Z();
 
   if (hits.size() > 0) {
     fTrack->cryostat = hits[0]->WireID().Cryostat;
@@ -281,14 +688,14 @@ void sbn::TrackCaloSkimmer::FillTrack(const recob::Track &track,
 
   // Fill each hit
   for (unsigned i_hit = 0; i_hit < hits.size(); i_hit++) {
-    sbn::HitInfo hinfo = MakeHit(*hits[i_hit], hits[i_hit].key(), *thms[i_hit], track, calo);
-    if (hinfo.plane == 0) {
+    sbn::TrackHitInfo hinfo = MakeHit(*hits[i_hit], hits[i_hit].key(), *thms[i_hit], track, calo);
+    if (hinfo.h.plane == 0) {
       fTrack->hits0.push_back(hinfo);
     }
-    else if (hinfo.plane == 1) {
+    else if (hinfo.h.plane == 1) {
       fTrack->hits1.push_back(hinfo);
     } 
-    else if (hinfo.plane == 2) {
+    else if (hinfo.h.plane == 2) {
       fTrack->hits2.push_back(hinfo);
     }
   }
@@ -348,7 +755,6 @@ void sbn::TrackCaloSkimmer::FillTrack(const recob::Track &track,
   std::sort(fTrack->wires1.begin(), fTrack->wires1.end(), [](auto const &lhs, auto const &rhs) {return lhs.wire < rhs.wire;});
   std::sort(fTrack->wires2.begin(), fTrack->wires2.end(), [](auto const &lhs, auto const &rhs) {return lhs.wire < rhs.wire;});
 
-
   // get information on nearby tracks
   for (const GlobalTrackInfo &othr: tracks) {
     if ((track.End() - othr.start).r() < 50. || (track.End() - othr.end).r() < 50.) {
@@ -359,27 +765,6 @@ void sbn::TrackCaloSkimmer::FillTrack(const recob::Track &track,
     }
   }
 
-  // Save?
-  bool select = false;
-  if (!fSelectionTools.size()) select = true;
-
-  // Take the OR of each selection tool
-  int i_select = 0;
-  for (const std::unique_ptr<sbn::ITCSSelectionTool> &t: fSelectionTools) {
-    if (t->DoSelect(*fTrack)) {
-      select = true;
-      fTrack->selected = i_select;
-      fTrack->nprescale = t->GetPrescale();
-      break;
-    }
-    i_select ++;
-  }
-  
-  // Save!
-  if (select) {
-    if (fVerbose) std::cout << "Track Selected!\n";
-    fTree->Fill();
-  }
 }
 
 void sbn::TrackCaloSkimmer::DoTailFit() {
@@ -387,7 +772,7 @@ void sbn::TrackCaloSkimmer::DoTailFit() {
   std::vector<double> fit_rr;
   std::vector<double> fit_dqdx;
 
-  for (const HitInfo &h: fTrack->hits2) {
+  for (const TrackHitInfo &h: fTrack->hits2) {
     if (h.oncalo && h.rr > 0. && h.rr < fTailFitResidualRange) {
       fit_rr.push_back(h.rr);
       fit_dqdx.push_back(h.dqdx);
@@ -445,26 +830,27 @@ void sbn::TrackCaloSkimmer::DoTailFit() {
 }
 
 
-sbn::HitInfo sbn::TrackCaloSkimmer::MakeHit(const recob::Hit &hit,
+sbn::TrackHitInfo sbn::TrackCaloSkimmer::MakeHit(const recob::Hit &hit,
     unsigned hkey,
     const recob::TrackHitMeta &thm,
     const recob::Track &trk,
     const std::vector<art::Ptr<anab::Calorimetry>> &calo) {
 
-  // HitInfo to save
-  sbn::HitInfo hinfo;
+  // TrackHitInfo to save
+  sbn::TrackHitInfo hinfo;
 
   // information from the hit object
-  hinfo.integral = hit.Integral();
-  hinfo.sumadc = hit.SummedADC();
-  hinfo.width = hit.RMS();
-  hinfo.time = hit.PeakTime();
-  hinfo.mult = hit.Multiplicity();
-  hinfo.wire = hit.WireID().Wire;
-  hinfo.plane = hit.WireID().Plane;
-  hinfo.tpc = hit.WireID().TPC;
-  hinfo.end = hit.EndTick();
-  hinfo.start = hit.StartTick();
+  hinfo.h.integral = hit.Integral();
+  hinfo.h.sumadc = hit.SummedADC();
+  hinfo.h.width = hit.RMS();
+  hinfo.h.time = hit.PeakTime();
+  hinfo.h.mult = hit.Multiplicity();
+  hinfo.h.wire = hit.WireID().Wire;
+  hinfo.h.plane = hit.WireID().Plane;
+  hinfo.h.tpc = hit.WireID().TPC;
+  hinfo.h.end = hit.EndTick();
+  hinfo.h.start = hit.StartTick();
+  hinfo.h.id = (int)hkey;
 
   // look up the snippet
   sbn::TrackCaloSkimmer::Snippet snippet {hit.WireID(), hit.StartTick(), hit.EndTick()};
@@ -480,7 +866,7 @@ sbn::HitInfo sbn::TrackCaloSkimmer::MakeHit(const recob::Hit &hit,
   // Which wires to save
   int min_tick = (int)std::floor(hit.PeakTime() - fHitRawDigitsTickCollectWidth);
   int max_tick = (int)std::ceil(hit.PeakTime() + fHitRawDigitsTickCollectWidth);
-  for (int wire = hinfo.wire - fHitRawDigitsWireCollectWidth; wire <= hinfo.wire + fHitRawDigitsWireCollectWidth; wire++) {
+  for (int wire = hinfo.h.wire - fHitRawDigitsWireCollectWidth; wire <= hinfo.h.wire + fHitRawDigitsWireCollectWidth; wire++) {
     geo::WireID w(hit.WireID(), wire);
 
     if (fWiresToSave.count(w)) {
@@ -501,18 +887,18 @@ sbn::HitInfo sbn::TrackCaloSkimmer::MakeHit(const recob::Hit &hit,
   // Save trajectory information if we can
   if (!badhit) {
     geo::Point_t loc = trk.LocationAtPoint(thm.Index());
-    hinfo.x = loc.X();
-    hinfo.y = loc.Y();
-    hinfo.z = loc.Z();
+    hinfo.h.p.x = loc.X();
+    hinfo.h.p.y = loc.Y();
+    hinfo.h.p.z = loc.Z();
 
     geo::Vector_t dir = trk.DirectionAtPoint(thm.Index());
-    hinfo.dir_x = dir.X();
-    hinfo.dir_y = dir.Y();
-    hinfo.dir_z = dir.Z();
+    hinfo.dir.x = dir.X();
+    hinfo.dir.y = dir.Y();
+    hinfo.dir.z = dir.Z();
 
     // And determine if the Hit is on a Calorimetry object
     for (const art::Ptr<anab::Calorimetry> &c: calo) {
-      if (c->PlaneID().Plane != hinfo.plane) continue;
+      if (c->PlaneID().Plane != hinfo.h.plane) continue;
 
       // Found the plane! Now find the hit:
       for (unsigned i_calo = 0; i_calo < c->dQdx().size(); i_calo++) {

--- a/sbncode/Calibration/fcl/icarus_trackcalo_skimmer.fcl
+++ b/sbncode/Calibration/fcl/icarus_trackcalo_skimmer.fcl
@@ -25,6 +25,9 @@ caloskim_cryoe: {
   TRKproducer:  "pandoraTrackGausCryoE"
   T0producer: "pandoraGausCryoE"
   PFPproducer: "pandoraGausCryoE"
+  G4producer: ""
+  SimChannelproducer: ""
+  HITproducer: "cluster3DCryoE"
   RawDigitproducers: ["daqTPC:PHYSCRATEDATATPCEW", "daqTPC:PHYSCRATEDATATPCEE"]
   RequireT0: true
   HitRawDigitsTickCollectWidth: 50
@@ -39,6 +42,9 @@ caloskim_cryow: {
   TRKproducer:  "pandoraTrackGausCryoW"
   T0producer: "pandoraGausCryoW"
   PFPproducer: "pandoraGausCryoW"
+  G4producer: ""
+  SimChannelproducer: ""
+  HITproducer: "cluster3DCryoE"
   RawDigitproducers: ["daqTPC:PHYSCRATEDATATPCWW", "daqTPC:PHYSCRATEDATATPCWE"]
   RequireT0: true
   HitRawDigitsTickCollectWidth: 50


### PR DESCRIPTION
Depends on updates to the sbnobj repository: https://github.com/SBNSoftware/sbnobj/pull/22.

This adds in truth information and end-point-hit saving to the track calorimetry skimmer.

This PR has some urgency -- I would like it to be merged in for this week's release if possible so it can be included in a data processing campaign in ICARUS. 

I would ask @mrmooney to be the reviewer if he is available so that it can be reviewed promptly. 