### PR TITLE
change genieweight fhicl, universes 100->20

### DIFF
--- a/sbncode/SBNEventWeight/jobs/genie/eventweight_genie_sbn.fcl
+++ b/sbncode/SBNEventWeight/jobs/genie/eventweight_genie_sbn.fcl
@@ -11,7 +11,7 @@ BEGIN_PROLOG
 
 
 # Choose the desired uiverses number for multisim mode
-n_universes: 100
+n_universes: 20
 
 sbn_eventweight_genie: {
   module_type: "SBNEventWeight"


### PR DESCRIPTION
For current genie weight calculators: it takes 1.5 minute to prepare 50 knob for each universe. This effect is linear such that we can speed up the code by using less universes; say 20, then we only need 30 mins to prepare knobs.