### PR TITLE
use ts0() instead od ts0_ns in CAFMaker

### DIFF
--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -66,9 +66,9 @@ namespace caf
                   caf::SRCRTHit &srhit,
                   bool allowEmpty) {
 
-    srhit.time = (use_ts0 ? (float)hit.ts0_ns : hit.ts1_ns) / 1000.;
-    srhit.t0 = ((long long)(hit.ts0_ns)-(long long)(gate_start_timestamp))/1000.;
-    srhit.t1 = hit.ts1_ns/1000.;
+    srhit.time = (use_ts0 ? (float)hit.ts0() : hit.ts1()) / 1000.;
+    srhit.t0 = ((long long)(hit.ts0())-(long long)(gate_start_timestamp))/1000.;
+    srhit.t1 = hit.ts1()/1000.;
 
     srhit.position.x = hit.x_pos;
     srhit.position.y = hit.y_pos;


### PR DESCRIPTION
Same as https://github.com/SBNSoftware/sbncode/pull/271, but based on `develop`.