### PR TITLE
Add missing definition for fmatch

### DIFF
--- a/sbncode/CAFMaker/cafmakerjob_sbnd_fmatch.fcl
+++ b/sbncode/CAFMaker/cafmakerjob_sbnd_fmatch.fcl
@@ -1,3 +1,4 @@
 #include "cafmakerjob_sbnd.fcl"
 
+physics.producers.fmatch: @local::sbnd_simple_flashmatch
 physics.runprod: [fmatch, @sequence::physics.runprod]


### PR DESCRIPTION
The `cafmakerjob_sbnd_fmatch.fcl` was missing the definition of `fmatch`. I suspect this was on `cafmakerjob_sbnd.fcl` but got cleaned away, as it shouldn't have been there since `sbndcode` does run `fmatch` by default.

No changes needed for the `cafmaker_icarus` side of things.