### PR TITLE
Simple-Flash Match: multi-matcher, unbiased, tuneable, fast.

### DIFF
--- a/sbncode/FlashMatch/CMakeLists.txt
+++ b/sbncode/FlashMatch/CMakeLists.txt
@@ -31,6 +31,8 @@ art_make(
 
   larpandora_LArPandoraInterface
 
+  # caf_RecoUtils //uncomment for creating metrics
+  # nusimdata_SimulationBase //uncomment for creating metrics
   ${MF_MESSAGELOGGER}
   ${FHICLCPP}
   ${ROOT_GEOM}

--- a/sbncode/FlashMatch/CMakeLists.txt
+++ b/sbncode/FlashMatch/CMakeLists.txt
@@ -30,9 +30,9 @@ art_make(
   lardataobj_Simulation
 
   larpandora_LArPandoraInterface
+  larsim_Utils
 
-  # caf_RecoUtils //uncomment for creating metrics
-  # nusimdata_SimulationBase //uncomment for creating metrics
+  nusimdata_SimulationBase
   ${MF_MESSAGELOGGER}
   ${FHICLCPP}
   ${ROOT_GEOM}

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -59,6 +59,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <limits>
 #include <list>
 #include <memory>
 #include <set>
@@ -133,6 +134,12 @@ public:
 
 
 private:
+  // aliases for the objects that are stored
+  using sFM    = sbn::SimpleFlashMatch;
+  using Charge = sbn::SimpleFlashMatch::Charge;
+  using Flash  = sbn::SimpleFlashMatch::Flash;
+  using Score  = sbn::SimpleFlashMatch::Score;
+
   // Declare member data here.
   //  ::flashmatch::FlashMatchManager m_flashMatchManager; ///< The flash match manager
   // art::InputTag fFlashProducer;
@@ -141,7 +148,8 @@ private:
   void loadMetrics(void);
   bool computeChargeMetrics(const flashmatch::QCluster_t& qClusters);
   bool computeFlashMetrics(const SimpleFlash& simpleFlash);
-  bool computeScore(const std::set<unsigned>& tpcWithHits, const int pdgc);
+  Score computeScore(const std::set<unsigned>& tpcWithHits,
+                    const int pdgc) const;
   // double hypoFlashX_splines() const;
   std::tuple<double, double, double, double> hypoFlashX_fits(
     double flash_r, double flash_ratio) const;
@@ -269,12 +277,6 @@ private:
   const double kEps = 1e-4;
 
   // std::vector<double> _pe_reco_v, _pe_hypo_v;
-
-  // aliases for the objects that are stored
-  using sFM    = sbn::SimpleFlashMatch;
-  using Charge = sbn::SimpleFlashMatch::Charge;
-  using Flash  = sbn::SimpleFlashMatch::Flash;
-  using Score  = sbn::SimpleFlashMatch::Score;
 
   // Tree variables
   double _charge_x_gl, _charge_x,

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -52,6 +52,8 @@
 #include "sbncode/OpDet/PDMapAlg.h"
 #include "sbnobj/Common/Reco/SimpleFlashMatchVars.h"
 
+// #include "nusimdata/SimulationBase/MCParticle.h" //uncomment for creating metrics
+// #include "nusimdata/SimulationBase/MCTruth.h" //uncomment for creating metrics
 // turn the warnings back on
 //#pragma GCC diagnostic pop
 
@@ -346,7 +348,7 @@ private:
     _hypo_x, _hypo_x_err, _hypo_x_rr, _hypo_x_ratio,
     _y_skew, _z_skew;
   double _score, _scr_y, _scr_z, _scr_rr, _scr_ratio;
-  unsigned _evt, _run, _sub, _slices;
+  unsigned _evt, _run, _sub, _slices;//, _true_nus; // uncomment for creating metrics
 
   std::vector<double> fdYMeans, fdZMeans, fRRMeans, fRatioMeans;
   std::vector<double> fdYSpreads, fdZSpreads, fRRSpreads, fRatioSpreads;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -326,12 +326,12 @@ private:
   const unsigned fOpDetNormalizer;
   const double fTermThreshold;
 
-  const unsigned kRght = 0;
-  const unsigned kLeft = 1;
+  static constexpr unsigned kRght = 0;
+  static constexpr unsigned kLeft = 1;
 
-  const unsigned kActivityInRght = 100;
-  const unsigned kActivityInLeft = 200;
-  const unsigned kActivityInBoth = 300;
+  static constexpr unsigned kActivityInRght = 100;
+  static constexpr unsigned kActivityInLeft = 200;
+  static constexpr unsigned kActivityInBoth = 300;
 
   // root stuff
   TTree* _flashmatch_nuslice_tree;
@@ -340,11 +340,11 @@ private:
     std::unique_ptr<TF1> f;
   };
   TH2D* fRRH2; TH2D* fRatioH2;
-  const unsigned kMinEntriesInProjection = 100;
+  static constexpr unsigned kMinEntriesInProjection = 100;
   std::array<Fits, 3> fRRFits;
   std::array<Fits, 3> fRatioFits;
   const std::array<std::string, 3> kSuffixes{"l", "h", "m"};// low, high, medium
-  const double kEps = 1e-4;
+  static constexpr double kEps = 1e-4;
 
   // Tree variables
   double _charge_x_gl, _charge_x,
@@ -361,19 +361,19 @@ private:
   std::vector<double> fdYMeans, fdZMeans, fRRMeans, fRatioMeans;
   std::vector<double> fdYSpreads, fdZSpreads, fRRSpreads, fRatioSpreads;
 
-  const bool kNoScr = false;
-  const double kNoScrTime = -9999.;
-  const double kNoScrQ  = -9999.;
-  const double kNoScrPE = -9999.;
-  const int kQNoOpHScr = -1;
-  const int kNoChrgScr = -2;
-  const int k0VUVPEScr = -3;
-  const int kNoOpHInEvt = -11;
-  const int kNoPFPInEvt = -12;
-  // const int kNoSlcInEvt = -13;
+  static constexpr bool kNoScr = false;
+  static constexpr double kNoScrTime = -9999.;
+  static constexpr double kNoScrQ  = -9999.;
+  static constexpr double kNoScrPE = -9999.;
+  static constexpr int kQNoOpHScr = -1;
+  static constexpr int kNoChrgScr = -2;
+  static constexpr int k0VUVPEScr = -3;
+  static constexpr int kNoOpHInEvt = -11;
+  static constexpr int kNoPFPInEvt = -12;
+  static constexpr int kNoSlcInEvt = -13;
   struct BookKeeping {
     int job_bookkeeping, events_processed;
-    unsigned events, nopfpneutrino,// noslice,
+    unsigned events, nopfpneutrino, noslice,
       nullophittime, nonvalidophit;
 
     int pfp_bookkeeping, scored_pfp;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -120,6 +120,7 @@ private:
   bool createOpHitsTimeHist(
     const std::vector<recob::OpHit>& opHits) const;
   bool findMaxPeak(std::vector<recob::OpHit>& opHits);
+  inline std::string detectorName(const std::string detName) const;
   bool isPDInCryo(const int pdChannel) const;
   bool isSBNDPDRelevant(const int pdChannel,
                         const std::set<unsigned>& tpcWithHits) const;
@@ -156,15 +157,16 @@ private:
   const double fChargeToNPhotonsShower, fChargeToNPhotonsTrack;
   const double fMinHitQ, fMinSliceQ;
   const double fMinOpHPE, fMinFlashPE;
-  std::string fDetector; // SBND or ICARUS
-  bool fSBND, fICARUS;
-  std::unique_ptr<opdet::PDMapAlg> fPDMapAlgPtr;
+  const art::ServiceHandle<geo::Geometry> fGeometry;
+  const std::string fDetector; // SBND or ICARUS
+  const bool fSBND, fICARUS;
+  const std::unique_ptr<opdet::PDMapAlg> fPDMapAlgPtr;
   const int fCryostat;  // =0 or =1 to match ICARUS reco chain selection
   // geo::CryostatID fCryostat;  // TODO: use this type instead
-  std::unique_ptr<geo::CryostatGeo> fGeoCryo;
+  const std::unique_ptr<geo::CryostatGeo> fGeoCryo;
   const int fNBins;
   const double fDriftDistance;
-  size_t fNTPC;
+  const size_t fNTPC;
   unsigned fDriftVolumes;
   unsigned fTPCPerDriftVolume;
   const unsigned fOpDetNormalizer;
@@ -174,7 +176,6 @@ private:
 
   unsigned fPeakCounter = 0;
   std::vector<recob::OpHit>::iterator fOpH_beg, fOpH_end;
-  const art::ServiceHandle<geo::Geometry> geometry;
 
   // root stuff
   TTree* _flashmatch_nuslice_tree;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -143,7 +143,7 @@ private:
   bool computeFlashMetrics(const SimpleFlash& simpleFlash);
   bool computeScore(const std::set<unsigned>& tpcWithHits, const int pdgc);
   // double hypoFlashX_splines() const;
-  std::tuple<double, double, double> hypoFlashX_fits(
+  std::tuple<double, double, double, double> hypoFlashX_fits(
     double flash_r, double flash_ratio) const;
   // ::flashmatch::Flash_t GetFlashPESpectrum(const recob::OpFlash& opflash);
   // void CollectDownstreamPFParticles(const lar_pandora::PFParticleMap& pfParticleMap,
@@ -264,7 +264,7 @@ private:
   };
   std::array<Fits, 3> fRRFits;
   std::array<Fits, 3> fRatioFits;
-  const std::array<std::string, 3> suffixes{"l", "h", "m"};
+  const std::array<std::string, 3> kSuffixes{"l", "h", "m"};// low, high, medium
   // const std::string kPolFit = "pol3";
   const double kEps = 1e-4;
 
@@ -280,8 +280,8 @@ private:
   double _charge_x_gl, _charge_x,
     _charge_y, _charge_z, _charge_q;
   double _flash_x, _flash_x_gl, _flash_y, _flash_z,
-    _flash_r, _flash_pe, _flash_unpe, _flash_ratio,
-    _flash_time, _hypo_x, _hypo_x_rr, _hypo_x_ratio;
+    _flash_r, _flash_pe, _flash_unpe, _flash_ratio, _flash_time,
+    _hypo_x, _hypo_x_err, _hypo_x_rr, _hypo_x_ratio;
   double _score, _scr_y, _scr_z, _scr_rr, _scr_ratio;
   unsigned _evt, _run, _sub; //_slices;
 

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -35,7 +35,8 @@
 #include "lardataobj/RecoBase/OpHit.h"
 // #include "lardataobj/RecoBase/OpFlash.h"
 #include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
-// #include "nusimdata/SimulationBase/MCParticle.h" //uncomment for creating metrics
+#include "larsim/Utils/TruthMatchUtils.h"
+#include "nusimdata/SimulationBase/MCParticle.h"
 
 #include "TTree.h"
 #include "TF1.h"
@@ -43,13 +44,12 @@
 #include "TH1.h"
 #include "TH2.h"
 
-// #include "sbncode/CAFMaker/RecoUtils/RecoUtils.h" //uncomment for creating metrics
 #include "sbncode/OpT0Finder/flashmatch/Base/OpT0FinderTypes.h"
 #include "sbncode/OpDet/PDMapAlg.h"
 #include "sbnobj/Common/Reco/SimpleFlashMatchVars.h"
 
-// #include "nusimdata/SimulationBase/MCParticle.h" //uncomment for creating metrics
-// #include "nusimdata/SimulationBase/MCTruth.h" //uncomment for creating metrics
+#include "nusimdata/SimulationBase/MCParticle.h"
+#include "nusimdata/SimulationBase/MCTruth.h"
 
 #include <algorithm>
 #include <iterator>
@@ -227,6 +227,7 @@ private:
                     const art::Ptr<recob::PFParticle>& pfp_ptr,
                     const art::ValidHandle<std::vector<recob::PFParticle>>& pfps_h,
                     std::vector<art::Ptr<recob::PFParticle>>& pfp_v) const;
+  unsigned trueNus(art::Event& evt) const;
   void updateChargeMetrics(const ChargeMetrics& chargeMetrics);
   void updateFlashMetrics(const FlashMetrics& flashMetrics);
   void updateScore(const Score& score);
@@ -297,6 +298,7 @@ private:
   const bool fForceConcurrence;
   const bool fUseUncoatedPMT, fUseOppVolMetric;//, fUseCalo;
   const bool fUseARAPUCAS;
+  const bool fStoreTrueNus;
   const bool fStoreCheatMCT0;
   const std::string fInputFilename;
   const bool fNoAvailableMetrics, fMakeTree;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -154,8 +154,8 @@ private:
   const std::string fInputFilename;
   const bool fNoAvailableMetrics, fMakeTree;
   const double fChargeToNPhotonsShower, fChargeToNPhotonsTrack;
-  const double fMinHitQ, fMinSliceQ, fQScale;
-  const double fMinOpHPE, fMinFlashPE, fPEScale;
+  const double fMinHitQ, fMinSliceQ;
+  const double fMinOpHPE, fMinFlashPE;
   std::string fDetector; // SBND or ICARUS
   bool fSBND, fICARUS;
   std::unique_ptr<opdet::PDMapAlg> fPDMapAlgPtr;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -225,8 +225,10 @@ private:
   unsigned icarusPDinTPC(const int pdChannel) const;
   double wallXWithMaxPE(const OpHitIt opH_beg,
                         const OpHitIt opH_end) const;
+  std::list<double> wiresXGl() const;
+  double driftDistance() const;
   double flashXGl(const double hypo_x, const double flash_x) const;
-  double driftDistance(const double x) const;
+  double foldXGl(const double x_gl) const;
   unsigned driftVolume(const double x) const;
   template <typename Stream>
   void printBookKeeping(Stream&& out);
@@ -260,23 +262,23 @@ private:
   const std::string fDetector; // SBND or ICARUS
   const bool fSBND, fICARUS;
   const std::unique_ptr<opdet::PDMapAlg> fPDMapAlgPtr;
+  const size_t fNTPC;
   const int fCryostat;  // =0 or =1 to match ICARUS reco chain selection
   // geo::CryostatID fCryostat;  // TODO: use this type instead
   const std::unique_ptr<geo::CryostatGeo> fGeoCryo;
-  const double fDriftDistance, fXBinWidth;
+  const std::list<double> fWiresX_gl;
+  const double fDriftDistance;
   const int fXBins;
+  const double fXBinWidth;
   const std::string fRR_TF1_fit, fRatio_TF1_fit;
   unsigned fYBins,fZBins;
   double fYLow, fYHigh, fZLow, fZHigh;
   double fYSkewThreshold, fZSkewThreshold;
   const double fYBiasSlope, fZBiasSlope;
-  const size_t fNTPC;
   unsigned fDriftVolumes;
   unsigned fTPCPerDriftVolume;
   const unsigned fOpDetNormalizer;
   const double fTermThreshold;
-  std::list<double> fWiresX_gl;
-  // std::vector<double> fPMTChannelCorrection;
 
   const unsigned kRght = 0;
   const unsigned kLeft = 1;

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -123,6 +123,18 @@ public:
       {}
     // faulty charges constructor
     ChargeMetrics() : metric_ok(false) {}
+    std::string dumpMetrics() const
+      {
+        std::ostringstream stream;
+        stream
+          << "  x:       " << x << "\n"
+          << "  x_gl:    " << x_gl << "\n"
+          << "  y:       " << y << "\n"
+          << "  z:       " << z << "\n"
+          << "  q:       " << q << "\n"
+          << "  metric_ok: " << metric_ok << "\n";
+        return stream.str();
+      }
   };
 
   struct FlashMetrics {
@@ -149,6 +161,30 @@ public:
       h_x(0.), h_xerr(0.), h_xrr(0.), h_xratio(0.),
       y_skew(0.), z_skew(0.),
       metric_ok(false) {}
+    std::string dumpMetrics() const
+      {
+        std::ostringstream stream;
+        stream
+          << "  x:       " << x << "\n"
+          << "  x_gl:    " << x_gl << "\n"
+          << "  y:       " << y << "\n"
+          << "  yb:      " << yb << "\n"
+          << "  z:       " << z << "\n"
+          << "  zb:      " << zb << "\n"
+          << "  rr:      " << rr << "\n"
+          << "  pe:      " << pe << "\n"
+          << "  unpe:    " << unpe << "\n"
+          << "  ratio:   " << ratio << "\n"
+          << "  time:    " << time << "\n"
+          << "  h_x:     " << h_x << "\n"
+          << "  h_xerr:  " << h_xerr << "\n"
+          << "  h_xrr:   " << h_xrr << "\n"
+          << "  h_xratio:" << h_xratio << "\n"
+          << "  y_skew:  " << y_skew << "\n"
+          << "  z_skew:  " << z_skew << "\n"
+          << "  metric_ok: " << std::boolalpha << metric_ok << "\n";
+        return stream.str();
+      }
   };
 
 
@@ -235,6 +271,8 @@ private:
   void updateBookKeeping();
   template <typename Stream>
   void printMetrics(const std::string metric,
+                    const ChargeMetrics& charge,
+                    const FlashMetrics& flash,
                     const int pdgc,
                     const std::set<unsigned>& tpcWithHits,
                     const double term,

--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -317,9 +317,8 @@ private:
   const int fXBins;
   const double fXBinWidth;
   const std::string fRR_TF1_fit, fRatio_TF1_fit;
-  unsigned fYBins,fZBins;
-  double fYLow, fYHigh, fZLow, fZHigh;
-  double fYSkewThreshold, fZSkewThreshold;
+  const unsigned fYBins,fZBins;
+  const double fYLow, fYHigh, fZLow, fZHigh;
   const double fYBiasSlope, fZBiasSlope;
   unsigned fDriftVolumes;
   unsigned fTPCPerDriftVolume;

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -271,8 +271,7 @@ void FlashPredict::produce(art::Event& evt)
 
   ChargeDigestMap chargeDigestMap = makeChargeDigest(evt, pfps_h);
 
-  // TODO: store flashMetrics
-  // std::map<unsigned, FlashMetrics> flashMetricsMap;
+  std::map<unsigned, FlashMetrics> flashMetricsMap;
   for(auto& chargeDigest : chargeDigestMap) {
     //const size_t pId = chargeDigest.second.pId;
     const int pfpPDGC = chargeDigest.second.pfpPDGC;
@@ -328,18 +327,16 @@ void FlashPredict::produce(art::Event& evt)
       }
       hits_ophits_concurrence = true;
 
-      // TODO: check if metrics already computed, if so skip computing
-      // and grab them. Depends on hitsInVolume, ophsInVolume and the
-      // current flash number ... perhaps?
-      // flashUId = something
-      // if(auto it=flashMetricsMap.find(flashUId); it!=flashMetricsMap.end()){
-      //   mf::LogDebug("FlashPredict") << "Reusing metrics previously computed, "
-      //                                << "for flashUId " << flashUId;
-      //   auto flash_tmp = it->second;
-      //   flashMetricsMap[flashUId] = flash_tmp;
-      // }
-
-      FlashMetrics flash_tmp = computeFlashMetrics(simpleFlash);
+      unsigned flashUId = simpleFlash.ophsInVolume * 10 + simpleFlash.flashId;
+      bool mets_in_map = flashMetricsMap.find(flashUId) != flashMetricsMap.end();
+      FlashMetrics flash_tmp = (mets_in_map) ?
+        flashMetricsMap[flashUId] : computeFlashMetrics(simpleFlash);
+      if(mets_in_map){
+        mf::LogDebug("FlashPredict")
+          << "Reusing metrics previously computed, for flashUId " << flashUId;
+      }
+      else
+        flashMetricsMap[flashUId] = flash_tmp;
 
       Score score_tmp = computeScore(charge, flash_tmp, tpcWithHits, pfpPDGC);
       if(score_tmp.total > 0. && score_tmp.total < score.total

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -749,7 +749,7 @@ FlashPredict::FlashMetrics FlashPredict::computeFlashMetrics(
         y_correction = (std::abs(flash.y_skew)<10) ?
           flash.y_skew * flash.h_x*flash.h_x * fYBiasSlope : 0.;
         z_correction = (std::abs(flash.z_skew)<10) ?
-          flash.z_skew * flash.h_x * fZBiasSlope : 0.;
+          flash.z_skew * flash.h_x*flash.h_x * fZBiasSlope : 0.;
       }
       else{// fICARUS
         y_correction = (std::abs(flash.y_skew)<10) ?

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -151,6 +151,7 @@ void FlashPredict::produce(art::Event& evt)
     _sub = evt.subRun();
     _run = evt.run();
     _slices        = 0;
+    // _true_nus      = 0; //uncomment for creating metrics
     _flash_time    = -9999.;
     _flash_pe      = -9999.;
     _flash_unpe    = -9999.;
@@ -163,6 +164,29 @@ void FlashPredict::produce(art::Event& evt)
     _score         = -9999.;
   }
   bk.events++;
+
+  // // uncomment below for creating metrics
+  // // * MC truth information
+  // art::Handle<std::vector<simb::MCTruth> > mctruthList_h;
+  // std::vector<art::Ptr<simb::MCTruth> > mclist;
+  // if(evt.getByLabel("generator", mctruthList_h))
+  //   art::fill_ptr_vector(mclist, mctruthList_h);
+  // _true_nus = 0;
+  // for(auto const& mc: mclist){
+  //   //Only deal with neutrinos
+  //   if(mc->Origin() != simb::kBeamNeutrino){continue;}
+  //   ++_true_nus;
+  //   // Anything else you need to do with truth at this stage...
+  // }
+  // // if (_true_nus > 1) {
+  // //   mf::LogWarning("FlashPredict") << "\t _true_nus:\t" << _true_nus << ". Skipping.";
+  // //   bk.noslice++;
+  // //   updateBookKeeping();
+  // //   e.put(std::move(T0_v));
+  // //   e.put(std::move(pfp_t0_assn_v));
+  // //   return;
+  // // }
+  // // uncomment above for creating metrics
 
   // grab PFParticles in event
   const auto pfps_h =
@@ -411,6 +435,7 @@ void FlashPredict::initTree(void)
   _flashmatch_nuslice_tree->Branch("run", &_run, "run/I");
   _flashmatch_nuslice_tree->Branch("sub", &_sub, "sub/I");
   _flashmatch_nuslice_tree->Branch("slices", &_slices, "slices/I");
+  // _flashmatch_nuslice_tree->Branch("true_nus", &_true_nus, "true_nus/I"); // uncomment for creating metrics
   _flashmatch_nuslice_tree->Branch("flash_time", &_flash_time, "flash_time/D");
   _flashmatch_nuslice_tree->Branch("flash_x_gl", &_flash_x_gl, "flash_x_gl/D");
   _flashmatch_nuslice_tree->Branch("flash_x", &_flash_x, "flash_x/D");
@@ -1565,6 +1590,7 @@ void FlashPredict::printMetrics(const std::string metric,
     << "pfp.PdgCode:\t" << pdgc << "\n"
     << "tpcWithHits:\t" << tpcs << "\n"
     << "_slices:    \t" << std::setw(8) << _slices     << "\n"
+    // << "_true_nus:  \t" << std::setw(8) << _true_nus   << "\n" // uncomment for creating metrics
     << "charge metrics:\n" << charge.dumpMetrics() << "\n"
     << "flash metrics:\n"  << flash.dumpMetrics() << "\n";
 }

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -351,7 +351,7 @@ void FlashPredict::produce(art::Event& evt)
     if(!hits_ophits_concurrence) {
       std::string extra_message = (!fForceConcurrence) ? "" :
         "\nConsider setting ForceConcurrence to false to lower requirements";
-      mf::LogWarning("FlashPredict")
+      mf::LogInfo("FlashPredict")
         << "No OpHits where there's charge. Skipping..." << extra_message;
       bk.no_oph_hits++;
       mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
@@ -360,7 +360,6 @@ void FlashPredict::produce(art::Event& evt)
       util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
       continue;
     }
-
     else if(!flash.metric_ok){
       printMetrics("ERROR", pfpPDGC, tpcWithHits, 0, mf::LogError("FlashPredict"));
       bk.no_flash_pe++;

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -19,8 +19,8 @@ FlashPredict::FlashPredict(fhicl::ParameterSet const& p)
     // , fTrackProducer(p.get<std::string>("TrackProducer"))
   , fClockData(art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob())
   , fTickPeriod(fClockData.OpticalClock().TickPeriod()) // us
-  , fBeamWindowStart(p.get<double>("BeamWindowStart")) //us // TODO: should come from service
-  , fBeamWindowEnd(p.get<double>("BeamWindowEnd"))// us // TODO: should come from service
+  , fBeamWindowStart(p.get<double>("BeamWindowStart")) //us
+  , fBeamWindowEnd(p.get<double>("BeamWindowEnd"))// us
   , fFlashStart(p.get<double>("FlashStart")) // in us w.r.t. flash time
   , fFlashEnd(p.get<double>("FlashEnd"))  // in us w.r.t flash time
   , fTimeBins(unsigned(1/fTickPeriod * (fBeamWindowEnd - fBeamWindowStart)))
@@ -57,6 +57,12 @@ FlashPredict::FlashPredict(fhicl::ParameterSet const& p)
   , fXBinWidth(fDriftDistance/fXBins)// cm
   , fRR_TF1_fit(p.get<std::string>("rr_TF1_fit", "pol3"))
   , fRatio_TF1_fit(p.get<std::string>("ratio_TF1_fit", "pol3"))
+  , fYBins(p.get<unsigned>("YBins", 0.))
+  , fZBins(p.get<unsigned>("ZBins", 0.))
+  , fYLow(p.get<double>("YLow", 0.))
+  , fYHigh(p.get<double>("YHigh", 0.))
+  , fZLow(p.get<double>("ZLow", 0.))
+  , fZHigh(p.get<double>("ZHigh", 0.))
   , fYBiasSlope(p.get<double>("YBiasSlope", 0.))
   , fZBiasSlope(p.get<double>("ZBiasSlope", 0.))
   , fOpDetNormalizer((fSBND) ? 4 : 1)
@@ -84,11 +90,6 @@ FlashPredict::FlashPredict(fhicl::ParameterSet const& p)
     }
     fTPCPerDriftVolume = 1;
     fDriftVolumes = fNTPC/fTPCPerDriftVolume;
-    // TODO: make these few fcl params
-    fYBins = 9; fYLow = -180.; fYHigh = 180.;
-    fYSkewThreshold = 0.3; //fYBiasSlope = 0.004;
-    fZBins = 12; fZLow = 10.; fZHigh = 490.;
-    fZSkewThreshold = 0.33; //fZBiasSlope = 0.35;
   }
   else if(fICARUS && !fSBND) {
     if(fUseUncoatedPMT || fUseARAPUCAS) {
@@ -99,11 +100,6 @@ FlashPredict::FlashPredict(fhicl::ParameterSet const& p)
     }
     fTPCPerDriftVolume = 2;
     fDriftVolumes = fNTPC/fTPCPerDriftVolume;
-    // TODO: make these few fcl params
-    fYBins = 5; fYLow = -135.; fYHigh = 85.;
-    fYSkewThreshold = 0.1; //fYBiasSlope = 0.4;
-    fZBins = 18; fZLow = -900.; fZHigh = 900.;
-    fZSkewThreshold = 1e8; //fZBiasSlope = 0.; // No Z bias correction
   }
   else {
     throw cet::exception("FlashPredict")
@@ -777,13 +773,6 @@ FlashPredict::FlashMetrics FlashPredict::computeFlashMetrics(
       }
       flash.y = flash.yb - y_correction;
       flash.z = flash.zb - z_correction;
-      //     (-fYSkewThreshold<flash.y_skew && flash.y_skew<fYSkewThreshold) ?
-      //   0. : copysign(1., flash.y_skew);
-      // double z_correction =
-      //   (-fZSkewThreshold<flash.z_skew && flash.z_skew<fZSkewThreshold) ?
-      //   0. : copysign(1., flash.z_skew);
-      // flash.y = flash.yb - y_correction * fYBiasSlope * flash.h_x;
-      // flash.z = flash.zb - z_correction * fZBiasSlope * flash.h_x;
     }
 
     return flash;

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -333,7 +333,21 @@ void FlashPredict::produce(art::Event& evt)
         flash = flash_tmp;
       }
     } // for simpleFlashes
-    if(!flash.metric_ok){
+    // TODO: make sure this is ok, again got to think about ICARUS
+    if(!hits_ophits_concurrence) {
+      std::string extra_message = (fForceConcurrence) ? "" :
+        "\nConsider setting ForceConcurrence to false to lower requirements";
+      mf::LogWarning("FlashPredict")
+        << "No OpHits where there's charge. Skipping..." << extra_message;
+      bk.no_oph_hits++;
+      mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
+      sFM_v->emplace_back(sFM(kNoScr, kNoScrTime, Charge(kNoScrQ),
+                              Flash(kNoScrPE), Score(kQNoOpHScr)));
+      util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
+      continue;
+    }
+
+    else if(!flash.metric_ok){
       printMetrics("ERROR", pfpPDGC, tpcWithHits, 0, mf::LogError("FlashPredict"));
       bk.no_flash_pe++;
       mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
@@ -368,19 +382,6 @@ void FlashPredict::produce(art::Event& evt)
       printMetrics("ERROR", pfpPDGC, tpcWithHits, 0, mf::LogError("FlashPredict"));
     }
 
-    // TODO: make sure this is ok, again got to think about ICARUS
-    if(!hits_ophits_concurrence) {
-      std::string extra_message = (fForceConcurrence) ? "" :
-        "\nConsider setting ForceConcurrence to false to lower requirements";
-      mf::LogWarning("FlashPredict")
-        << "No OpHits where there's charge. Skipping..." << extra_message;
-      bk.no_oph_hits++;
-      mf::LogDebug("FlashPredict") << "Creating sFM and PFP-sFM association";
-      sFM_v->emplace_back(sFM(kNoScr, kNoScrTime, Charge(kNoScrQ),
-                              Flash(kNoScrPE), Score(kQNoOpHScr)));
-      util::CreateAssn(*this, evt, *sFM_v, pfp_ptr, *pfp_sFM_assn_v);
-      continue;
-    }
 
   } // chargeDigestMap: PFparticles that pass criteria
   bk.events_processed++;

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -1584,7 +1584,7 @@ void FlashPredict::updateBookKeeping()
     - bk.no_flash_pe;
 
   if(1-std::abs(bk.events_processed-bk.job_bookkeeping) == 0 ||
-     1-std::abs(bk.scored_pfp != bk.pfp_bookkeeping) == 0)
+     1-std::abs(bk.scored_pfp-bk.pfp_bookkeeping) == 0)
     printBookKeeping(mf::LogWarning("FlashPredict"));
 }
 

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -724,12 +724,16 @@ FlashPredict::FlashMetrics FlashPredict::computeFlashMetrics(
       double y_correction = 0.;
       double z_correction = 0.;
       if(fSBND) {
-        y_correction = flash.y_skew * flash.h_x*flash.h_x * fYBiasSlope;
-        z_correction = flash.z_skew * flash.h_x * fZBiasSlope;
+        y_correction = (std::abs(flash.y_skew)<10) ?
+          flash.y_skew * flash.h_x*flash.h_x * fYBiasSlope : 0.;
+        z_correction = (std::abs(flash.z_skew)<10) ?
+          flash.z_skew * flash.h_x * fZBiasSlope : 0.;
       }
       else{// fICARUS
-        y_correction = flash.y_skew * flash.h_x * fYBiasSlope;
-        z_correction = flash.z_skew * flash.h_x * fZBiasSlope;
+        y_correction = (std::abs(flash.y_skew)<10) ?
+          flash.y_skew * flash.h_x * fYBiasSlope : 0.;
+        z_correction =  (std::abs(flash.z_skew)<10) ?
+          flash.z_skew * flash.h_x * fZBiasSlope : 0.;
       }
       flash.y = flash.yb - y_correction;
       flash.z = flash.zb - z_correction;

--- a/sbncode/FlashMatch/FlashPredict_module.cc
+++ b/sbncode/FlashMatch/FlashPredict_module.cc
@@ -30,6 +30,7 @@ FlashPredict::FlashPredict(fhicl::ParameterSet const& p)
   , fUseUncoatedPMT(p.get<bool>("UseUncoatedPMT", false))
   , fUseOppVolMetric(p.get<bool>("UseOppVolMetric", false))
   , fUseARAPUCAS(p.get<bool>("UseARAPUCAS", false))
+  , fStoreTrueNus(p.get<bool>("StoreTrueNus", false))
   , fStoreCheatMCT0(p.get<bool>("StoreCheatMCT0", false))
     // , fUseCalo(p.get<bool>("UseCalo", false))
   , fInputFilename(p.get<std::string>("InputFileName")) // root file with score metrics
@@ -148,7 +149,7 @@ void FlashPredict::produce(art::Event& evt)
     _sub = evt.subRun();
     _run = evt.run();
     _slices        = 0;
-    // _true_nus      = -9999; //uncomment for creating metrics
+    _true_nus      = -9999;
     _flash_time    = -9999.;
     _flash_pe      = -9999.;
     _flash_unpe    = -9999.;
@@ -159,20 +160,13 @@ void FlashPredict::produce(art::Event& evt)
     _hypo_x_rr     = -9999.;
     _hypo_x_ratio  = -9999.;
     _score         = -9999.;
-    // if(fStoreCheatMCT0) _mcT0 = -9999.; //uncomment for creating metrics
+    _mcT0          = -9999.;
   }
   bk.events++;
 
-  // //uncomment below for creating metrics
-  // art::Handle<std::vector<simb::MCTruth> > mctruthList_h;
-  // std::vector<art::Ptr<simb::MCTruth> > mclist;
-  // if(evt.getByLabel("generator", mctruthList_h))
-  //   art::fill_ptr_vector(mclist, mctruthList_h);
-  // _true_nus = 0;
-  // for(auto const& mc: mclist){
-  //   if(mc->Origin() == simb::kBeamNeutrino) ++_true_nus;
-  // }
-  // //uncomment above for creating metrics
+  if(fMakeTree && fStoreTrueNus){
+    _true_nus = trueNus(evt);
+  }
 
   // grab PFParticles in event
   const auto pfps_h =
@@ -289,7 +283,6 @@ void FlashPredict::produce(art::Event& evt)
     const auto& pfp_ptr = chargeDigest.second.pfp_ptr;
     const auto& qClusters = chargeDigest.second.qClusters;
     const auto& tpcWithHits = chargeDigest.second.tpcWithHits;
-    // _mcT0 = chargeDigest.second.mcT0; //uncomment for creating metrics
 
     unsigned hitsInVolume = 0;
     bool in_right = false, in_left = false;
@@ -382,6 +375,7 @@ void FlashPredict::produce(art::Event& evt)
     if(score.total > 0. &&
        score.total < std::numeric_limits<double>::max()){
       if(fMakeTree) {
+        _mcT0 = chargeDigest.second.mcT0;
         updateChargeMetrics(charge);
         updateFlashMetrics(flash);
         updateScore(score);
@@ -449,8 +443,8 @@ void FlashPredict::initTree(void)
   _flashmatch_nuslice_tree->Branch("scr_ratio", &_scr_ratio, "scr_ratio/D");
   _flashmatch_nuslice_tree->Branch("y_skew", &_y_skew, "y_skew/D");
   _flashmatch_nuslice_tree->Branch("z_skew", &_z_skew, "z_skew/D");
-  // _flashmatch_nuslice_tree->Branch("true_nus", &_true_nus, "true_nus/I"); //uncomment for creating metrics
-  // if(fStoreCheatMCT0) _flashmatch_nuslice_tree->Branch("mcT0", &_mcT0, "mcT0/D"); //uncomment for creating metrics
+  _flashmatch_nuslice_tree->Branch("true_nus", &_true_nus, "true_nus/I");
+  _flashmatch_nuslice_tree->Branch("mcT0", &_mcT0, "mcT0/D");
 }
 
 
@@ -623,16 +617,8 @@ double FlashPredict::cheatMCT0(const std::vector<art::Ptr<recob::Hit>>& hits,
                                const std::vector<art::Ptr<simb::MCParticle>>& mcParticles)
 {
   auto clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
-  const std::vector<std::pair<int, float>> matches =
-    CAFRecoUtils::AllTrueParticleIDEnergyMatches(clockData, hits, true);
-  int pidMaxEnergy = -1;
-  double maxEnergy = -10;
-  for(auto& m : matches){
-    if(m.second > maxEnergy){
-      pidMaxEnergy = m.first;
-      maxEnergy = m.second;
-    }
-  }
+  int pidMaxEnergy =
+    TruthMatchUtils::TrueParticleIDFromTotalTrueEnergy(clockData, hits, true);
   for(auto& mcp: mcParticles){
     if(mcp->TrackId() == pidMaxEnergy){
       return mcp->Position().T();
@@ -995,12 +981,11 @@ FlashPredict::ChargeDigestMap FlashPredict::makeChargeDigest(
   // art::FindManyP<anab::Calorimetry>  track_calo_assn_v(calo_h,
   //                                                      evt, fCaloProducer);
 
-  // //uncomment for creating metrics
-  // std::vector<art::Ptr<simb::MCParticle>> mcParticles;
-  // if(fStoreCheatMCT0){
-  //   lar_pandora::LArPandoraHelper::CollectMCParticles(evt, "largeant", mcParticles);
-  // }
-  // //uncomment for creating metrics
+  std::vector<art::Ptr<simb::MCParticle>> mcParticles;
+  if(fStoreCheatMCT0){
+    lar_pandora::LArPandoraHelper::CollectMCParticles(evt, "largeant",
+                                                      mcParticles);
+  }
 
   std::unordered_map<size_t, size_t> pfpMap;
   for(size_t pId=0; pId<pfps_h->size(); pId++) {
@@ -1052,7 +1037,7 @@ FlashPredict::ChargeDigestMap FlashPredict::makeChargeDigest(
     addDaughters(pfpMap, pfp_ptr, pfps_h, particles_in_slice);
 
     double sliceQ = 0.;
-    // std::vector<art::Ptr<recob::Hit>> hits_in_slice;//uncomment for creating metrics
+    std::vector<art::Ptr<recob::Hit>> hits_in_slice;
     flashmatch::QCluster_t particlesClusters;
     for(const auto& particle: particles_in_slice) {
       const auto particle_key = particle.key();
@@ -1062,12 +1047,10 @@ FlashPredict::ChargeDigestMap FlashPredict::makeChargeDigest(
       for(const auto& spacepoint : particle_spacepoints) {
         const auto spacepoint_key = spacepoint.key();
         const auto& hits = spacepoint_hits_assns.at(spacepoint_key);
-        // //uncomment for creating metrics
-        // if(fStoreCheatMCT0){
-        //   hits_in_slice.insert(hits_in_slice.end(),
-        //                        hits.begin(), hits.end());
-        // }
-        // //uncomment for creating metrics
+        if(fStoreCheatMCT0){
+          hits_in_slice.insert(hits_in_slice.end(),
+                               hits.begin(), hits.end());
+        }
         const auto& pos = spacepoint->XYZ();
         double spacepointQ = 0.;
         flashmatch::QCluster_t hitsClusters;
@@ -1096,15 +1079,10 @@ FlashPredict::ChargeDigestMap FlashPredict::makeChargeDigest(
                                spsClusters.begin(), spsClusters.end());
     } // for particles in slice
     if(sliceQ < fMinSliceQ) continue;
+    double mcT0 = (fStoreCheatMCT0) ? cheatMCT0(hits_in_slice, mcParticles)/1000.
+      : -9999.;
     chargeDigestMap[sliceQ] =
-      ChargeDigest(pId, pfpPDGC, pfp_ptr, particlesClusters, tpcWithHits);
-
-    // //uncomment this instead of above line for running with metrics
-    // double mcT0 = (fStoreCheatMCT0) ? cheatMCT0(hits_in_slice, mcParticles)/1000.
-    //   : -9999.;
-    // chargeDigestMap[sliceQ] =
-    //   ChargeDigest(pId, pfpPDGC, pfp_ptr, particlesClusters, tpcWithHits, mcT0);
-    // //uncomment this instead of above line for running with metrics
+      ChargeDigest(pId, pfpPDGC, pfp_ptr, particlesClusters, tpcWithHits, mcT0);
   } // over all slices
   return chargeDigestMap;
 }
@@ -1123,6 +1101,20 @@ void FlashPredict::addDaughters(
     addDaughters(pfpMap, daughter_ptr, pfps_h, mothers_daughters);
   }
   return;
+}
+
+
+unsigned FlashPredict::trueNus(art::Event& evt) const
+{
+  art::Handle<std::vector<simb::MCTruth> > mctruthList_h;
+  std::vector<art::Ptr<simb::MCTruth> > mclist;
+  if(evt.getByLabel("generator", mctruthList_h))
+    art::fill_ptr_vector(mclist, mctruthList_h);
+  unsigned true_nus = 0;
+  for(auto const& mc: mclist){
+    if(mc->Origin() == simb::kBeamNeutrino) ++true_nus;
+  }
+  return true_nus;
 }
 
 
@@ -1615,8 +1607,8 @@ void FlashPredict::printMetrics(const std::string metric,
     << "pfp.PdgCode:\t" << pdgc << "\n"
     << "tpcWithHits:\t" << tpcs << "\n"
     << "_slices:    \t" << std::setw(8) << _slices   << "\n"
-    // << "_true_nus:  \t" << std::setw(8) << _true_nus << "\n" //uncomment for creating metrics
-    // << "_mcT0:      \t" << std::setw(8) << _mcT0     << "\n" //uncomment for creating metrics
+    << "_true_nus:  \t" << std::setw(8) << _true_nus << "\n"
+    << "_mcT0:      \t" << std::setw(8) << _mcT0     << "\n"
     << "charge metrics:\n" << charge.dumpMetrics()   << "\n"
     << "flash metrics:\n"  << flash.dumpMetrics()    << "\n";
 }

--- a/sbncode/FlashMatch/template_generators/generate_simple_weighted_template.py
+++ b/sbncode/FlashMatch/template_generators/generate_simple_weighted_template.py
@@ -258,9 +258,6 @@ def generator(nuslice_tree, rootfile, pset):
         match_score_scatter.Fill(qX, score)
         match_score_hist.Fill(score)
 
-    errors = [1, 0, -1]
-    fitname_suffix = ["_h", "_m", "_l"]
-
     metrics_filename = 'fm_metrics_' + detector + '.root'
     hfile = gROOT.FindObject(metrics_filename)
     if hfile:
@@ -277,6 +274,10 @@ def generator(nuslice_tree, rootfile, pset):
     rr_hist.Write()
     rr_prof.Write()
     rr_h1.Write()
+
+    errors = [1, 0, -1]
+    fitname_suffix = ["_h", "_m", "_l"]
+
     rr_fit_funcs = []
     for e,suf in zip(errors, fitname_suffix):
         yvals = [a + e*b for a, b in zip(rr_means, rr_spreads)]

--- a/sbncode/FlashMatch/template_generators/generate_simple_weighted_template.py
+++ b/sbncode/FlashMatch/template_generators/generate_simple_weighted_template.py
@@ -79,15 +79,69 @@ detector = "experiment"
 #                 print()
 
 
-def generator(nuslice_tree, rootfile, pset):
-    n_bins = pset.n_bins
-    drift_distance = pset.DriftDistance
-    bin_width = drift_distance/n_bins
-    half_bin_width = bin_width/2.
 
-    xvals = np.arange(half_bin_width, drift_distance, bin_width)
+def hypo_flashx_from_H2(flash_rr, rr_h2, flash_ratio, ratio_h2):
+    rr_hypoX, rr_hypoXWgt = x_estimate_and_rms(flash_rr, rr_h2);
+    ratio_hypoX, ratio_hypoXWgt = x_estimate_and_rms(flash_ratio, ratio_h2);
+
+    sum_weights = rr_hypoXWgt + ratio_hypoXWgt
+    hypo_x = (rr_hypoX*rr_hypoXWgt + ratio_hypoX*ratio_hypoXWgt) / sum_weights
+    hypo_x_err = np.sqrt(sum_weights) / sum_weights
+    # return (hypo_x, hypo_x_err, rr_hypoX, ratio_hypoX)
+    return hypo_x
+
+
+def x_estimate_and_rms(metric_value, metric_h2):
+    kMinEntriesInProjection = 100
+    fXBinWidth = 5.
+    bin = metric_h2.GetYaxis().FindBin(metric_value);
+    bins = metric_h2.GetNbinsY();
+    metric_hypoX = -1.;
+    metric_hypoXWgt = 0.;
+    bin_buff = 0;
+    while 0 < bin-bin_buff or bin+bin_buff <= bins :
+        low_bin = bin-bin_buff if 0 < bin-bin_buff else 0
+        high_bin = bin+bin_buff if bin+bin_buff <= bins else -1
+        metric_px = metric_h2.ProjectionX("metric_px", low_bin, high_bin);
+        if metric_px.GetEntries() > kMinEntriesInProjection :
+            metric_hypoX = metric_px.GetRandom();
+            metric_rmsX = metric_px.GetRMS();
+            if metric_rmsX < fXBinWidth: # something went wrong
+                print(f"metric_h2 projected on metric_value: {metric_value}, bin: {bin}, "
+                      f"bin_buff: {bin_buff}; has {metric_px.GetEntries()} entries.")
+                print(f"metric_hypoX: {metric_hypoX}, metric_rmsX: {metric_rmsX}")
+                return (-1., 0.); # no estimate
+            metric_hypoXWgt = 1/(metric_rmsX*metric_rmsX);
+            return (metric_hypoX, metric_hypoXWgt);
+        bin_buff += 1;
+    return (-1., 0.); # no estimate
+
+
+def y_bias(y_skew, hypo_x, y_bias_slope):
+      if detector == "sbnd":
+          return y_skew * hypo_x * hypo_x * y_bias_slope
+      elif detector == "icarus":
+          return y_skew * hypo_x * y_bias_slope
+
+
+def z_bias(z_skew, hypo_x, z_bias_slope):
+    if detector == "sbnd":
+          return z_skew * hypo_x * z_bias_slope;
+    elif detector == "icarus":
+          return z_skew * hypo_x * z_bias_slope;
+
+
+def generator(nuslice_tree, rootfile, pset):
+    drift_distance = pset.DriftDistance
+    xbin_width = pset.XBinWidth
+    x_bins = int(drift_distance/xbin_width)
+    half_bin_width = xbin_width/2.
+    y_bias_slope = pset.YBiasSlope
+    z_bias_slope = pset.ZBiasSlope
+
+    xvals = np.arange(half_bin_width, drift_distance, xbin_width)
     xerrs = np.array([half_bin_width] * len(xvals))
-    dist_to_anode_bins = n_bins
+    dist_to_anode_bins = x_bins
     dist_to_anode_low = 0.
     dist_to_anode_up = drift_distance
     if detector == "sbnd":
@@ -101,16 +155,16 @@ def generator(nuslice_tree, rootfile, pset):
             x_gl_low = 380
             x_gl_up = 50
 
-    profile_bins = n_bins
+    profile_bins = x_bins
     profile_option = 's'  # errors are the standard deviation
 
-    dy_spreads = [None] * n_bins
-    dy_means = [None] * n_bins
-    dy_hist = TH2D("dy_hist", "#Delta y",
-                   dist_to_anode_bins, dist_to_anode_low, dist_to_anode_up,
-                   pset.dy_bins, pset.dy_low, pset.dy_up)
-    dy_hist.GetXaxis().SetTitle("distance from anode (cm)")
-    dy_hist.GetYaxis().SetTitle("y_flash - y_TPC (cm)")
+    dy_spreads = [None] * x_bins
+    dy_means = [None] * x_bins
+    dy_h2 = TH2D("dy_h2", "#Delta y",
+                 dist_to_anode_bins, dist_to_anode_low, dist_to_anode_up,
+                 pset.dy_bins, pset.dy_low, pset.dy_up)
+    dy_h2.GetXaxis().SetTitle("distance from anode (cm)")
+    dy_h2.GetYaxis().SetTitle("y_flash - y_TPC (cm)")
     dy_prof = TProfile("dy_prof", "Profile of dy_spreads in #Delta y",
                        profile_bins, dist_to_anode_low, dist_to_anode_up,
                        pset.dy_low*2, pset.dy_up*2, profile_option)
@@ -121,13 +175,13 @@ def generator(nuslice_tree, rootfile, pset):
     dy_h1.GetXaxis().SetTitle("distance from anode (cm)")
     dy_h1.GetYaxis().SetTitle("y_flash - y_TPC (cm)")
 
-    dz_spreads = [None] * n_bins
-    dz_means = [None] * n_bins
-    dz_hist = TH2D("dz_hist", "#Delta z",
-                   dist_to_anode_bins, dist_to_anode_low, dist_to_anode_up,
-                   pset.dz_bins, pset.dz_low, pset.dz_up)
-    dz_hist.GetXaxis().SetTitle("distance from anode (cm)")
-    dz_hist.GetYaxis().SetTitle("z_flash - z_TPC (cm)")
+    dz_spreads = [None] * x_bins
+    dz_means = [None] * x_bins
+    dz_h2 = TH2D("dz_h2", "#Delta z",
+                 dist_to_anode_bins, dist_to_anode_low, dist_to_anode_up,
+                 pset.dz_bins, pset.dz_low, pset.dz_up)
+    dz_h2.GetXaxis().SetTitle("distance from anode (cm)")
+    dz_h2.GetYaxis().SetTitle("z_flash - z_TPC (cm)")
     dz_prof = TProfile("dz_prof", "Profile of dz_spreads in #Delta z",
                        profile_bins, dist_to_anode_low, dist_to_anode_up,
                        pset.dz_low*2.5, pset.dz_up*2.5, profile_option)
@@ -138,13 +192,13 @@ def generator(nuslice_tree, rootfile, pset):
     dz_h1.GetXaxis().SetTitle("distance from anode (cm)")
     dz_h1.GetYaxis().SetTitle("z_flash - z_TPC (cm)")
 
-    rr_spreads = [None] * n_bins
-    rr_means = [None] * n_bins
-    rr_hist = TH2D("rr_hist", "PE Spread",
-                   dist_to_anode_bins, dist_to_anode_low, dist_to_anode_up,
-                   pset.rr_bins, pset.rr_low, pset.rr_up)
-    rr_hist.GetXaxis().SetTitle("distance from anode (cm)")
-    rr_hist.GetYaxis().SetTitle("spread (cm)")
+    rr_spreads = [None] * x_bins
+    rr_means = [None] * x_bins
+    rr_h2 = TH2D("rr_h2", "PE Spread",
+                 dist_to_anode_bins, dist_to_anode_low, dist_to_anode_up,
+                 pset.rr_bins, pset.rr_low, pset.rr_up)
+    rr_h2.GetXaxis().SetTitle("distance from anode (cm)")
+    rr_h2.GetYaxis().SetTitle("spread (cm)")
     rr_prof = TProfile("rr_prof", "Profile of PE Spread",
                        profile_bins, dist_to_anode_low, dist_to_anode_up,
                        pset.rr_low, pset.rr_up, profile_option)
@@ -155,22 +209,22 @@ def generator(nuslice_tree, rootfile, pset):
     rr_h1.GetXaxis().SetTitle("distance from anode (cm)")
     rr_h1.GetYaxis().SetTitle("spread (cm)")
 
-    pe_spreads = [None] * n_bins
-    pe_means = [None] * n_bins
-    pe_hist = TH2D("pe_hist", "PE Ratio",
-                   dist_to_anode_bins, dist_to_anode_low, dist_to_anode_up,
-                   pset.pe_bins, pset.pe_low, pset.pe_up)
-    pe_hist.GetXaxis().SetTitle("distance from anode (cm)")
-    pe_hist.GetYaxis().SetTitle("ratio")
-    pe_prof = TProfile("pe_prof", "Profile of PE Ratio",
-                       profile_bins, dist_to_anode_low, dist_to_anode_up,
-                       pset.pe_low, pset.pe_up, profile_option)
-    pe_prof.GetXaxis().SetTitle("distance from anode (cm)")
-    pe_prof.GetYaxis().SetTitle("ratio")
-    pe_h1 = TH1D("pe_h1", "",
-                 profile_bins, dist_to_anode_low, dist_to_anode_up)
-    pe_h1.GetXaxis().SetTitle("distance from anode (cm)")
-    pe_h1.GetYaxis().SetTitle("ratio")
+    ratio_spreads = [None] * x_bins
+    ratio_means = [None] * x_bins
+    ratio_h2 = TH2D("ratio_h2", "PE Ratio",
+                    dist_to_anode_bins, dist_to_anode_low, dist_to_anode_up,
+                    pset.ratio_bins, pset.ratio_low, pset.ratio_up)
+    ratio_h2.GetXaxis().SetTitle("distance from anode (cm)")
+    ratio_h2.GetYaxis().SetTitle("ratio")
+    ratio_prof = TProfile("ratio_prof", "Profile of PE Ratio",
+                          profile_bins, dist_to_anode_low, dist_to_anode_up,
+                          pset.ratio_low, pset.ratio_up, profile_option)
+    ratio_prof.GetXaxis().SetTitle("distance from anode (cm)")
+    ratio_prof.GetYaxis().SetTitle("ratio")
+    ratio_h1 = TH1D("ratio_h1", "",
+                    profile_bins, dist_to_anode_low, dist_to_anode_up)
+    ratio_h1.GetXaxis().SetTitle("distance from anode (cm)")
+    ratio_h1.GetYaxis().SetTitle("ratio")
 
     unfolded_score_scatter = TH2D("unfolded_score_scatter", "Scatter plot of match scores",
                                   2*dist_to_anode_bins, x_gl_low, x_gl_up,
@@ -178,8 +232,8 @@ def generator(nuslice_tree, rootfile, pset):
     unfolded_score_scatter.GetXaxis().SetTitle("X global (cm)")
     unfolded_score_scatter.GetYaxis().SetTitle("match score (arbitrary)")
     oldunfolded_score_scatter = TH2D("oldunfolded_score_scatter", "Scatter plot of match scores, old metrics",
-                                  2*dist_to_anode_bins, x_gl_low, x_gl_up,
-                                  pset.score_hist_bins, pset.score_hist_low, pset.score_hist_up*(3./5.))
+                                     2*dist_to_anode_bins, x_gl_low, x_gl_up,
+                                     pset.score_hist_bins, pset.score_hist_low, pset.score_hist_up*(3./5.))
     oldunfolded_score_scatter.GetXaxis().SetTitle("X global (cm)")
     oldunfolded_score_scatter.GetYaxis().SetTitle("match score (arbitrary)")
     match_score_scatter = TH2D("match_score_scatter", "Scatter plot of match scores",
@@ -187,21 +241,29 @@ def generator(nuslice_tree, rootfile, pset):
                                pset.score_hist_bins, pset.score_hist_low, pset.score_hist_up*(3./5.))
     match_score_scatter.GetXaxis().SetTitle("distance from anode (cm)")
     match_score_scatter.GetYaxis().SetTitle("match score (arbitrary)")
-    match_score_hist = TH1D("match_score", "Match Score",
-                            pset.score_hist_bins, pset.score_hist_low, pset.score_hist_up)
-    match_score_hist.GetXaxis().SetTitle("match score (arbitrary)")
+    match_score_h1 = TH1D("match_score", "Match Score",
+                          pset.score_hist_bins, pset.score_hist_low, pset.score_hist_up)
+    match_score_h1.GetXaxis().SetTitle("match score (arbitrary)")
 
+    # fill rr_h2 and ratio_h2 first
     for e in nuslice_tree:
         qX = e.charge_x
+        rr_h2.Fill(qX, e.flash_rr)
+        rr_prof.Fill(qX, e.flash_rr)
+        ratio_h2.Fill(qX, e.flash_ratio)
+        ratio_prof.Fill(qX, e.flash_ratio)
+    # use rr_h2 and ratio_h2 to compute hypo_x
+    for e in nuslice_tree:
+        qX = e.charge_x
+        hypo_x = hypo_flashx_from_H2(e.flash_rr, rr_h2, e.flash_ratio, ratio_h2)
+        corr_flash_y = e.flash_yb - y_bias(e.y_skew, hypo_x, y_bias_slope)
+        corr_flash_z = e.flash_zb - z_bias(e.z_skew, hypo_x, z_bias_slope)
 
-        dy_hist.Fill(qX, e.flash_y - e.charge_y)
-        dy_prof.Fill(qX, e.flash_y - e.charge_y)
-        dz_hist.Fill(qX, e.flash_z - e.charge_z)
-        dz_prof.Fill(qX, e.flash_z - e.charge_z)
-        rr_hist.Fill(qX, e.flash_r)
-        rr_prof.Fill(qX, e.flash_r)
-        pe_hist.Fill(qX, e.flash_ratio)
-        pe_prof.Fill(qX, e.flash_ratio)
+        dy_h2.Fill(qX, corr_flash_y - e.charge_y)
+        dy_prof.Fill(qX, corr_flash_y - e.charge_y)
+        dz_h2.Fill(qX, corr_flash_z - e.charge_z)
+        dz_prof.Fill(qX, corr_flash_z - e.charge_z)
+
 
     # fill histograms for match score calculation from profile histograms
     for ib in list(range(0, profile_bins)):
@@ -218,16 +280,16 @@ def generator(nuslice_tree, rootfile, pset):
         rr_h1.SetBinError(ibp, rr_prof.GetBinError(ibp))
         rr_means[int(ib)] = rr_prof.GetBinContent(ibp)
         rr_spreads[int(ib)] = rr_prof.GetBinError(ibp)
-        pe_h1.SetBinContent(ibp, pe_prof.GetBinContent(ibp))
-        pe_h1.SetBinError(ibp, pe_prof.GetBinError(ibp))
-        pe_means[int(ib)] = pe_prof.GetBinContent(ibp)
-        pe_spreads[int(ib)] = pe_prof.GetBinError(ibp)
+        ratio_h1.SetBinContent(ibp, ratio_prof.GetBinContent(ibp))
+        ratio_h1.SetBinError(ibp, ratio_prof.GetBinError(ibp))
+        ratio_means[int(ib)] = ratio_prof.GetBinContent(ibp)
+        ratio_spreads[int(ib)] = ratio_prof.GetBinError(ibp)
 
     for e in nuslice_tree:
         qX = e.charge_x
         qXGl = e.charge_x_gl
         # calculate match score
-        isl = int(qX/bin_width)
+        isl = int(qX/xbin_width)
         score = 0.
         if dy_spreads[isl] <= 1.e-8:
             print("Warning zero spread.\n",
@@ -241,22 +303,26 @@ def generator(nuslice_tree, rootfile, pset):
             print("Warning zero spread.\n",
                   f"qX: {qX}. isl: {isl}. rr_spreads[isl]: {rr_spreads[isl]} ")
             rr_spreads[isl] = rr_spreads[isl+1]
-        if pe_spreads[isl] <= 1.e-8:
+        if ratio_spreads[isl] <= 1.e-8:
             print("Warning zero spread.\n",
-                  f"qX: {qX}. isl: {isl}. pe_spreads[isl]: {pe_spreads[isl]} ")
-            pe_spreads[isl] = pe_spreads[isl+1]
-            # pe_spreads[isl] = pe_spreads[isl-1]
-        score += abs(abs(e.flash_y-e.charge_y) - dy_means[isl])/dy_spreads[isl]
-        score += abs(abs(e.flash_z-e.charge_z) - dz_means[isl])/dz_spreads[isl]
-        score += abs(e.flash_r-rr_means[isl])/rr_spreads[isl]
+                  f"qX: {qX}. isl: {isl}. ratio_spreads[isl]: {ratio_spreads[isl]} ")
+            ratio_spreads[isl] = ratio_spreads[isl+1]
+            # ratio_spreads[isl] = ratio_spreads[isl-1]
+        hypo_x = hypo_flashx_from_H2(e.flash_rr, rr_h2, e.flash_ratio, ratio_h2)
+        corr_flash_y = e.flash_yb - y_bias(e.y_skew, hypo_x, y_bias_slope)
+        corr_flash_z = e.flash_zb - z_bias(e.z_skew, hypo_x, z_bias_slope)
+
+        score += abs(abs(corr_flash_y-e.charge_y) - dy_means[isl])/dy_spreads[isl]
+        score += abs(abs(corr_flash_z-e.charge_z) - dz_means[isl])/dz_spreads[isl]
+        score += abs(e.flash_rr-rr_means[isl])/rr_spreads[isl]
         if (detector == "sbnd" and pset.UseUncoatedPMT) or \
            (detector == "icarus" and pset.UseOppVolMetric) :
-            score += abs(e.flash_ratio-pe_means[isl])/pe_spreads[isl]
+            score += abs(e.flash_ratio-ratio_means[isl])/ratio_spreads[isl]
 
         oldunfolded_score_scatter.Fill(qXGl, e.score)
         unfolded_score_scatter.Fill(qXGl, score)
         match_score_scatter.Fill(qX, score)
-        match_score_hist.Fill(score)
+        match_score_h1.Fill(score)
 
     metrics_filename = 'fm_metrics_' + detector + '.root'
     hfile = gROOT.FindObject(metrics_filename)
@@ -265,54 +331,53 @@ def generator(nuslice_tree, rootfile, pset):
     hfile = TFile(metrics_filename, 'RECREATE',
                   'Simple flash matching metrics for ' + detector.upper())
 
-    dy_hist.Write()
+    dy_h2.Write()
     dy_prof.Write()
     dy_h1.Write()
-    dz_hist.Write()
+    dz_h2.Write()
     dz_prof.Write()
     dz_h1.Write()
-    rr_hist.Write()
+    rr_h2.Write()
     rr_prof.Write()
     rr_h1.Write()
 
     errors = [1, 0, -1]
     fitname_suffix = ["_h", "_m", "_l"]
-
     rr_fit_funcs = []
     for e,suf in zip(errors, fitname_suffix):
         yvals = [a + e*b for a, b in zip(rr_means, rr_spreads)]
-        graph = TGraph(n_bins,
+        graph = TGraph(x_bins,
                        array('f', xvals), array('f', yvals))
         name = "rr_fit" + suf
         print("Fitting: ", name)
-        f = TF1(name, "pol3")
+        f = TF1(name, pset.rr_TF1_fit)
         graph.Fit(f)
         f.Write()
         rr_fit_funcs.append(f)
-    pe_hist.Write()
-    pe_prof.Write()
-    pe_h1.Write()
-    pe_fit_funcs = []
+    ratio_h2.Write()
+    ratio_prof.Write()
+    ratio_h1.Write()
+    ratio_fit_funcs = []
     for e,suf in zip(errors, fitname_suffix):
-        yvals = [a + e*b for a, b in zip(pe_means, pe_spreads)]
-        graph = TGraph(n_bins,
+        yvals = [a + e*b for a, b in zip(ratio_means, ratio_spreads)]
+        graph = TGraph(x_bins,
                        array('f', xvals), array('f', yvals))
-        name = "pe_fit" + suf
+        name = "ratio_fit" + suf
         print("Fitting: ", name)
-        f = TF1(name, "pol3")
+        f = TF1(name, pset.ratio_TF1_fit)
         graph.Fit(f)
         f.Write()
-        pe_fit_funcs.append(f)
+        ratio_fit_funcs.append(f)
     match_score_scatter.Write()
     oldunfolded_score_scatter.Write()
     unfolded_score_scatter.Write()
-    match_score_hist.Write()
+    match_score_h1.Write()
     hfile.Close()
 
     canv = TCanvas("canv")
 
-    dy_hist.Draw()
-    crosses = TGraphErrors(n_bins,
+    dy_h2.Draw()
+    crosses = TGraphErrors(x_bins,
                            array('f', xvals), array('f', dy_means),
                            array('f', xerrs), array('f', dy_spreads))
     crosses.SetLineColor(ROOT.kAzure+9)
@@ -321,8 +386,8 @@ def generator(nuslice_tree, rootfile, pset):
     canv.Print("dy.pdf")
     canv.Update()
 
-    dz_hist.Draw()
-    crosses = TGraphErrors(n_bins,
+    dz_h2.Draw()
+    crosses = TGraphErrors(x_bins,
                            array('f', xvals), array('f', dz_means),
                            array('f', xerrs), array('f', dz_spreads))
     crosses.SetLineColor(ROOT.kAzure+9)
@@ -331,8 +396,8 @@ def generator(nuslice_tree, rootfile, pset):
     canv.Print("dz.pdf")
     canv.Update()
 
-    rr_hist.Draw()
-    crosses = TGraphErrors(n_bins,
+    rr_h2.Draw()
+    crosses = TGraphErrors(x_bins,
                            array('f', xvals), array('f', rr_means),
                            array('f', xerrs), array('f', rr_spreads))
     crosses.SetLineColor(ROOT.kAzure+9)
@@ -344,17 +409,17 @@ def generator(nuslice_tree, rootfile, pset):
     canv.Print("rr.pdf")
     canv.Update()
 
-    pe_hist.Draw()
-    crosses = TGraphErrors(n_bins,
-                           array('f', xvals), array('f', pe_means),
-                           array('f', xerrs), array('f', pe_spreads))
+    ratio_h2.Draw()
+    crosses = TGraphErrors(x_bins,
+                           array('f', xvals), array('f', ratio_means),
+                           array('f', xerrs), array('f', ratio_spreads))
     crosses.SetLineColor(ROOT.kAzure+9)
     crosses.SetLineWidth(3)
     crosses.Draw("Psame")
-    for f in pe_fit_funcs:
+    for f in ratio_fit_funcs:
         f.SetLineColor(ROOT.kOrange+7)
         f.DrawF1(0., drift_distance, "lsame")
-    canv.Print("pe.pdf")
+    canv.Print("ratio.pdf")
     canv.Update()
 
     oldunfolded_score_scatter.Draw()
@@ -369,7 +434,7 @@ def generator(nuslice_tree, rootfile, pset):
     canv.Print("match_score_scatter.pdf")
     canv.Update()
 
-    match_score_hist.Draw()
+    match_score_h1.Draw()
     canv.Print("match_score.pdf")
     canv.Update()
     sleep(20)

--- a/sbncode/FlashMatch/template_generators/generate_simple_weighted_template.py
+++ b/sbncode/FlashMatch/template_generators/generate_simple_weighted_template.py
@@ -247,6 +247,7 @@ def generator(nuslice_tree, rootfile, pset):
 
     # fill rr_h2 and ratio_h2 first
     for e in nuslice_tree:
+        if e.slices > e.true_nus: continue
         qX = e.charge_x
         rr_h2.Fill(qX, e.flash_rr)
         rr_prof.Fill(qX, e.flash_rr)
@@ -254,6 +255,7 @@ def generator(nuslice_tree, rootfile, pset):
         ratio_prof.Fill(qX, e.flash_ratio)
     # use rr_h2 and ratio_h2 to compute hypo_x
     for e in nuslice_tree:
+        if e.slices > e.true_nus: continue
         qX = e.charge_x
         hypo_x = hypo_flashx_from_H2(e.flash_rr, rr_h2, e.flash_ratio, ratio_h2)
         corr_flash_y = e.flash_yb - y_bias(e.y_skew, hypo_x, y_bias_slope)
@@ -286,6 +288,7 @@ def generator(nuslice_tree, rootfile, pset):
         ratio_spreads[int(ib)] = ratio_prof.GetBinError(ibp)
 
     for e in nuslice_tree:
+        if e.slices > e.true_nus: continue
         qX = e.charge_x
         qXGl = e.charge_x_gl
         # calculate match score

--- a/sbncode/FlashMatch/template_generators/generate_simple_weighted_template.py
+++ b/sbncode/FlashMatch/template_generators/generate_simple_weighted_template.py
@@ -133,8 +133,8 @@ def z_bias(z_skew, hypo_x, z_bias_slope):
 
 def generator(nuslice_tree, rootfile, pset):
     drift_distance = pset.DriftDistance
-    xbin_width = pset.XBinWidth
-    x_bins = int(drift_distance/xbin_width)
+    x_bins = pset.XBins
+    xbin_width = drift_distance/x_bins
     half_bin_width = xbin_width/2.
     y_bias_slope = pset.YBiasSlope
     z_bias_slope = pset.ZBiasSlope


### PR DESCRIPTION
Substantial improvements to discern in-time and out-of-time interactions.

Particularly, interactions occurring on the far half side of the TPCs will be much better matched. Also now _near time_ interactions, eg cosmics that may be synchronous to the beam, will be time-tagged and match.

- Multi-flash matching, allowing many to many matching. At a minimal cost of processing time.
- Completely decoupled the charge and flash computations.
- New fcl parameters to fine tune the module to improve performance, or to aid with commissioning tasks.
- In particular more control to filter small depositions of charge and light
- Enforce flash and charge concurrence
- Metrics are now created with non split slices
- Substantial improvements in the reconstruction of the flash centre: (flash_x, flash_y, flash_z)
- ..... Improved ratio metric construction for ICARUS
- ..... Robuster method to compute `hypo_x_rr` and `hypo_x_ratio`, both show less bias
- ..... Use skew to unbias `flash_y` and `flash_z`, not yet optimised

More details on:
https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=22643

This is the main PR. `sbndcode, icaruscode, sbnd_data, icarus_data` will be updated too, they all depend on this PR.