### PR TITLE
Improve bookeeping of not-candidate slices

### DIFF
--- a/sbncode/FlashMatch/FlashPredict.hh
+++ b/sbncode/FlashMatch/FlashPredict.hh
@@ -369,6 +369,7 @@ private:
   static constexpr int kQNoOpHScr = -1;
   static constexpr int kNoChrgScr = -2;
   static constexpr int k0VUVPEScr = -3;
+  static constexpr int kNotANuScr = -4;
   static constexpr int kNoOpHInEvt = -11;
   static constexpr int kNoPFPInEvt = -12;
   static constexpr int kNoSlcInEvt = -13;
@@ -379,7 +380,7 @@ private:
 
     int pfp_bookkeeping, scored_pfp;
     unsigned pfp_to_score, no_charge, no_oph_hits,
-      no_flash_pe;
+      no_flash_pe, no_nu_candidate;
   };
   BookKeeping bk;
 };


### PR DESCRIPTION
Now my module creates associations for every slice, and not just the ones that are potential neutrino candidates.

There will be warnings related to the size of the assns vector, as now there will be more assns than before. The size should be the same as the `recob::Slice` vector.