### PR TITLE
This is a fix for a seg-fault arising from missing MWR devices

### DIFF
--- a/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
@@ -569,9 +569,8 @@ sbn::BNBSpillInfo sbn::BNBRetriever::makeBNBSpillInfo
     beamInfo.M875BB_spill_time_diff = (MWR_times[0][matched_MWR[0]] - time);
   }
 
- if(unpacked_MWR[1].size() == 0){
-    std::vector<int> empty;
-    beamInfo.M876BB = empty;
+ if(unpacked_MWR[1].empty()){
+    beamInfo.M876BB.clear();
     beamInfo.M876BB_spill_time_diff = -999;//units in seconds
  }
  else{

--- a/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
@@ -560,9 +560,8 @@ sbn::BNBSpillInfo sbn::BNBRetriever::makeBNBSpillInfo
     assert(!MWRdata.empty());
   }
 
-  if(unpacked_MWR[0].size() == 0){
-    std::vector<int> empty;
-    beamInfo.M875BB = empty;
+  if(unpacked_MWR[0].empty()){
+    beamInfo.M875BB.clear();
     beamInfo.M875BB_spill_time_diff = -999;//units in seconds
   }
   else{

--- a/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
@@ -560,13 +560,38 @@ sbn::BNBSpillInfo sbn::BNBRetriever::makeBNBSpillInfo
     assert(!MWRdata.empty());
   }
 
-  beamInfo.M875BB = unpacked_MWR[0][matched_MWR[0]];
-  beamInfo.M875BB_spill_time_diff = (MWR_times[0][matched_MWR[0]] - time);
-  beamInfo.M876BB = unpacked_MWR[1][matched_MWR[1]];
-  beamInfo.M876BB_spill_time_diff = (MWR_times[1][matched_MWR[1]] - time);
-  beamInfo.MMBTBB = unpacked_MWR[2][matched_MWR[2]];
-  beamInfo.MMBTBB_spill_time_diff = (MWR_times[2][matched_MWR[2]] - time);
-  
+  if(unpacked_MWR[0].size() == 0){
+    std::vector<int> empty;
+    empty.push_back(0);
+    beamInfo.M875BB = empty;
+    beamInfo.M875BB_spill_time_diff = -999;
+  }
+  else{
+    beamInfo.M875BB = unpacked_MWR[0][matched_MWR[0]];
+    beamInfo.M875BB_spill_time_diff = (MWR_times[0][matched_MWR[0]] - time);
+  }
+
+ if(unpacked_MWR[1].size() == 0){
+    std::vector<int> empty;
+    empty.push_back(0);
+    beamInfo.M876BB = empty;
+    beamInfo.M876BB_spill_time_diff = -999;
+ }
+ else{
+   beamInfo.M876BB = unpacked_MWR[1][matched_MWR[1]];
+   beamInfo.M876BB_spill_time_diff = (MWR_times[1][matched_MWR[1]] - time);
+ }
+
+ if(unpacked_MWR[2].size() == 0){
+    std::vector<int> empty;
+    empty.push_back(0);
+    beamInfo.MMBTBB = empty;
+    beamInfo.MMBTBB_spill_time_diff = -999;
+  }
+ else{
+   beamInfo.MMBTBB = unpacked_MWR[2][matched_MWR[2]];
+   beamInfo.MMBTBB_spill_time_diff = (MWR_times[2][matched_MWR[2]] - time);
+ }
   // We do not write these to the art::Events because 
   // we can filter events but want to keep all the POT 
   // information, so we'll write it to the SubRun

--- a/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
@@ -562,9 +562,8 @@ sbn::BNBSpillInfo sbn::BNBRetriever::makeBNBSpillInfo
 
   if(unpacked_MWR[0].size() == 0){
     std::vector<int> empty;
-    empty.push_back(0);
     beamInfo.M875BB = empty;
-    beamInfo.M875BB_spill_time_diff = -999;
+    beamInfo.M875BB_spill_time_diff = -999;//units in seconds
   }
   else{
     beamInfo.M875BB = unpacked_MWR[0][matched_MWR[0]];
@@ -573,9 +572,8 @@ sbn::BNBSpillInfo sbn::BNBRetriever::makeBNBSpillInfo
 
  if(unpacked_MWR[1].size() == 0){
     std::vector<int> empty;
-    empty.push_back(0);
     beamInfo.M876BB = empty;
-    beamInfo.M876BB_spill_time_diff = -999;
+    beamInfo.M876BB_spill_time_diff = -999;//units in seconds
  }
  else{
    beamInfo.M876BB = unpacked_MWR[1][matched_MWR[1]];
@@ -584,9 +582,8 @@ sbn::BNBSpillInfo sbn::BNBRetriever::makeBNBSpillInfo
 
  if(unpacked_MWR[2].size() == 0){
     std::vector<int> empty;
-    empty.push_back(0);
     beamInfo.MMBTBB = empty;
-    beamInfo.MMBTBB_spill_time_diff = -999;
+    beamInfo.MMBTBB_spill_time_diff = -999;//units in seconds
   }
  else{
    beamInfo.MMBTBB = unpacked_MWR[2][matched_MWR[2]];

--- a/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
@@ -578,9 +578,8 @@ sbn::BNBSpillInfo sbn::BNBRetriever::makeBNBSpillInfo
    beamInfo.M876BB_spill_time_diff = (MWR_times[1][matched_MWR[1]] - time);
  }
 
- if(unpacked_MWR[2].size() == 0){
-    std::vector<int> empty;
-    beamInfo.MMBTBB = empty;
+ if(unpacked_MWR[2].empty()){
+    beamInfo.MMBTBB.clear();
     beamInfo.MMBTBB_spill_time_diff = -999;//units in seconds
   }
  else{


### PR DESCRIPTION
Adding in a quick hot-fix for when the spills aren't matched to any MWR signals, long term this should be looked into but this gets production going. Marking this as a bug fix.