### PR TITLE
Add another globalTree bail out condition for the case where the list of labels is empty

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -394,6 +394,8 @@ void CAFMaker::beginRun(art::Run& run) {
   }
 
 
+  if(fParams.SystWeightLabels().empty()) return; // no need for globalTree
+
   SRGlobal global;
 
   for(const std::string& label: fParams.SystWeightLabels()){


### PR DESCRIPTION
This fixes the "multiple globalTrees in output" problem for job configurations that don't include any reweights. I think that problem is harmless, but aesthetically unappealing, so if this simple fix could sneak in somewhere that would be good.