### PR TITLE
Fixing SBND CAF maker fcl 

### DIFF
--- a/fcl/caf/sbnd/cafmakerjob_sbnd.fcl
+++ b/fcl/caf/sbnd/cafmakerjob_sbnd.fcl
@@ -135,3 +135,5 @@ physics.producers.mycafmaker.CosmicGenLabel: "corsika"
 # This job doesn't run the genie weights, and we assume they won't be in the
 # input art file.
 physics.producers.mycafmaker.SystWeightLabels: []
+
+services.BackTrackerService.BackTracker.SimChannelModuleLabel: "simdrift"

--- a/fcl/caf/sbnd/cafmakerjob_sbnd_sce.fcl
+++ b/fcl/caf/sbnd/cafmakerjob_sbnd_sce.fcl
@@ -54,3 +54,4 @@ physics.runprod: [ pandoraTrackMCS, pandoraTrackRange,
 # Enable the Space-Charge service
 #include "enable_spacecharge_services_sbnd.fcl"
 
+services.BackTrackerService.BackTracker.SimChannelModuleLabel: "simdrift"

--- a/fcl/caf/sbnd/cafmakerjob_sbnd_sce.fcl
+++ b/fcl/caf/sbnd/cafmakerjob_sbnd_sce.fcl
@@ -55,3 +55,4 @@ physics.runprod: [ pandoraTrackMCS, pandoraTrackRange,
 #include "enable_spacecharge_services_sbnd.fcl"
 
 services.BackTrackerService.BackTracker.SimChannelModuleLabel: "simdrift"
+physics.producers.mycafmaker.SimChannelLabel: "simdrift"

--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -879,6 +879,7 @@ caf::g4_process_ caf::GetG4ProcessID(const std::string &process_name) {
   MATCH_PROCESS(muPairProd)
   MATCH_PROCESS(hPairProd)
   MATCH_PROCESS(LArVoxelReadoutScoringProcess)
+  MATCH_PROCESS(Transportation)
   std::cerr << "Error: Process name with no match (" << process_name << ")\n";
   assert(false);
   return caf::kG4UNKNOWN; // unreachable in debug mode

--- a/sbncode/PID/Dazzle_module.cc
+++ b/sbncode/PID/Dazzle_module.cc
@@ -89,7 +89,7 @@ class Dazzle : public art::EDProducer {
   art::ServiceHandle<art::TFileService> tfs;
   art::ServiceHandle<cheat::ParticleInventoryService> particleInventory;
 
-  art::InputTag fLArGeantLabel, fPFPLabel, fTrackLabel, fCaloLabel, fMCSLabel, fChi2Label, fRangeLabel, fClosestApproachLabel, fStoppingChi2Label;
+  art::InputTag fLArGeantLabel, fSimChannelLabel, fPFPLabel, fTrackLabel, fCaloLabel, fMCSLabel, fChi2Label, fRangeLabel, fClosestApproachLabel, fStoppingChi2Label;
   const float fMinTrackLength;
   const bool fMakeTree, fRunMVA;
   const std::string fMethodName, fWeightFile;
@@ -157,6 +157,7 @@ class Dazzle : public art::EDProducer {
 Dazzle::Dazzle(fhicl::ParameterSet const& p)
     : EDProducer { p }
     , fLArGeantLabel(p.get<std::string>("LArGeantLabel"))
+    , fSimChannelLabel(p.get<std::string>("SimChannelLabel"))
     , fPFPLabel(p.get<std::string>("PFPLabel"))
     , fTrackLabel(p.get<std::string>("TrackLabel"))
     , fCaloLabel(p.get<std::string>("CaloLabel"))
@@ -321,7 +322,7 @@ void Dazzle::produce(art::Event& e)
 
   auto const pfpHandle(e.getValidHandle<std::vector<recob::PFParticle>>(fPFPLabel));
   auto const clusterHandle(e.getValidHandle<std::vector<recob::Cluster>>(fPFPLabel));
-  auto const simChannelHandle(e.getValidHandle<std::vector<sim::SimChannel>>(fLArGeantLabel));
+  auto const simChannelHandle(e.getValidHandle<std::vector<sim::SimChannel>>(fSimChannelLabel));
   auto const trackHandle(e.getValidHandle<std::vector<recob::Track>>(fTrackLabel));
 
   std::vector<art::Ptr<recob::PFParticle>> pfps;

--- a/sbncode/PID/Dazzle_module.cc
+++ b/sbncode/PID/Dazzle_module.cc
@@ -89,7 +89,7 @@ class Dazzle : public art::EDProducer {
   art::ServiceHandle<art::TFileService> tfs;
   art::ServiceHandle<cheat::ParticleInventoryService> particleInventory;
 
-  art::InputTag fLArGeantLabel, fSimChannelLabel, fPFPLabel, fTrackLabel, fCaloLabel, fMCSLabel, fChi2Label, fRangeLabel, fClosestApproachLabel, fStoppingChi2Label;
+  art::InputTag fSimChannelLabel, fPFPLabel, fTrackLabel, fCaloLabel, fMCSLabel, fChi2Label, fRangeLabel, fClosestApproachLabel, fStoppingChi2Label;
   const float fMinTrackLength;
   const bool fMakeTree, fRunMVA;
   const std::string fMethodName, fWeightFile;
@@ -156,7 +156,6 @@ class Dazzle : public art::EDProducer {
 
 Dazzle::Dazzle(fhicl::ParameterSet const& p)
     : EDProducer { p }
-    , fLArGeantLabel(p.get<std::string>("LArGeantLabel"))
     , fSimChannelLabel(p.get<std::string>("SimChannelLabel"))
     , fPFPLabel(p.get<std::string>("PFPLabel"))
     , fTrackLabel(p.get<std::string>("TrackLabel"))

--- a/sbncode/PID/Razzle_module.cc
+++ b/sbncode/PID/Razzle_module.cc
@@ -83,7 +83,7 @@ class Razzle : public art::EDProducer {
   art::ServiceHandle<art::TFileService> tfs;
   art::ServiceHandle<cheat::ParticleInventoryService> particleInventory;
 
-  art::InputTag fLArGeantLabel, fPFPLabel, fShowerLabel, fShowerSelVarsLabel;
+  art::InputTag fLArGeantLabel, fSimChannelLabel, fPFPLabel, fShowerLabel, fShowerSelVarsLabel;
   const float fMinShowerEnergy;
   const bool fMakeTree, fRunMVA;
   const std::string fMethodName, fWeightFile;
@@ -138,6 +138,7 @@ class Razzle : public art::EDProducer {
 Razzle::Razzle(fhicl::ParameterSet const& p)
     : EDProducer { p }
     , fLArGeantLabel(p.get<std::string>("LArGeantLabel"))
+    , fSimChannelLabel(p.get<std::string>("SimChannelLabel"))
     , fPFPLabel(p.get<std::string>("PFPLabel"))
     , fShowerLabel(p.get<std::string>("ShowerLabel"))
     , fShowerSelVarsLabel(p.get<std::string>("ShowerSelVarsLabel"))
@@ -254,7 +255,7 @@ void Razzle::produce(art::Event& e)
   auto const clockData(art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(e));
 
   auto const pfpHandle(e.getValidHandle<std::vector<recob::PFParticle>>(fPFPLabel));
-  auto const simChannelHandle(e.getValidHandle<std::vector<sim::SimChannel>>(fLArGeantLabel));
+  auto const simChannelHandle(e.getValidHandle<std::vector<sim::SimChannel>>(fSimChannelLabel));
   auto const showerHandle(e.getValidHandle<std::vector<recob::Shower>>(fShowerLabel));
 
   std::vector<art::Ptr<recob::PFParticle>> pfps;

--- a/sbncode/PID/Razzle_module.cc
+++ b/sbncode/PID/Razzle_module.cc
@@ -83,7 +83,7 @@ class Razzle : public art::EDProducer {
   art::ServiceHandle<art::TFileService> tfs;
   art::ServiceHandle<cheat::ParticleInventoryService> particleInventory;
 
-  art::InputTag fLArGeantLabel, fSimChannelLabel, fPFPLabel, fShowerLabel, fShowerSelVarsLabel;
+  art::InputTag fSimChannelLabel, fPFPLabel, fShowerLabel, fShowerSelVarsLabel;
   const float fMinShowerEnergy;
   const bool fMakeTree, fRunMVA;
   const std::string fMethodName, fWeightFile;
@@ -137,7 +137,6 @@ class Razzle : public art::EDProducer {
 
 Razzle::Razzle(fhicl::ParameterSet const& p)
     : EDProducer { p }
-    , fLArGeantLabel(p.get<std::string>("LArGeantLabel"))
     , fSimChannelLabel(p.get<std::string>("SimChannelLabel"))
     , fPFPLabel(p.get<std::string>("PFPLabel"))
     , fShowerLabel(p.get<std::string>("ShowerLabel"))

--- a/sbncode/PID/sbn_pid.fcl
+++ b/sbncode/PID/sbn_pid.fcl
@@ -4,6 +4,7 @@ dazzle:
 {
   module_type:          Dazzle
   LArGeantLabel:        "largeant"
+  SimChannelLabel:      "simdrift"
   PFPLabel:             "pandora"
   TrackLabel:           "pandoraTrack"
   CaloLabel:            "pandoraCalo"
@@ -28,6 +29,7 @@ razzle:
 {
   module_type:         Razzle
   LArGeantLabel:       "largeant"
+  SimChannelLabel:     "simdrift"
   PFPLabel:            "pandora"
   ShowerLabel:         "pandoraShowerSBN"
   ShowerSelVarsLabel:  "pandoraShowerSelectionVars"

--- a/sbncode/PID/sbn_pid.fcl
+++ b/sbncode/PID/sbn_pid.fcl
@@ -3,7 +3,6 @@ BEGIN_PROLOG
 dazzle:
 {
   module_type:          Dazzle
-  LArGeantLabel:        "largeant"
   SimChannelLabel:      "simdrift"
   PFPLabel:             "pandora"
   TrackLabel:           "pandoraTrack"
@@ -28,7 +27,6 @@ dazzle:
 razzle:
 {
   module_type:         Razzle
-  LArGeantLabel:       "largeant"
   SimChannelLabel:     "simdrift"
   PFPLabel:            "pandora"
   ShowerLabel:         "pandoraShowerSBN"


### PR DESCRIPTION
Updated things to call the correct SimChannel label to match the LArG4 migration. 