### PR TITLE
Light sim+reco updates for SBN2022A release

### DIFF
--- a/sbncode/OpT0Finder/flashmatch/Algorithms/CMakeLists.txt
+++ b/sbncode/OpT0Finder/flashmatch/Algorithms/CMakeLists.txt
@@ -7,7 +7,8 @@ art_make(
         larsim_PhotonPropagation
         larsim_PhotonPropagation_PhotonVisibilityService_service
         larsim_LegacyLArG4
-        sbncode_OpT0Finder_flashmatch_GeoAlgo
+        larcorealg_GeoAlgo
+        # sbncode_OpT0Finder_flashmatch_GeoAlgo
         sbncode_OpT0Finder_flashmatch_Base
         ${ART_FRAMEWORK_CORE}
         ${ART_FRAMEWORK_PRINCIPAL}

--- a/sbncode/OpT0Finder/flashmatch/Algorithms/LightPath.h
+++ b/sbncode/OpT0Finder/flashmatch/Algorithms/LightPath.h
@@ -24,10 +24,10 @@
 #include "flashmatch/Base/CustomAlgoFactory.h"
 #include "flashmatch/GeoAlgo/GeoTrajectory.h"
 #else
-#include "sbncode/OpT0Finder/flashmatch/GeoAlgo/GeoTrajectory.h"
+#include "larcorealg/GeoAlgo/GeoTrajectory.h"
 #include "sbncode/OpT0Finder/flashmatch/Base/BaseAlgorithm.h"
 #include "sbncode/OpT0Finder/flashmatch/Base/CustomAlgoFactory.h"
-#include "sbncode/OpT0Finder/flashmatch/GeoAlgo/GeoTrajectory.h"
+#include "larcorealg/GeoAlgo/GeoTrajectory.h"
 #endif
 
 #include <iostream>

--- a/sbncode/OpT0Finder/flashmatch/Algorithms/PhotonLibHypothesis.h
+++ b/sbncode/OpT0Finder/flashmatch/Algorithms/PhotonLibHypothesis.h
@@ -29,7 +29,6 @@
 #include "sbncode/OpT0Finder/flashmatch/Base/FMWKInterface.h"
 #include "sbncode/OpT0Finder/flashmatch/Base/BaseFlashFilter.h"
 #include "sbncode/OpT0Finder/flashmatch/Base/FlashHypothesisFactory.h"
-#include "larsim/LegacyLArG4/OpFastScintillation.hh"
 #endif
 
 #include <iostream>
@@ -70,7 +69,6 @@ namespace flashmatch {
     std::vector<double> _qe_v;     ///< PMT-wise relative QE
     bool _use_semi_analytical;     ///< If the semi-analytical approach should be used
     #if USING_LARSOFT == 1
-    larg4::OpFastScintillation* _opfast_scintillation; ///< For SBND semi-analytical
     phot::PhotonVisibilityService const* const _vis;
     #endif
   };

--- a/sbncode/OpT0Finder/flashmatch/Base/BaseFlashHypothesis.h
+++ b/sbncode/OpT0Finder/flashmatch/Base/BaseFlashHypothesis.h
@@ -16,6 +16,10 @@
 
 #include "BaseAlgorithm.h"
 
+#if USING_LARSOFT == 1
+#include "larsim/PhotonPropagation/SemiAnalyticalModel.h"
+#endif
+
 namespace flashmatch {
   /**
      \class FlashHypothesis
@@ -46,10 +50,19 @@ namespace flashmatch {
     /// Sets the channels sensitive to visible light
     void SetUncoatedPMTs(std::vector<int> ch_uncoated) { _uncoated_pmt_list = ch_uncoated; }
 
+    #if USING_LARSOFT == 1
+    /// Sets the semi analytical model
+    void SetSemiAnalyticalModel(std::unique_ptr<SemiAnalyticalModel> model) { _semi_model = std::move(model); }
+    #endif
+
   protected:
 
     std::vector<int> _channel_mask; ///< The list of channels to use
     std::vector<int> _uncoated_pmt_list; ///< A list of opdet sensitive to visible (reflected) light
+
+    #if USING_LARSOFT == 1
+    std::unique_ptr<SemiAnalyticalModel> _semi_model;
+    #endif
 
   };
 }

--- a/sbncode/OpT0Finder/flashmatch/Base/CMakeLists.txt
+++ b/sbncode/OpT0Finder/flashmatch/Base/CMakeLists.txt
@@ -2,7 +2,8 @@ set( ROOTLIB -L$ENV{ROOTSYS}/lib -lCore  -lRIO -lNet -lHist -lGraf -lGraf3d -lGp
 link_libraries( ${LIB_NAME} -L$ENV{BOOST_LIB} ${ROOTLIB} )
 art_make(
     LIB_LIBRARIES
-        sbncode_OpT0Finder_flashmatch_GeoAlgo
+        larcorealg_GeoAlgo
+        # sbncode_OpT0Finder_flashmatch_GeoAlgo
         larcorealg_Geometry
         larcore_Geometry_Geometry_service
         lardataalg_DetectorInfo

--- a/sbncode/OpT0Finder/flashmatch/Base/FMWKInterface.cxx
+++ b/sbncode/OpT0Finder/flashmatch/Base/FMWKInterface.cxx
@@ -76,7 +76,7 @@ namespace flashmatch{
     _drift_velocity = det_prop.DriftVelocity();
     _pmt_v.clear();
 
-    _pmt_v.reserve(geo->NOpDets());
+    _pmt_v.resize(geo->NOpDets());
 
     for (size_t opdet = 0; opdet < geo->NOpDets(); opdet++) {
 
@@ -84,12 +84,14 @@ namespace flashmatch{
       geo->OpDetGeoFromOpDet(opdet).GetCenter(&pos[0]);
 
       geoalgo::Point_t pmt(pos);
-      _pmt_v.push_back(pmt);
+      _pmt_v[opdet] = pmt;
     }
 
     double global_x_min = 1e9, global_x_max = -1e9;
     double global_y_min = 1e9, global_y_max = -1e9;
     double global_z_min = 1e9, global_z_max = -1e9;
+
+    _bbox_map.reserve(geo->Ncryostats() * geo->NTPC());
 
     for (size_t cryo = 0; cryo < geo->Ncryostats(); cryo++) {
       for (size_t tpc = 0; tpc < geo->NTPC(cryo); tpc++) {
@@ -110,8 +112,7 @@ namespace flashmatch{
         if (z_min < global_z_min) global_z_min = z_min;
         if (z_max > global_z_max) global_z_max = z_max;
 
-        auto pair = std::pair<int,int>(tpc, cryo);
-        _bbox_map[pair] = geoalgo::AABox(x_min, y_min, z_min, x_max, y_max, z_max);
+        _bbox_map.emplace(std::make_pair(tpc, cryo), geoalgo::AABox(x_min, y_min, z_min, x_max, y_max, z_max));
       }
 
       _bbox = geoalgo::AABox(global_x_min, global_y_min, global_z_min,

--- a/sbncode/OpT0Finder/flashmatch/Base/FMWKInterface.h
+++ b/sbncode/OpT0Finder/flashmatch/Base/FMWKInterface.h
@@ -17,7 +17,8 @@ namespace flashmatch {
   using Config_t = flashmatch::PSet;
 }
 #else
-#include "sbncode/OpT0Finder/flashmatch/GeoAlgo/GeoAABox.h"
+// #include "sbncode/OpT0Finder/flashmatch/GeoAlgo/GeoAABox.h"
+#include "larcorealg/GeoAlgo/GeoAABox.h"
 #include "OpT0FinderException.h"
 #include "OpT0FinderLogger.h"
 #include "fhiclcpp/ParameterSet.h"

--- a/sbncode/OpT0Finder/flashmatch/Base/FMWKInterface.h
+++ b/sbncode/OpT0Finder/flashmatch/Base/FMWKInterface.h
@@ -5,6 +5,9 @@
 #define USING_LARSOFT 1
 #endif
 
+#include <unordered_map>
+#include <boost/functional/hash.hpp>
+
 #if USING_LARSOFT == 0
 #include "FMWKTools/ConfigManager.h"
 #include "flashmatch/GeoAlgo/GeoAABox.h"
@@ -76,7 +79,7 @@ namespace flashmatch {
     static DetectorSpecs* _me;
     std::vector<geoalgo::Point_t> _pmt_v;
     geoalgo::AABox _bbox;
-    std::map<std::pair<int, int>, geoalgo::AABox> _bbox_map; ///< A bbox map (cryo,tpc) -> bbox
+    std::unordered_map<std::pair<int, int>, geoalgo::AABox, boost::hash<std::pair<int, int>>> _bbox_map; ///< A bbox map (cryo,tpc) -> bbox
     double _drift_velocity;
     #if USING_LARSOFT == 0
     sim::PhotonVoxelDef _voxel_def;

--- a/sbncode/OpT0Finder/flashmatch/Base/FlashMatchManager.cxx
+++ b/sbncode/OpT0Finder/flashmatch/Base/FlashMatchManager.cxx
@@ -401,6 +401,13 @@ namespace flashmatch {
     }
   }
 
+  #if USING_LARSOFT == 1
+  void FlashMatchManager::SetSemiAnalyticalModel(std::unique_ptr<SemiAnalyticalModel> model) {
+    if (_alg_flash_hypothesis) {
+      _alg_flash_hypothesis->SetSemiAnalyticalModel(std::move(model));
+    }
+  }
+  #endif
 
 }
 

--- a/sbncode/OpT0Finder/flashmatch/Base/FlashMatchManager.h
+++ b/sbncode/OpT0Finder/flashmatch/Base/FlashMatchManager.h
@@ -102,6 +102,10 @@ namespace flashmatch {
     /// Sets the channels sensitive to visible light
     void SetUncoatedPMTs(std::vector<int> ch_uncoated);
 
+    #if USING_LARSOFT == 1
+    void SetSemiAnalyticalModel(std::unique_ptr<SemiAnalyticalModel> model);
+    #endif
+
   private:
 
     void AddCustomAlgo(BaseAlgorithm* alg);

--- a/sbncode/OpT0Finder/flashmatch/CMakeLists.txt
+++ b/sbncode/OpT0Finder/flashmatch/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_subdirectory(GeoAlgo)
+# add_subdirectory(GeoAlgo) # Already in larcorealg
 add_subdirectory(Base)
 add_subdirectory(Algorithms)


### PR DESCRIPTION
This PR contains the light simulation and reconstruction updates for the SBN2022A release, cherry-picking the required commits to allow compatibility with the SBN2021C branch. Commits taken from:
* https://github.com/SBNSoftware/sbncode/pull/227 (OpT0Finder)

Requires https://github.com/SBNSoftware/sbndcode/pull/253 and https://github.com/LArSoft/larsim/pull/84.