### PR TITLE
Adding implicit factor of 1e12 protons explicitly to BNB/NuMI POT accounting

### DIFF
--- a/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
@@ -554,8 +554,8 @@ sbn::BNBSpillInfo sbn::BNBRetriever::makeBNBSpillInfo
   
   //Store everything in our data-product
   sbn::BNBSpillInfo beamInfo;
-  beamInfo.TOR860 = TOR860;
-  beamInfo.TOR875 = TOR875;
+  beamInfo.TOR860 = TOR860*1e12; //add in factor of 1e12 protons to get correct POT units
+  beamInfo.TOR875 = TOR875*1e12; //add in factor of 1e12 protons to get correct POT units
   beamInfo.LM875A = LM875A;
   beamInfo.LM875B = LM875B;
   beamInfo.LM875C = LM875C;

--- a/sbncode/BeamSpillInfoRetriever/NuMIRetriever/NuMIRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/NuMIRetriever/NuMIRetriever_module.cc
@@ -194,8 +194,8 @@ void sbn::NuMIRetriever::produce(art::Event &e)
       double time_closest_ns = (TRTGTD_time - time_closest_int)*1000000000;
 
       sbn::NuMISpillInfo NuMIbeamInfo;
-      NuMIbeamInfo.TORTGT = TORTGT;
-      NuMIbeamInfo.TOR101 = TOR101;
+      NuMIbeamInfo.TORTGT = TORTGT*1e12; //include factor of 1e12 protons in POT calculation
+      NuMIbeamInfo.TOR101 = TOR101*1e12; //include factor of 1e12 protons in POT calculation
       NuMIbeamInfo.TRTGTD = TRTGTD;
       NuMIbeamInfo.TR101D = TR101D;
       NuMIbeamInfo.HRNDIR = HRNDIR;


### PR DESCRIPTION
Added factor of 1e12 explicity to POT accounting variables for both BNB and NuMI. Allows for correct conversion from extracted IFBeam database values. Tested on BNB/NuMI raw data from run 7844 (BNB) and 7897 (NuMI) and both results make sense.