### PR TITLE
Default CreateFlatCAF to true

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -31,7 +31,7 @@ namespace caf
     };
 
     Atom<bool> CreateFlatCAF { Name("CreateFlatCAF"),
-      Comment("Whether to produce an output file in FlatCAF format"), false
+      Comment("Whether to produce an output file in FlatCAF format"), true
     };
 
     Atom<std::string> CAFFilename { Name("CAFFilename"),


### PR DESCRIPTION
The user is more likely to regret a missing flatcaf than they are to miss the disk space. This is still easy configurable in the job fcl.