### PR TITLE
move experiment genie_xsec dependency to sbncode

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -38,7 +38,7 @@ larsoft             v09_27_00
 sbnobj              v09_11_15_01
 sbnanaobj           v09_16_12
 sbndaq_artdaq_core  v0_07_08_of0
-genie_xsec          v3_00_04a
+genie_xsec          v3_00_06
 
 # list products required ONLY for the build
 # any products here must NOT have qualifiers

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -38,7 +38,7 @@ larsoft             v09_27_00
 sbnobj              v09_11_15_01
 sbnanaobj           v09_16_12
 sbndaq_artdaq_core  v0_07_08_of0
-genie_xsec          v3_00_06
+genie_xsec          v3_00_04a
 
 # list products required ONLY for the build
 # any products here must NOT have qualifiers

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -38,6 +38,7 @@ larsoft             v09_27_00
 sbnobj              v09_11_15_01
 sbnanaobj           v09_16_12
 sbndaq_artdaq_core  v0_07_08_of0
+genie_xsec          v3_00_04a
 
 # list products required ONLY for the build
 # any products here must NOT have qualifiers
@@ -46,11 +47,11 @@ cetbuildtools v7_17_01 - only_for_build
 # We now define allowed qualifiers and the corresponding qualifiers for the dependencies.
 # Make the table by adding columns before "notes".
 
-qualifier     larsoft     sbnobj     sbnanaobj  sbndaq_artdaq_core  notes
-e20:debug     e20:debug   e20:debug  e20:debug  e20:debug:s110      -nq-
-e20:prof      e20:prof    e20:prof   e20:prof   e20:prof:s110       -nq-
-c7:debug      c7:debug    c7:debug   c7:debug   c7:debug:s110       -nq-
-c7:prof       c7:prof     c7:prof    c7:prof    c7:prof:s110        -nq-
+qualifier     larsoft     sbnobj     sbnanaobj  sbndaq_artdaq_core genie_xsec               notes
+e20:debug     e20:debug   e20:debug  e20:debug  e20:debug:s110     G1810a0211a:k250:e1000   -nq-
+e20:prof      e20:prof    e20:prof   e20:prof   e20:prof:s110      G1810a0211a:k250:e1000   -nq-
+c7:debug      c7:debug    c7:debug   c7:debug   c7:debug:s110      G1810a0211a:k250:e1000   -nq-
+c7:prof       c7:prof     c7:prof    c7:prof    c7:prof:s110       G1810a0211a:k250:e1000   -nq-
 
 # table fragment to set FW_SEARCH_PATH needed to find XML files:
 table_fragment_begin


### PR DESCRIPTION
This is a request to move experiment genie_xsec dependency to sbncode.
Open issue details:
https://github.com/SBNSoftware/sbncode/issues/15#issuecomment-889241974
Closes #15 
ExperimentPRs:
https://github.com/SBNSoftware/sbndcode/pull/131
https://github.com/SBNSoftware/icaruscode/pull/222