### PR TITLE
POT Accounting in CAFs using BNB Retriever module

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -60,8 +60,8 @@ namespace caf
       Comment("List of suffixes to add to TPC reco tag names (e.g. cryo0 cryo1)")
     };
 
-    Atom<string> POTDataLabel {
-      Name("POTDataLabel"),
+    Atom<string> BNBPOTDataLabel {
+      Name("BNBPOTDataLabel"),
       Comment("Label of BNBRetriever module"),
       "bnbinfo"
     };

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -60,6 +60,12 @@ namespace caf
       Comment("List of suffixes to add to TPC reco tag names (e.g. cryo0 cryo1)")
     };
 
+    Atom<string> POTDataLabel {
+      Name("POTDataLabel"),
+      Comment("Label of BNBRetriever module"),
+      "bnbinfo"
+    };
+
     Atom<string> G4Label {
       Name("G4Label"),
       Comment("Label of G4 module."),

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -451,9 +451,9 @@ void CAFMaker::beginSubRun(art::SubRun& sr) {
     fBNBInfo.clear();
     fSubRunPOT = 0;
     art::Handle<std::vector<sbn::BNBSpillInfo> > bnb_spill;
-    sr.getByLabel(fParams.POTDataLabel(), bnb_spill);
-    std::vector<art::Ptr<sbn::BNBSpillInfo> >  bnb_spill_info;
+    sr.getByLabel(fParams.BNBPOTDataLabel(), bnb_spill);
     if (bnb_spill.isValid()) {
+      std::vector<art::Ptr<sbn::BNBSpillInfo> >  bnb_spill_info;
       art::fill_ptr_vector(bnb_spill_info, bnb_spill);
       FillExposure(bnb_spill_info, fBNBInfo, fSubRunPOT);
       fTotalPOT += fSubRunPOT;
@@ -1409,10 +1409,10 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   StandardRecord* prec = &rec;
   fRecTree->SetBranchAddress("rec", &prec);
   fRecTree->Fill();
-  fBNBInfo.clear();
-  rec.hdr.pot = 0;
   srcol->push_back(rec);
   evt.put(std::move(srcol));
+  fBNBInfo.clear();
+  rec.hdr.pot = 0;
 }
 
 void CAFMaker::endSubRun(art::SubRun& sr) {

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -99,6 +99,7 @@
 #include "sbnobj/Common/Reco/MVAPID.h"
 #include "sbnobj/Common/Reco/ScatterClosestApproach.h"
 #include "sbnobj/Common/Reco/StoppingChi2Fit.h"
+#include "sbnobj/Common/POTAccounting/BNBSpillInfo.h"
 
 #include "canvas/Persistency/Provenance/ProcessConfiguration.h"
 #include "larcoreobj/SummaryData/POTSummary.h"
@@ -167,6 +168,7 @@ class CAFMaker : public art::EDProducer {
   double fSubRunPOT;
   double fTotalSinglePOT;
   double fTotalEvents;
+  std::vector<caf::SRBNBInfo> bnb_info_store;
   // int fCycle;
   // int fBatch;
 
@@ -443,12 +445,56 @@ void CAFMaker::beginRun(art::Run& run) {
 void CAFMaker::beginSubRun(art::SubRun& sr) {
   // get the POT
   // get POT information
-  art::Handle<sumdata::POTSummary> pot_handle;
-  sr.getByLabel("generator", pot_handle);
-
-  if (pot_handle.isValid()) {
-    fSubRunPOT = pot_handle->totgoodpot;
-    fTotalPOT += fSubRunPOT;
+  fIsRealData = true;
+  if(fIsRealData)
+  {
+    bnb_info_store.clear();
+    fSubRunPOT = 0;
+    art::Handle<std::vector<sbn::BNBSpillInfo> > bnb_spill;
+    sr.getByLabel("bnbinfo", bnb_spill);
+    std::vector<art::Ptr<sbn::BNBSpillInfo> >  bnb_spill_info;
+    if (bnb_spill.isValid()) {
+      art::fill_ptr_vector(bnb_spill_info, bnb_spill);
+      for(unsigned int i = 0; i < bnb_spill_info.size(); ++i)
+      {
+	caf::SRBNBInfo single_store;
+	fSubRunPOT += bnb_spill_info[i]->TOR875;
+	fTotalPOT += bnb_spill_info[i]->TOR875;
+	single_store.spill_time_sec = bnb_spill_info[i]->spill_time_s;
+	single_store.spill_time_nsec = bnb_spill_info[i]->spill_time_ns;
+	single_store.event = bnb_spill_info[i]->event;
+	single_store.TOR860 = bnb_spill_info[i]->TOR860;
+	single_store.TOR875 = bnb_spill_info[i]->TOR875;
+	single_store.LM875A = bnb_spill_info[i]->LM875A;
+	single_store.LM875B = bnb_spill_info[i]->LM875B;
+	single_store.LM875C = bnb_spill_info[i]->LM875C;
+	single_store.HP875 = bnb_spill_info[i]->HP875;
+	single_store.VP875 = bnb_spill_info[i]->VP875;
+	single_store.HPTG1 = bnb_spill_info[i]->HPTG1;
+	single_store.VPTG1 = bnb_spill_info[i]->VPTG1;
+	single_store.HPTG2 = bnb_spill_info[i]->HPTG2;
+	single_store.VPTG2 = bnb_spill_info[i]->VPTG2;
+	single_store.BTJT2 = bnb_spill_info[i]->BTJT2;
+	single_store.THCURR = bnb_spill_info[i]->THCURR;
+	single_store.M875BB = bnb_spill_info[i]->M875BB;
+	single_store.M876BB = bnb_spill_info[i]->M876BB;
+	single_store.MMBTBB = bnb_spill_info[i]->MMBTBB;
+	single_store.M875BB_spill_time_diff = bnb_spill_info[i]->M875BB_spill_time_diff;
+	single_store.M876BB_spill_time_diff = bnb_spill_info[i]->M876BB_spill_time_diff;
+	single_store.MMBTBB_spill_time_diff = bnb_spill_info[i]->MMBTBB_spill_time_diff;
+	bnb_info_store.push_back(single_store);
+      }
+    }
+  }
+  else
+  {
+    art::Handle<sumdata::POTSummary> pot_handle;
+    sr.getByLabel("generator", pot_handle);
+    
+    if (pot_handle.isValid()) {
+      fSubRunPOT = pot_handle->totgoodpot;
+      fTotalPOT += fSubRunPOT;
+    }
   }
   std::cout << "POT: " << fSubRunPOT << std::endl;
 
@@ -1368,6 +1414,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   rec.hdr.det     = fDet;
   rec.hdr.fno     = fFileNumber;
   rec.hdr.pot     = fSubRunPOT;
+  if(fIsRealData)
+    rec.hdr.bnbinfo = bnb_info_store;
   rec.hdr.ngenevt = n_gen_evt;
   rec.hdr.mctype  = mctype;
   rec.hdr.first_in_file = fFirstInFile;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -446,16 +446,14 @@ void CAFMaker::beginRun(art::Run& run) {
 void CAFMaker::beginSubRun(art::SubRun& sr) {
   // get the POT
   // get POT information
+  fBNBInfo.clear();
+  fSubRunPOT = 0;
+  auto bnb_spill = sr.getHandle<std::vector<sbn::BNBSpillInfo>>(fParams.BNBPOTDataLabel());
+  fIsRealData = bnb_spill.isValid();
   if(fIsRealData)
-  {
-    fBNBInfo.clear();
-    fSubRunPOT = 0;
-    art::Handle<std::vector<sbn::BNBSpillInfo> > bnb_spill;
-    sr.getByLabel(fParams.BNBPOTDataLabel(), bnb_spill);
+    {
     if (bnb_spill.isValid()) {
-      std::vector<art::Ptr<sbn::BNBSpillInfo> >  bnb_spill_info;
-      art::fill_ptr_vector(bnb_spill_info, bnb_spill);
-      FillExposure(bnb_spill_info, fBNBInfo, fSubRunPOT);
+      FillExposure(*bnb_spill, fBNBInfo, fSubRunPOT);
       fTotalPOT += fSubRunPOT;
     }
   }

--- a/sbncode/CAFMaker/FillExposure.cxx
+++ b/sbncode/CAFMaker/FillExposure.cxx
@@ -3,37 +3,43 @@
 
 namespace caf
 {
-  void FillExposure(const std::vector<art::Ptr<sbn::BNBSpillInfo> > bnb_spill_info,
+
+  caf::SRBNBInfo makeSRBNBInfo(sbn::BNBSpillInfo const& info)
+  {
+    caf::SRBNBInfo single_store;
+    single_store.spill_time_sec = info.spill_time_s;
+    single_store.spill_time_nsec = info.spill_time_ns;
+    single_store.event = info.event;
+    single_store.TOR860 = info.TOR860;
+    single_store.TOR875 = info.TOR875;
+    single_store.LM875A = info.LM875A;
+    single_store.LM875B = info.LM875B;
+    single_store.LM875C = info.LM875C;
+    single_store.HP875 = info.HP875;
+    single_store.VP875 = info.VP875;
+    single_store.HPTG1 = info.HPTG1;
+    single_store.VPTG1 = info.VPTG1;
+    single_store.HPTG2 = info.HPTG2;
+    single_store.VPTG2 = info.VPTG2;
+    single_store.BTJT2 = info.BTJT2;
+    single_store.THCURR = info.THCURR;
+    single_store.M875BB = info.M875BB;
+    single_store.M876BB = info.M876BB;
+    single_store.MMBTBB = info.MMBTBB;
+    single_store.M875BB_spill_time_diff = info.M875BB_spill_time_diff;
+    single_store.M876BB_spill_time_diff = info.M876BB_spill_time_diff;
+    single_store.MMBTBB_spill_time_diff = info.MMBTBB_spill_time_diff;
+    return single_store;
+  }
+
+  void FillExposure(const std::vector<sbn::BNBSpillInfo>& bnb_spill_info,
 		    std::vector<caf::SRBNBInfo>& BNBInfo,
 		    double& subRunPOT)
   {
-    for(const art::Ptr<sbn::BNBSpillInfo>& info: bnb_spill_info)
+    for(const sbn::BNBSpillInfo& info: bnb_spill_info)
       {
-	caf::SRBNBInfo single_store;
-        subRunPOT += info->TOR875;
-        single_store.spill_time_sec = info->spill_time_s;
-        single_store.spill_time_nsec = info->spill_time_ns;
-        single_store.event = info->event;
-        single_store.TOR860 = info->TOR860;
-        single_store.TOR875 = info->TOR875;
-        single_store.LM875A = info->LM875A;
-        single_store.LM875B = info->LM875B;
-        single_store.LM875C = info->LM875C;
-        single_store.HP875 = info->HP875;
-        single_store.VP875 = info->VP875;
-        single_store.HPTG1 = info->HPTG1;
-        single_store.VPTG1 = info->VPTG1;
-        single_store.HPTG2 = info->HPTG2;
-        single_store.VPTG2 = info->VPTG2;
-        single_store.BTJT2 = info->BTJT2;
-        single_store.THCURR = info->THCURR;
-        single_store.M875BB = info->M875BB;
-        single_store.M876BB = info->M876BB;
-        single_store.MMBTBB = info->MMBTBB;
-        single_store.M875BB_spill_time_diff = info->M875BB_spill_time_diff;
-	single_store.M876BB_spill_time_diff = info->M876BB_spill_time_diff;
-        single_store.MMBTBB_spill_time_diff = info->MMBTBB_spill_time_diff;
-        BNBInfo.push_back(single_store);
+	subRunPOT += info.TOR875;
+        BNBInfo.push_back(makeSRBNBInfo(info));
       }
   }
 }

--- a/sbncode/CAFMaker/FillExposure.cxx
+++ b/sbncode/CAFMaker/FillExposure.cxx
@@ -1,0 +1,39 @@
+
+#include "FillExposure.h"
+
+namespace caf
+{
+  void FillExposure(const std::vector<art::Ptr<sbn::BNBSpillInfo> > bnb_spill_info,
+		    std::vector<caf::SRBNBInfo>& BNBInfo,
+		    double& subRunPOT)
+  {
+    for(const art::Ptr<sbn::BNBSpillInfo>& info: bnb_spill_info)
+      {
+	caf::SRBNBInfo single_store;
+        subRunPOT += info->TOR875;
+        single_store.spill_time_sec = info->spill_time_s;
+        single_store.spill_time_nsec = info->spill_time_ns;
+        single_store.event = info->event;
+        single_store.TOR860 = info->TOR860;
+        single_store.TOR875 = info->TOR875;
+        single_store.LM875A = info->LM875A;
+        single_store.LM875B = info->LM875B;
+        single_store.LM875C = info->LM875C;
+        single_store.HP875 = info->HP875;
+        single_store.VP875 = info->VP875;
+        single_store.HPTG1 = info->HPTG1;
+        single_store.VPTG1 = info->VPTG1;
+        single_store.HPTG2 = info->HPTG2;
+        single_store.VPTG2 = info->VPTG2;
+        single_store.BTJT2 = info->BTJT2;
+        single_store.THCURR = info->THCURR;
+        single_store.M875BB = info->M875BB;
+        single_store.M876BB = info->M876BB;
+        single_store.MMBTBB = info->MMBTBB;
+        single_store.M875BB_spill_time_diff = info->M875BB_spill_time_diff;
+	single_store.M876BB_spill_time_diff = info->M876BB_spill_time_diff;
+        single_store.MMBTBB_spill_time_diff = info->MMBTBB_spill_time_diff;
+        BNBInfo.push_back(single_store);
+      }
+  }
+}

--- a/sbncode/CAFMaker/FillExposure.cxx
+++ b/sbncode/CAFMaker/FillExposure.cxx
@@ -38,7 +38,7 @@ namespace caf
   {
     for(const sbn::BNBSpillInfo& info: bnb_spill_info)
       {
-	subRunPOT += info.TOR875;
+	subRunPOT += info.POT();
         BNBInfo.push_back(makeSRBNBInfo(info));
       }
   }

--- a/sbncode/CAFMaker/FillExposure.cxx
+++ b/sbncode/CAFMaker/FillExposure.cxx
@@ -1,5 +1,5 @@
 
-#include "FillExposure.h"
+#include "sbncode/CAFMaker/FillExposure.h"
 
 namespace caf
 {

--- a/sbncode/CAFMaker/FillExposure.h
+++ b/sbncode/CAFMaker/FillExposure.h
@@ -1,15 +1,7 @@
 #ifndef CAF_FILLEXPOSURE_H
 #define CAF_FILLEXPOSURE_H
 
-#include "art/Framework/Core/EDProducer.h"
-#include "art/Framework/Core/FileBlock.h"
-#include "art/Framework/Core/ModuleMacros.h"
-#include "art/Framework/Principal/Event.h"
-#include "art/Framework/Principal/Handle.h"
-#include "art/Framework/Principal/SubRun.h"
-
-#include "sbnanaobj/StandardRecord/StandardRecord.h"
-#include "sbnanaobj/StandardRecord/SRHeader.h"
+#include "canvas/Persistency/Common/Ptr.h"
 #include "sbnanaobj/StandardRecord/SRBNBInfo.h"
 #include "sbnobj/Common/POTAccounting/BNBSpillInfo.h"
 #include <vector>

--- a/sbncode/CAFMaker/FillExposure.h
+++ b/sbncode/CAFMaker/FillExposure.h
@@ -1,0 +1,25 @@
+#ifndef CAF_FILLEXPOSURE_H
+#define CAF_FILLEXPOSURE_H
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/FileBlock.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/SubRun.h"
+
+#include "sbnanaobj/StandardRecord/StandardRecord.h"
+#include "sbnanaobj/StandardRecord/SRHeader.h"
+#include "sbnanaobj/StandardRecord/SRBNBInfo.h"
+#include "sbnobj/Common/POTAccounting/BNBSpillInfo.h"
+#include <vector>
+
+namespace caf
+{
+  void FillExposure(const std::vector<art::Ptr<sbn::BNBSpillInfo> > bnb_spill_info,
+		    std::vector<caf::SRBNBInfo>& BNBInfo,
+		    double& subRunPOT);
+  
+}
+
+#endif

--- a/sbncode/CAFMaker/FillExposure.h
+++ b/sbncode/CAFMaker/FillExposure.h
@@ -1,16 +1,17 @@
 #ifndef CAF_FILLEXPOSURE_H
 #define CAF_FILLEXPOSURE_H
 
-#include "canvas/Persistency/Common/Ptr.h"
 #include "sbnanaobj/StandardRecord/SRBNBInfo.h"
 #include "sbnobj/Common/POTAccounting/BNBSpillInfo.h"
 #include <vector>
 
 namespace caf
 {
-  void FillExposure(const std::vector<art::Ptr<sbn::BNBSpillInfo> > bnb_spill_info,
+  void FillExposure(const std::vector<sbn::BNBSpillInfo>& bnb_spill_info,
 		    std::vector<caf::SRBNBInfo>& BNBInfo,
 		    double& subRunPOT);
+
+  caf::SRBNBInfo makeSRBNBInfo(sbn::BNBSpillInfo const& info);
   
 }
 


### PR DESCRIPTION
Adding POT Accounting to CAFs usign output of BNBRetriever module. Fills in SRHeader with one entry per event. More ideal is an entry per subrun.