### PR TITLE
Fix use of same name algorithm

### DIFF
--- a/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.cxx
+++ b/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.cxx
@@ -5,7 +5,7 @@
 #include "TMatrixDSymEigen.h"
 
 using namespace std;
-using namespace trkf;
+using namespace trkf::sbn;
 using namespace recob::tracking;
 
 recob::MCSFitResult TrajectoryMCSFitter::fitMcs(const recob::TrackTrajectory& traj, int pid, bool momDepConst) const {

--- a/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.h
+++ b/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.h
@@ -9,7 +9,7 @@
 #include "lardataobj/RecoBase/Track.h"
 #include "lardata/RecoObjects/TrackState.h"
 
-namespace trkf {
+namespace trkf::sbn {
   /**
    * @file  larreco/RecoAlg/TrajectoryMCSFitter.h
    * @class trkf::TrajectoryMCSFitter

--- a/sbncode/LArRecoProducer/MCSFitAllPID_module.cc
+++ b/sbncode/LArRecoProducer/MCSFitAllPID_module.cc
@@ -44,7 +44,7 @@ public:
 
 private:
 
-  trkf::TrajectoryMCSFitter fMCSCalculator;
+  trkf::sbn::TrajectoryMCSFitter fMCSCalculator;
   art::InputTag fTrackLabel;
   float fMinTrackLength;
 };


### PR DESCRIPTION
The TrajectoryMCSFitter algorithm has an identical name to one that resides in [larreco](https://github.com/LArSoft/larreco/blob/develop/larreco/RecoAlg/TrajectoryMCSFitter.h). This leads to undefined behaviour which showed up in the CI when testing (unrelated) SBNSoftware/sbndcode#278. By changing the namespace in which our version of the alg resides we can fix this issue.

Kyle from SciSoft has confirmed that my understanding of this is correct and the solution has been tested with the CI system.