### PR TITLE
BNBRetriever fix: don't write entries incrementally

### DIFF
--- a/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
@@ -609,7 +609,7 @@ void sbn::BNBRetriever::endSubRun(art::SubRun& sr)
 mf::LogDebug("BNBRetriever")<< "Total number of DAQ Spills : " << TotalBeamSpills << std::endl;
 mf::LogDebug("BNBRetriever")<< "Total number of Selected Spills : " << fOutbeamInfos.size() << std::endl;
 
-  auto p =  std::make_unique< std::vector< sbn::BNBSpillInfo > >(fOutbeamInfos);
+  auto p =  std::make_unique< std::vector< sbn::BNBSpillInfo > >(std::move(fOutbeamInfos));
 
   sr.put(std::move(p), art::subRunFragment());
 

--- a/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
@@ -609,7 +609,8 @@ void sbn::BNBRetriever::endSubRun(art::SubRun& sr)
 mf::LogDebug("BNBRetriever")<< "Total number of DAQ Spills : " << TotalBeamSpills << std::endl;
 mf::LogDebug("BNBRetriever")<< "Total number of Selected Spills : " << fOutbeamInfos.size() << std::endl;
 
-  auto p =  std::make_unique< std::vector< sbn::BNBSpillInfo > >(std::move(fOutbeamInfos));
+  auto p =  std::make_unique< std::vector< sbn::BNBSpillInfo > >();
+  std::swap(*p, fOutbeamInfos);
 
   sr.put(std::move(p), art::subRunFragment());
 


### PR DESCRIPTION
The issue is that the buffer where `sbn::BNBSpillInfo` entries are kept is never emptied.

~The fix I propose is not fully C++-compliant, since after move a `std::vector` is only guaranteed to be destructible, while we keep reusing it assuming it empty. Adding a `fOutbeamInfos = {};` would make it compliant, but it's just too ugly for me to bear (science!).~ _Edit: checking back the C++17 standard and the common Internet lore, it appears that additional guarantees are provided for STL containers after the move and that the change is actually compliant._

**Important**: this is GitHub coding: I haven't even tried to compile it. C.I. test is imperative here.

**Note**: this pull request is to `develop`; it needs to be merged into the proper 2021C production branch too.