### PR TITLE
Saving CRT T0 instead of T1 in CAF

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -237,12 +237,14 @@ namespace caf
 
     Atom<long long> CRTSimT0Offset {
       Name("CRTSimT0Offset"),
-      Comment("start of beam gate/simulation time in the simulated CRT clock")
+      Comment("start of beam gate/simulation time in the simulated CRT clock"),
+      0,
     };
 
     Atom<art::InputTag> TriggerLabel {
       Name("TriggerLabel"),
-      Comment("Label of trigger.")
+      Comment("Label of trigger."),
+      "daqTrigger"
     };
 
     Atom<string> FlashTrigLabel {

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -249,7 +249,7 @@ namespace caf
     Atom<bool> CRTUseTS0 {
       Name("CRTUseTS0"),
       Comment("Whether to use ts0 or ts1 to fill the time of the SRCRTHit and SRCRTTrack"),
-      true
+      false
     };
 
     Atom<string> SimChannelLabel {

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -234,8 +234,13 @@ namespace caf
       Comment("Label of sbn CRT tracks."),
       "crttrack" // same for icarus and sbnd
     };
-    
-    Atom<string> TriggerLabel {
+
+    Atom<long long> CRTSimT0Offset {
+      Name("CRTSimT0Offset"),
+      Comment("start of beam gate/simulation time in the simulated CRT clock")
+    };
+
+    Atom<art::InputTag> TriggerLabel {
       Name("TriggerLabel"),
       Comment("Label of trigger.")
     };

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -235,6 +235,11 @@ namespace caf
       "crttrack" // same for icarus and sbnd
     };
     
+    Atom<string> TriggerLabel {
+      Name("TriggerLabel"),
+      Comment("Label of trigger.")
+    };
+
     Atom<string> FlashTrigLabel {
       Name("FlashTrigLabel"),
       Comment("Label of bool of passing flash trigger."),
@@ -244,7 +249,7 @@ namespace caf
     Atom<bool> CRTUseTS0 {
       Name("CRTUseTS0"),
       Comment("Whether to use ts0 or ts1 to fill the time of the SRCRTHit and SRCRTTrack"),
-      false
+      true
     };
 
     Atom<string> SimChannelLabel {

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1015,7 +1015,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   if (crthits_handle.isValid()) {
 
     //==== gate start time
-    long long m_gate_start_timestamp = 0;
+    long long m_gate_start_timestamp = 1600000;
     if(isRealData){
 
       art::Handle< std::vector<raw::ExternalTrigger> > externalTrigger_handle;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -113,6 +113,7 @@
 #include "sbnanaobj/StandardRecord/SRGlobal.h"
 
 #include "sbnanaobj/StandardRecord/Flat/FlatRecord.h"
+#include "icaruscode/Decode/DataProducts/ExtraTriggerInfo.h"
 
 // // CAFMaker
 #include "sbncode/CAFMaker/AssociationUtil.h"
@@ -1010,10 +1011,19 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   GetByLabelStrict(evt, fParams.CRTHitLabel(), crthits_handle);
   // fill into event
   if (crthits_handle.isValid()) {
+
+    //==== gate start time
+    uint64_t m_gate_start_timestamp = 0;
+    if(isRealData){
+      art::Handle<sbn::ExtraTriggerInfo> trigger_handle;
+      evt.getByLabel( fParams.TriggerLabel(), trigger_handle );
+      m_gate_start_timestamp = trigger_handle->beamGateTimestamp;
+    }
+
     const std::vector<sbn::crt::CRTHit> &crthits = *crthits_handle;
     for (unsigned i = 0; i < crthits.size(); i++) {
       srcrthits.emplace_back();
-      FillCRTHit(crthits[i], fParams.CRTUseTS0(), srcrthits.back());
+      FillCRTHit(crthits[i], m_gate_start_timestamp, fParams.CRTUseTS0(), srcrthits.back());
     }
   }
 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1033,13 +1033,6 @@ void CAFMaker::produce(art::Event& evt) noexcept {
         double TriggerRelativeTime = trgs[0].TriggerTime(); // Trigger time w.r.t. electronics clock T0 in us
         m_gate_start_timestamp = TriggerAbsoluteTime + (int)(BeamGateRelativeTime*1000-TriggerRelativeTime*1000);
       }
-      /*
-      04/02/22: use this when we understand the relation between trigger and event time better
-      else if(trgs.empty()){
-        //==== When trigger is not available, use the event timestamp
-        m_gate_start_timestamp = evt.time().timeHigh() * 1'000'000'000LL + evt.time().timeLow();
-      }
-      */
       else{
         std::cout << "Unexpected in " << evt.id() << ": there are " << trgs.size()
           << " triggers in '" << fParams.TriggerLabel().encode() << "' data product."

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1015,7 +1015,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   if (crthits_handle.isValid()) {
 
     //==== gate start time
-    long long m_gate_start_timestamp = 1600000;
+    long long m_gate_start_timestamp = 1600000; // 03/31/22: This is current MC default shift, 1600 us
     if(isRealData){
 
       art::Handle< std::vector<raw::ExternalTrigger> > externalTrigger_handle;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1015,7 +1015,9 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   if (crthits_handle.isValid()) {
 
     //==== gate start time
-    long long m_gate_start_timestamp = 1600000; // 03/31/22: This is current MC default shift, 1600 us
+    //==== 03/31/22 : 1600000 ns = 1.6 ms is the default T0Offset in MC
+    //==== https://github.com/SBNSoftware/icaruscode/blob/v09_37_02_01/icaruscode/CRT/crtsimmodules_icarus.fcl#L11
+    long long m_gate_start_timestamp = 1600000; // ns
     if(isRealData){
 
       art::Handle< std::vector<raw::ExternalTrigger> > externalTrigger_handle;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -68,7 +68,7 @@ namespace caf
 
     srhit.time = (use_ts0 ? (float)hit.ts0_ns : hit.ts1_ns) / 1000.;
     srhit.t0 = (long long)(hit.ts0_ns-gate_start_timestamp)/1000.;
-    srhit.t1 = (long long)(hit.ts1_ns-gate_start_timestamp)/1000.;
+    srhit.t1 = hit.ts1_ns/1000.;
 
     srhit.position.x = hit.x_pos;
     srhit.position.y = hit.y_pos;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -70,10 +70,11 @@ namespace caf
 
     if(use_ts0){
       if(gate_start_timestamp>0){
-        srhit.time = -((gate_start_timestamp-hit.ts0_ns)/1e3)+1e6; // us
+        long long tmp_crttime = hit.ts0_ns-gate_start_timestamp; // ns
+        srhit.time = (float)tmp_crttime/1000.; // ns->us
       }
       else{
-        srhit.time = hit.ts0_ns/1e3-1600;
+        srhit.time = hit.ts0_ns/1000.-1600.;
       }
     }
     else{

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -67,7 +67,7 @@ namespace caf
                   bool allowEmpty) {
 
     srhit.time = (use_ts0 ? (float)hit.ts0_ns : hit.ts1_ns) / 1000.;
-    srhit.t0 = (long long)(hit.ts0_ns-gate_start_timestamp)/1000.;
+    srhit.t0 = ((long long)(hit.ts0_ns)-(long long)(gate_start_timestamp))/1000.;
     srhit.t1 = hit.ts1_ns/1000.;
 
     srhit.position.x = hit.x_pos;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -66,27 +66,9 @@ namespace caf
                   caf::SRCRTHit &srhit,
                   bool allowEmpty) {
 
-    //srhit.time = (use_ts0 ? (float)hit.ts0_ns : hit.ts1_ns) / 1000.;
-
-    if(use_ts0){
-      if(gate_start_timestamp>0){
-        long long tmp_crttime = hit.ts0_ns-gate_start_timestamp; // ns
-        srhit.time = (float)tmp_crttime/1000.; // ns->us
-      }
-      else{
-        //==== 03/31/22
-        //==== This must be MC case.
-        //==== Now the timing in MC (both T0 and T1) starts from 0 and peaks at 1600 us
-        //==== We are shifting the peak position to 0 to match with data T0 case above
-        srhit.time = hit.ts0_ns/1000.-1600.; // us
-      }
-    }
-    else{
-      //==== 03/31/22
-      //==== For MC, for the same reason as in T0, peak is at 1600 us
-      //==== For Data, we don't have good understanding of T1 yet, but it also starts at 0
-      srhit.time = hit.ts1_ns/1000.-1600.; //us
-    }
+    srhit.time = (use_ts0 ? (float)hit.ts0_ns : hit.ts1_ns) / 1000.;
+    srhit.t0 = (long long)(hit.ts0_ns-gate_start_timestamp)/1000.;
+    srhit.t1 = (long long)(hit.ts1_ns-gate_start_timestamp)/1000.;
 
     srhit.position.x = hit.x_pos;
     srhit.position.y = hit.y_pos;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -74,11 +74,18 @@ namespace caf
         srhit.time = (float)tmp_crttime/1000.; // ns->us
       }
       else{
-        srhit.time = hit.ts0_ns/1000.-1600.;
+        //==== 03/31/22
+        //==== This must be MC case.
+        //==== Now the timing in MC (both T0 and T1) starts from 0 and peaks at 1600 us
+        //==== We are shifting the peak position to 0 to match with data T0 case above
+        srhit.time = hit.ts0_ns/1000.-1600.; // us
       }
     }
     else{
-      srhit.time = hit.ts1_ns/1000.;
+      //==== 03/31/22
+      //==== For MC, for the same reason as in T0, peak is at 1600 us
+      //==== For Data, we don't have good understanding of T1 yet, but it also starts at 0
+      srhit.time = hit.ts1_ns/1000.-1600.; //us
     }
 
     srhit.position.x = hit.x_pos;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -61,10 +61,24 @@ namespace caf
   }
 
   void FillCRTHit(const sbn::crt::CRTHit &hit,
+                  uint64_t gate_start_timestamp,
                   bool use_ts0,
                   caf::SRCRTHit &srhit,
                   bool allowEmpty) {
-    srhit.time = (use_ts0 ? (float)hit.ts0_ns : hit.ts1_ns) / 1000.;
+
+    //srhit.time = (use_ts0 ? (float)hit.ts0_ns : hit.ts1_ns) / 1000.;
+
+    if(use_ts0){
+      if(gate_start_timestamp>0){
+        srhit.time = -((gate_start_timestamp-hit.ts0_ns)/1e3)+1e6; // us
+      }
+      else{
+        srhit.time = hit.ts0_ns/1e3-1600;
+      }
+    }
+    else{
+      srhit.time = hit.ts1_ns/1000.;
+    }
 
     srhit.position.x = hit.x_pos;
     srhit.position.y = hit.y_pos;

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -158,6 +158,7 @@ namespace caf
                            unsigned truth_ind);
 
   void FillCRTHit(const sbn::crt::CRTHit &hit,
+                  uint64_t gate_start_timestamp,
                   bool use_ts0,
                   caf::SRCRTHit &srhit,
                   bool allowEmpty = false);


### PR DESCRIPTION
CRTHit has two types of timing information. `T0` is a absolute timestamp of a signal, which must be subtracted by the beam gate start timestemp. The other is `T1` which is a relative time w.r.t. beam early warning, but as shown in [SBN-doc-25395, page5](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=25395), `T1` is not yet understood well enough, while we have seen good results from `T0`. 
The default of `CRTUseTS0` atom is changed to `true`, and some lines added to read and subtract trigger/beam_gate timings using `raw::ExternalTrigger` and `raw::Trigger`. There are many conversions between `long long`, `uint64_t`, `double` and `float`, which might not be optimal but at least I checked they works as expected; any comments related to this are welcomed! For MC, we saw the `T0` alone can be used without `m_gate_start_timestamp`. 
