### PR TITLE
Adding trigger information to CAF files to compute time within beam gate

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1003,12 +1003,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   fSRTrigger.clear();
   if(isRealData)
   {
-    art::Handle<sbn::ExtraTriggerInfo> addltrig_handle;
-    evt.getByLabel(fParams.TriggerLabel(), addltrig_handle);
-    const sbn::ExtraTriggerInfo& addltrig = *addltrig_handle;
-    art::Handle<std::vector<raw::Trigger> > trig_handle;
-    evt.getByLabel(fParams.TriggerLabel(), trig_handle);
-    const std::vector<raw::Trigger>& trig = *trig_handle;
+    const auto& addltrig = evt.getProduct<sbn::ExtraTriggerInfo>(fParams.TriggerLabel());
+    const auto& trig = evt.getProduct<raw::Trigger>(fParams.TriggerLabel());
     if(trig.size()==1)
     {
       FillTrigger(addltrig, trig, fSRTrigger);

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1004,7 +1004,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   if(isRealData)
   {
     const auto& addltrig = evt.getProduct<sbn::ExtraTriggerInfo>(fParams.TriggerLabel());
-    const auto& trig = evt.getProduct<raw::Trigger>(fParams.TriggerLabel());
+    const auto& trig = evt.getProduct<std::vector<raw::Trigger>>(fParams.TriggerLabel());
     if(trig.size()==1)
     {
       FillTrigger(addltrig, trig, fSRTrigger);

--- a/sbncode/CAFMaker/FillTrigger.cxx
+++ b/sbncode/CAFMaker/FillTrigger.cxx
@@ -1,0 +1,29 @@
+
+#include "sbncode/CAFMaker/FillTrigger.h"
+
+#include <iostream>
+
+namespace caf
+{
+  void FillTrigger(const sbn::ExtraTriggerInfo& addltrig_info,
+		   const std::vector<raw::Trigger>& trig_info,
+		   std::vector<caf::SRTrigger>& triggerInfo)
+  {
+    uint64_t beam_ts = 0;
+    uint64_t trigger_ts = 0;
+    triggerInfo.emplace_back();
+    triggerInfo.back().global_trigger_time = addltrig_info.triggerTimestamp;
+    triggerInfo.back().beam_gate_time_abs = addltrig_info.beamGateTimestamp;
+    beam_ts = addltrig_info.beamGateTimestamp;
+    trigger_ts = addltrig_info.triggerTimestamp;
+    std::cout << addltrig_info.triggerTimestamp << " " << addltrig_info.beamGateTimestamp << std::endl;
+    int64_t diff_ts = trigger_ts - beam_ts;
+    triggerInfo.back().trigger_within_gate = diff_ts;
+    for(const raw::Trigger& trig: trig_info)
+    {
+      triggerInfo.back().beam_gate_det_time = trig.BeamGateTime();
+      triggerInfo.back().global_trigger_det_time = trig.TriggerTime();
+    }
+  }
+    
+}

--- a/sbncode/CAFMaker/FillTrigger.cxx
+++ b/sbncode/CAFMaker/FillTrigger.cxx
@@ -1,8 +1,6 @@
 
 #include "sbncode/CAFMaker/FillTrigger.h"
 
-#include <iostream>
-
 namespace caf
 {
   void FillTrigger(const sbn::ExtraTriggerInfo& addltrig_info,
@@ -16,7 +14,6 @@ namespace caf
     triggerInfo.back().beam_gate_time_abs = addltrig_info.beamGateTimestamp;
     beam_ts = addltrig_info.beamGateTimestamp;
     trigger_ts = addltrig_info.triggerTimestamp;
-    std::cout << addltrig_info.triggerTimestamp << " " << addltrig_info.beamGateTimestamp << std::endl;
     int64_t diff_ts = trigger_ts - beam_ts;
     triggerInfo.back().trigger_within_gate = diff_ts;
     for(const raw::Trigger& trig: trig_info)

--- a/sbncode/CAFMaker/FillTrigger.h
+++ b/sbncode/CAFMaker/FillTrigger.h
@@ -1,0 +1,19 @@
+#ifndef CAF_FILLTRIGGER_H
+#define CAF_FILLTRIGGER_H
+
+#include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
+#include "sbnanaobj/StandardRecord/SRTrigger.h"
+#include "lardataobj/RawData/TriggerData.h"
+
+#include <vector>
+
+namespace caf
+{
+
+  void FillTrigger(const sbn::ExtraTriggerInfo& addltrig_info,
+                   const std::vector<raw::Trigger>& trig_info,
+                   std::vector<caf::SRTrigger>& triggerInfo);
+
+}
+
+#endif


### PR DESCRIPTION
Adding trigger information to CAF files in order to compute the time within the beam gate. Requires changes to create a new place for trigger information in order move the `sbn::ExtraTriggerInfo` into sbncode.

Tested on ICARUS data from raw -> CAF stage and successfully extracted the correct trigger information at each stage.

Depends on equivalent PRs in icaruscode, sbnanaobj, and sbnobj