### PR TITLE
Updates to POT accounting codes to account for new trigger fragment

### DIFF
--- a/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/BNBRetriever/BNBRetriever_module.cc
@@ -20,7 +20,7 @@
 #include "larcorealg/CoreUtils/counter.h"
 
 #include "artdaq-core/Data/Fragment.hh"
-#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh"
+#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerV2Fragment.hh"
 
 #include "sbnobj/Common/POTAccounting/BNBSpillInfo.h"
 
@@ -245,17 +245,17 @@ sbn::BNBRetriever::TriggerInfo_t sbn::BNBRetriever::extractTriggerInfo(art::Even
   // 2. the time of the previously triggered event, t_previous_event (NOTE: Events are non-sequential!)
   // 3. the number of beam spills since the previously triggered event, number_of_gates_since_previous_event
   
-  auto const & raw_data = e.getProduct< std::vector<artdaq::Fragment> >({ raw_data_label, "ICARUSTriggerUDP" });
+  auto const & raw_data = e.getProduct< std::vector<artdaq::Fragment> >({ raw_data_label, "ICARUSTriggerV2" });
   
   TriggerInfo_t triggerInfo;
 
   for(auto raw_datum : raw_data){
    
     uint64_t artdaq_ts = raw_datum.timestamp();
-    icarus::ICARUSTriggerUDPFragment frag(raw_datum);
+    icarus::ICARUSTriggerV2Fragment frag(raw_datum);
     std::string data = frag.GetDataString();
     char *buffer = const_cast<char*>(data.c_str());
-    icarus::ICARUSTriggerInfo datastream_info = icarus::parse_ICARUSTriggerString(buffer);
+    icarus::ICARUSTriggerInfo datastream_info = icarus::parse_ICARUSTriggerV2String(buffer);
     triggerInfo.gate_type = datastream_info.gate_type;
     triggerInfo.number_of_gates_since_previous_event = frag.getDeltaGatesBNB();
   

--- a/sbncode/BeamSpillInfoRetriever/NuMIRetriever/NuMIRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/NuMIRetriever/NuMIRetriever_module.cc
@@ -19,7 +19,7 @@
 #include "larcorealg/Geometry/Exceptions.h"
 
 #include "artdaq-core/Data/Fragment.hh"
-#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh"
+#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerV2Fragment.hh"
 
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
@@ -92,7 +92,7 @@ void sbn::NuMIRetriever::produce(art::Event &e)
 
   int gate_type = 0;
   art::Handle< std::vector<artdaq::Fragment> > raw_data_ptr;
-  e.getByLabel(raw_data_label_, "ICARUSTriggerUDP", raw_data_ptr);
+  e.getByLabel(raw_data_label_, "ICARUSTriggerV2", raw_data_ptr);
   auto const & raw_data = (*raw_data_ptr);
 
   double t_current_event  = 0;
@@ -102,10 +102,10 @@ void sbn::NuMIRetriever::produce(art::Event &e)
   for(auto raw_datum : raw_data){
 
     uint64_t artdaq_ts = raw_datum.timestamp();
-    icarus::ICARUSTriggerUDPFragment frag(raw_datum);
+    icarus::ICARUSTriggerV2Fragment frag(raw_datum);
     std::string data = frag.GetDataString();
     char *buffer = const_cast<char*>(data.c_str());
-    icarus::ICARUSTriggerInfo datastream_info = icarus::parse_ICARUSTriggerString(buffer);
+    icarus::ICARUSTriggerInfo datastream_info = icarus::parse_ICARUSTriggerV2String(buffer);
     gate_type = datastream_info.gate_type;
     number_of_gates_since_previous_event = frag.getDeltaGatesNuMI();
 


### PR DESCRIPTION
Emergency PR in order to restart POT accounting efforts after updates to trigger decoding.

When doing the updates to the trigger fragment structure we missed the need to update what is referenced in the POT accounting codes. The fragments pulled for the POT accounting are now updated to match the new trigger system. Only will work with new data with new trigger system (>run 8354). Will need to expand this to create a separate path (via fcl or run number flags) to handle the data with the old trigger fragment. This is easier to handle as we don't need a sophisticated decoder for this so it might just have a pre-run 8354 and post-run 8354. Will need to examine this.

Tested with run 8413 which Maya was reporting issues processing before and both BNB and NuMI are now working and run 8353 (which I think is one of first runs with new trigger fragment). 