### PR TITLE
add headers needed by larsoft v09_50_00

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -61,6 +61,7 @@
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 
 #include "art_root_io/TFileService.h"
 

--- a/sbncode/CAFMaker/RecoUtils/RecoUtils.h
+++ b/sbncode/CAFMaker/RecoUtils/RecoUtils.h
@@ -13,6 +13,7 @@
 #include "art/Framework/Principal/Event.h"
 #include "fhiclcpp/ParameterSet.h" 
 #include "art/Framework/Principal/Handle.h" 
+#include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "canvas/Persistency/Common/Ptr.h" 
 #include "canvas/Persistency/Common/PtrVector.h" 
 #include "canvas/Persistency/Common/FindManyP.h"

--- a/sbncode/Calibration/TrackCaloSkimmer.h
+++ b/sbncode/Calibration/TrackCaloSkimmer.h
@@ -55,6 +55,7 @@
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 
 #include "nusimdata/SimulationBase/MCParticle.h"

--- a/sbncode/Calibration/TrackCaloSkimmerSelectStoppingTrack_tool.cc
+++ b/sbncode/Calibration/TrackCaloSkimmerSelectStoppingTrack_tool.cc
@@ -8,6 +8,7 @@
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 
 #include "ITCSSelectionTool.h"

--- a/sbncode/EventGenerator/MultiPart/MultiPartRain_module.cc
+++ b/sbncode/EventGenerator/MultiPart/MultiPartRain_module.cc
@@ -24,6 +24,7 @@
 #include "TRandom.h"
 #include "nurandom/RandomUtils/NuRandomService.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcoreobj/SummaryData/RunData.h"
 
 #include "nusimdata/SimulationBase/MCTruth.h"

--- a/sbncode/EventGenerator/MultiPart/MultiPartVertex_module.cc
+++ b/sbncode/EventGenerator/MultiPart/MultiPartVertex_module.cc
@@ -24,6 +24,7 @@
 #include "TRandom.h"
 #include "nurandom/RandomUtils/NuRandomService.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcoreobj/SummaryData/RunData.h"
 
 #include "nusimdata/SimulationBase/MCTruth.h"

--- a/sbncode/FluxReader/FluxGeoFilter_module.cc
+++ b/sbncode/FluxReader/FluxGeoFilter_module.cc
@@ -20,6 +20,7 @@
 
 //geometry
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "TGeoManager.h"
 
 #include "nusimdata/SimulationBase/MCFlux.h"

--- a/sbncode/FluxReader/FluxReader.cxx
+++ b/sbncode/FluxReader/FluxReader.cxx
@@ -40,6 +40,8 @@
 //#include "cetlib/exception.h"
 
 #include "lardata/Utilities/AssociationUtil.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
+
 namespace fluxr {
 
   FluxReader::FluxReader(fhicl::ParameterSet const & ps,

--- a/sbncode/GeometryTools/CRTGeoAlg.h
+++ b/sbncode/GeometryTools/CRTGeoAlg.h
@@ -21,6 +21,7 @@
 
 // LArSoft
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardataobj/Simulation/AuxDetSimChannel.h"
 #include "larcore/Geometry/AuxDetGeometry.h"

--- a/sbncode/GeometryTools/TPCGeoAlg.h
+++ b/sbncode/GeometryTools/TPCGeoAlg.h
@@ -22,6 +22,7 @@
 
 // LArSoft
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "lardataobj/RecoBase/Hit.h"

--- a/sbncode/NuMuSelection/MuPVertexStudy_module.cc
+++ b/sbncode/NuMuSelection/MuPVertexStudy_module.cc
@@ -24,6 +24,7 @@
 
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/BoxBoundedGeo.h"
 #include "larsim/MCCheater/BackTrackerService.h"

--- a/sbncode/NuMuSelection/MuonS2NStudy_module.cc
+++ b/sbncode/NuMuSelection/MuonS2NStudy_module.cc
@@ -24,6 +24,7 @@
 
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/BoxBoundedGeo.h"
 #include "larsim/MCCheater/BackTrackerService.h"

--- a/sbncode/NuMuSelection/NuMuEfficiencyStudy_module.cc
+++ b/sbncode/NuMuSelection/NuMuEfficiencyStudy_module.cc
@@ -24,6 +24,7 @@
 
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/BoxBoundedGeo.h"
 #include "larsim/MCCheater/BackTrackerService.h"

--- a/sbncode/PID/Razzle_module.cc
+++ b/sbncode/PID/Razzle_module.cc
@@ -39,6 +39,8 @@
 #include "lardataobj/RecoBase/PFParticleMetadata.h"
 #include "lardataobj/RecoBase/Shower.h"
 #include "lardataobj/RecoBase/Vertex.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larsim/MCCheater/BackTrackerService.h"
 #include "larsim/MCCheater/ParticleInventoryService.h"
 #include "larsim/Utils/TruthMatchUtils.h"

--- a/sbncode/TPCReco/CalorimetryAnalysis/CalorimetryAnalysis_module.cc
+++ b/sbncode/TPCReco/CalorimetryAnalysis/CalorimetryAnalysis_module.cc
@@ -47,6 +47,7 @@
 #include "nusimdata/SimulationBase/MCTruth.h"
 
 #include "larcorealg/GeoAlgo/GeoAlgo.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 
 #include "larevt/SpaceCharge/SpaceCharge.h"
 #include "larevt/SpaceChargeServices/SpaceChargeService.h"

--- a/sbncode/TPCReco/NuVertexChargeTree_module.cc
+++ b/sbncode/TPCReco/NuVertexChargeTree_module.cc
@@ -26,6 +26,7 @@
 #include "lardataobj/RecoBase/Shower.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/Exceptions.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"

--- a/sbncode/TPCReco/TrackHit/TrackAreaHit_module.cc
+++ b/sbncode/TPCReco/TrackHit/TrackAreaHit_module.cc
@@ -30,6 +30,7 @@
 #include "lardataobj/RecoBase/TrackHitMeta.h"
 #include "lardataobj/AnalysisBase/T0.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"

--- a/sbncode/TPCReco/TrackSplit/MergedTrackIdentifier_module.cc
+++ b/sbncode/TPCReco/TrackSplit/MergedTrackIdentifier_module.cc
@@ -31,6 +31,7 @@
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/TrackHitMeta.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"

--- a/sbncode/TPCReco/TrackSplit/TrackSplitter_module.cc
+++ b/sbncode/TPCReco/TrackSplit/TrackSplitter_module.cc
@@ -29,6 +29,7 @@
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/TrackHitMeta.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"

--- a/sbncode/TPCReco/VertexStub/VertexChargeVacuum_module.cc
+++ b/sbncode/TPCReco/VertexStub/VertexChargeVacuum_module.cc
@@ -28,6 +28,7 @@
 #include "lardataobj/RecoBase/SpacePoint.h"
 #include "lardataobj/RecoBase/Cluster.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"

--- a/sbncode/TPCReco/VertexStub/VertexStubTracker_module.cc
+++ b/sbncode/TPCReco/VertexStub/VertexStubTracker_module.cc
@@ -40,6 +40,7 @@
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/TrackHitMeta.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"


### PR DESCRIPTION
We expect that larsoft v09_50_00 will be using cetmodules to build the major packages.  Some cleanup was necessary as part of this work.  This means that some headers now need to be included where they are used.  This PR should be fine with the current sbncode release, since it simply adds headers.