### PR TITLE
Updates to MeVPrtl Generator

### DIFF
--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -191,6 +191,9 @@ namespace caf {
    srtruth.exit.x = truth.mevprtl_exit.X();
    srtruth.exit.y = truth.mevprtl_exit.Y();
    srtruth.exit.z = truth.mevprtl_exit.Z();
+   srtruth.start.x = truth.mevprtl_start.X();
+   srtruth.start.y = truth.mevprtl_start.Y();
+   srtruth.start.z = truth.mevprtl_start.Z();
 
    srtruth.C1 = truth.C1;
    srtruth.C2 = truth.C2;

--- a/sbncode/EventGenerator/MeVPrtl/MeVPrtlGen_module.cc
+++ b/sbncode/EventGenerator/MeVPrtl/MeVPrtlGen_module.cc
@@ -337,6 +337,15 @@ void evgen::ldm::MeVPrtlGen::produce(art::Event& evt)
 
     simb::MCTruth mctruth;
 
+    // Add the "Neutrino" as the 0th MCParticle
+    // This hopefully (???) won't do anything too bad and will give us
+    // the chance to use the neutrino energy in other things
+    simb::MCParticle fakenu(0, kaon.fntype, "primary", -1, 0, -1/* don't track */);
+    fakenu.AddTrajectoryPoint(mevprtl_truth.decay_pos, TLorentzVector(0, 0, flux.equiv_enu, flux.equiv_enu));
+    mctruth.Add(fakenu);
+    mctruth.SetNeutrino(-1, -1, -1, -1, -1, -1, 
+                        -1., -1., -1., -1.); 
+
     for (unsigned i_d = 0; i_d < mevprtl_truth.daughter_mom.size(); i_d++) {
       TLorentzVector daughter4p(mevprtl_truth.daughter_mom[i_d], mevprtl_truth.daughter_e[i_d]);
       simb::MCParticle d(0, mevprtl_truth.daughter_pdg[i_d], "primary", -1, daughter4p.M());

--- a/sbncode/EventGenerator/MeVPrtl/Tools/HNL/Kaon2HNLFlux_tool.cc
+++ b/sbncode/EventGenerator/MeVPrtl/Tools/HNL/Kaon2HNLFlux_tool.cc
@@ -240,6 +240,9 @@ bool Kaon2HNLFlux::MakeFlux(const simb::MCFlux &flux, evgen::ldm::MeVPrtlFlux &h
   hnl.secondary_pdg = (is_muon ? 11 : 13) * (kaon.kaon_pdg > 0 ? 1 : -1);
   hnl.generator = 1; // kHNL
 
+  // equivalent neutrino energy
+  hnl.equiv_enu = EnuLab(flux.fnecm, hnl.kmom, hnl.pos);
+
   return true;
 }
 

--- a/sbncode/EventGenerator/MeVPrtl/Tools/Higgs/Kaon2HiggsFlux_tool.cc
+++ b/sbncode/EventGenerator/MeVPrtl/Tools/Higgs/Kaon2HiggsFlux_tool.cc
@@ -282,6 +282,7 @@ bool Kaon2HiggsFlux::MakeFlux(const simb::MCFlux &flux, evgen::ldm::MeVPrtlFlux 
   higgs.kaon_pdg = kaon.kaon_pdg;
   higgs.generator = 0; // kDissonantHiggs
   higgs.secondary_pdg = PionPdg(kaon.kaon_pdg);
+  higgs.equiv_enu = EnuLab(flux.fnecm, higgs.kmom, higgs.pos);
 
   return true;
 }

--- a/sbncode/EventGenerator/MeVPrtl/Tools/IMeVPrtlFlux.h
+++ b/sbncode/EventGenerator/MeVPrtl/Tools/IMeVPrtlFlux.h
@@ -114,6 +114,18 @@ protected:
     // toff -= neutrino_tif;
     return TLorentzVector(fBeamOrigin, toff);
   }
+
+  // Compute the equivalent neutrino energy for a given parent meson position / momentum 
+  double EnuLab(double enucm, TLorentzVector meson_mom, TLorentzVector meson_pos) { // all in detector coordinates
+    // Assume neutrino travels to center of detector
+    double costh = meson_mom.Vect().Unit().Dot(-meson_pos.Vect().Unit());
+
+    // Scale factor
+    double M = 1. / (meson_mom.Gamma() * (1 - meson_mom.Beta() * costh));
+
+    return M * enucm;
+  }
+
 };
 
 } // namespace ldm

--- a/sbncode/EventGenerator/MeVPrtl/Tools/MixedWeightRayTraceBox_tool.cc
+++ b/sbncode/EventGenerator/MeVPrtl/Tools/MixedWeightRayTraceBox_tool.cc
@@ -192,6 +192,13 @@ TLorentzVector MixedWeightRayTraceBox::ThrowMeVPrtlMomentum(const MeVPrtlFlux &f
 }
 
 std::pair<double, double> MixedWeightRayTraceBox::DeltaPhi(TVector3 origin, TRotation &R) {
+  // If the parent hits the detector, then delta-phi is 2Pi 
+  TVector3 pdir = R.Inverse()*TVector3(0, 0, 1);
+  if (fBox.GetIntersections(origin, pdir).size()) {
+    std::cout << "Parent Direction: " << pdir.X() << " " << pdir.Y() << " " << pdir.Z() << " at location: " << origin.X() << " " << origin.Y() << " " << origin.Z() << " hits detector!\n";
+    return {-M_PI, M_PI};
+  }
+
   // Iterate over all corners and compute the limits of Phi
   double phihi = -M_PI;
   double philo = M_PI;


### PR DESCRIPTION
Fix phi computation in RayTracer. Add in more variables, including equivalent neutrino energy. Depends on https://github.com/SBNSoftware/sbnanaobj/pull/71 and https://github.com/SBNSoftware/sbnobj/pull/60.