### PR TITLE
Feature/jlarkin nuefakereco

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -983,7 +983,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   }
 
   std::vector<caf::SRFakeReco> srfakereco;
-  FillFakeReco(mctruths, mctracks, fActiveVolumes, *fFakeRecoTRandom, srfakereco);
+  FillFakeReco(mctruths, true_particles, mctracks, fActiveVolumes, *fFakeRecoTRandom, srfakereco);
 
   // Fill the MeVPrtl stuff
   for (unsigned i_prtl = 0; i_prtl < mevprtl_truths.size(); i_prtl++) {
@@ -1328,8 +1328,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 		     *pi_serv, clock_data, recslc);
 
       FillSliceFakeReco(slcHits, mctruths, srtruthbranch,
-			*pi_serv, clock_data, recslc, mctracks, fActiveVolumes,
-			*fFakeRecoTRandom);
+			*pi_serv, clock_data, recslc, true_particles, mctracks, 
+                        fActiveVolumes, *fFakeRecoTRandom);
     }
 
     //#######################################################

--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -25,6 +25,11 @@ bool FRFillNumuCC(const simb::MCTruth &mctruth,
                   const std::vector<geo::BoxBoundedGeo> &volumes,
                   TRandom &rand,
                   caf::SRFakeReco &fakereco);
+bool FRFillNueCC(const simb::MCTruth &mctruth,
+                  const std::vector<caf::SRTrueParticle> &srparticle,
+                  const std::vector<geo::BoxBoundedGeo> &volumes,
+                  TRandom &rand,
+                  caf::SRFakeReco &fakereco);
 
 // helper function definitions
 
@@ -34,6 +39,14 @@ bool isFromNuVertex(const simb::MCTruth& mc, const sim::MCTrack& track,
   TVector3 trkStart = track.Start().Position().Vect();
   return (trkStart - nuVtx).Mag() < distance;
 }
+
+bool isFromNuVertex(const simb::MCTruth& mc, const simb::MCParticle& particle,
+                    float distance=5.0) {
+  TVector3 nuVtx = mc.GetNeutrino().Nu().Trajectory().Position(0).Vect();
+  TVector3 partStart = particle.Position().Vect();
+  return (partStart - nuVtx).Mag() < distance;
+}
+
 
 // returns particle mass in MeV
 double PDGMass(int pdg) {
@@ -219,11 +232,16 @@ namespace caf {
                          const cheat::ParticleInventoryService &inventory_service,
                          const detinfo::DetectorClocksData &clockData,
                          caf::SRSlice &srslice,
+                         const std::vector<caf::SRTrueParticle> &srparticles,
                          const std::vector<art::Ptr<sim::MCTrack>> &mctracks,
                          const std::vector<geo::BoxBoundedGeo> &volumes, TRandom &rand)
   {
     caf::SRTruthMatch tmatch = MatchSlice2Truth(hits, neutrinos, srmc, inventory_service, clockData);
-    if(tmatch.index >= 0) FRFillNumuCC(*neutrinos[tmatch.index], mctracks, volumes, rand, srslice.fake_reco);
+    if(tmatch.index >= 0) {
+      FRFillNumuCC(*neutrinos[tmatch.index], mctracks, volumes, rand, srslice.fake_reco);
+      if(!srslice.fake_reco.filled)
+        FRFillNueCC(*neutrinos[tmatch.index], srparticles, volumes, rand, srslice.fake_reco);
+    }
   }//FillSliceFakeReco
 
 
@@ -607,6 +625,7 @@ namespace caf {
   } //FillTrueG4Particle
 
   void FillFakeReco(const std::vector<art::Ptr<simb::MCTruth>> &mctruths,
+                    const std::vector<caf::SRTrueParticle> &srparticles,
                     const std::vector<art::Ptr<sim::MCTrack>> &mctracks,
                     const std::vector<geo::BoxBoundedGeo> &volumes,
                     TRandom &rand,
@@ -616,11 +635,13 @@ namespace caf {
       bool do_fill = false;
       caf::SRFakeReco this_fakereco;
       do_fill = FRFillNumuCC(*mctruth, mctracks, volumes, rand, this_fakereco);
+      if(!do_fill) do_fill = FRFillNueCC(*mctruth, srparticles, volumes, rand, this_fakereco);
 
       // TODO: others?
       // if (!do_fill) ...
 
       if (do_fill) srfakereco.push_back(this_fakereco);
+      
     }
   }
 
@@ -836,6 +857,189 @@ bool FRFillNumuCC(const simb::MCTruth &mctruth,
   }
   fakereco.nhad = fakereco.hadrons.size();
   fakereco.filled = true;
+
+  return true;
+}
+
+bool FRFillNueCC(const simb::MCTruth &mctruth,
+                  const std::vector<caf::SRTrueParticle> &srparticles,
+                  const std::vector<geo::BoxBoundedGeo> &volumes,
+                  TRandom &rand,
+                  caf::SRFakeReco &fakereco) {
+  // Configuration -- TODO: make configurable?
+
+  // Fiducial Volume
+  float xmin = 10.;
+  float xmax = 10.;
+  float ymin = 10.;
+  float ymax = 10.;
+  float zmin = 10.;
+  float zmax = 100.;
+
+  // energy smearing
+  auto smear_lepton = [&rand](const caf::SRTrueParticle &lepton) -> float {
+    const double smearing = 0.15;
+    const double true_E = lepton.plane[0][2].visE + lepton.plane[1][2].visE;
+    const double smeared_E = rand.Gaus(true_E, smearing * true_E / std::sqrt(true_E));
+    return std::max(smeared_E, 0.0);
+  };
+  auto smear_hadron = [&rand](const caf::SRTrueParticle &hadron) -> float {
+    const double smearing = 0.05;
+    //const double true_E = hadron.plane[0][2].visE + hadron.plane[1][2].visE - PDGMass(hadron.pdg);
+    const double true_E = hadron.genE - PDGMass(hadron.pdg);
+    const double smeared_E = rand.Gaus(true_E, smearing * true_E);
+    return std::max(smeared_E, 0.0);
+  };
+
+  // visible energy threshold
+  const float hadronic_energy_threshold = 0.021; // GeV
+
+  fakereco.filled = false;
+
+  // first check if neutrino exists
+  if (!mctruth.NeutrinoSet()) return false;
+
+  TVector3 nuVtx = mctruth.GetNeutrino().Nu().Position().Vect();
+
+  // then check if fiducial
+  int cryo_index = -1;
+  for (unsigned i = 0; i < volumes.size(); i++) {
+    const geo::BoxBoundedGeo &vol = volumes[i];
+    geo::BoxBoundedGeo FV(vol.MinX() + xmin, vol.MaxX() - xmax, vol.MinY() + ymin, vol.MaxY() - ymax, vol.MinZ() + zmin, vol.MaxZ() - zmax);
+    if (FV.ContainsPosition(nuVtx)) {
+      cryo_index = i;
+      break;
+    }
+  }
+
+  if (cryo_index == -1) return false;
+
+  std::vector<geoalgo::AABox> aa_volumes;
+  const geo::BoxBoundedGeo &v = volumes.at(cryo_index);
+  aa_volumes.emplace_back(v.MinX(), v.MinY(), v.MinZ(), v.MaxX(), v.MaxY(), v.MaxZ());
+
+  //Showers arising from the vertex are identified and the reconstructed energy is found
+  //from smearing the ionisation deposition. If more than one shower with energy above
+  //100 MeV exists, the event is removed. This removes neutral pion events where the
+  //pion decays into two photon showers.
+
+  std::vector<const caf::SRTrueParticle*> lepton_candidates;
+  for(const auto& particle: srparticles) {
+    const int pdg = std::abs(particle.pdg);
+    const float distance_from_vertex = std::hypot(nuVtx.X() - particle.start.x,
+                                                  nuVtx.Y() - particle.start.y,
+                                                  nuVtx.Z() - particle.start.z);
+    if((pdg == 11 || pdg == 22) && distance_from_vertex < 5) {
+      const auto parent = std::find_if(srparticles.begin(), srparticles.end(),
+        [&particle](const caf::SRTrueParticle& parent_candidate) -> bool {
+          return particle.parent == std::abs(parent_candidate.G4ID);
+        });
+      if((parent == srparticles.end()
+           || !(std::abs((*parent).pdg) == 11 || std::abs((*parent).pdg) == 22))
+         && smear_lepton(particle) > 0.1) {
+        lepton_candidates.push_back(&particle);
+      }
+    }
+  }
+  if(lepton_candidates.size() != 1) return false;
+  
+  const caf::SRTrueParticle* lepton = lepton_candidates[0];
+  caf::SRFakeRecoParticle fake_lepton;
+  fake_lepton.pid = 11;
+  fake_lepton.ke = smear_lepton(*lepton) - PDGMass(11) / 1000;
+  // Should these be set for a shower?
+  // fake_lepton.len = ???;
+  // fake_lepton.costh = ???;
+  // fake_lepton.contained = false;
+
+  // Get hadrons
+
+  std::vector<caf::SRFakeRecoParticle> fake_hadrons;
+  float hadronic_E = 0.0;
+  for(const auto& particle: srparticles) {
+    const int pdg = std::abs(particle.pdg);
+    const float ke = smear_hadron(particle);
+    const float distance_from_vertex = std::hypot(nuVtx.X() - particle.start.x,
+                                                  nuVtx.Y() - particle.start.y,
+                                                  nuVtx.Z() - particle.start.z);
+
+    if((pdg == 2212 || pdg == 211 || pdg == 321) && distance_from_vertex < 5 && particle.start_process == caf::kG4primary) std::cout << "Energy: " << ke << std::endl;
+    if((pdg == 2212 || pdg == 211 || pdg == 321) && distance_from_vertex < 5
+       && particle.start_process == caf::kG4primary && ke > hadronic_energy_threshold) {
+      std::cout << "Found Hadron\n";
+
+      caf::SRFakeRecoParticle fake_hadron;
+      fake_hadron.pid = pdg;
+      fake_hadron.len = ContainedLength(TVector3(particle.start), TVector3(particle.end), aa_volumes);
+      fake_hadron.contained = false;
+      for(const geo::BoxBoundedGeo &vol: volumes) {
+        if(vol.ContainsPosition(TVector3(particle.start)) 
+           && vol.ContainsPosition(TVector3(particle.end))) {
+          fake_hadron.contained = true;
+        }
+      }
+      fake_hadron.costh = TVector3(particle.start).CosTheta();
+      fake_hadron.ke = ke;
+      hadronic_E += ke;
+      fake_hadrons.push_back(fake_hadron);
+    }
+  }
+
+  // If there is only one photon candidate in the event, a conversion gap cut is applied.
+  // If the vertex is deemed visible, due to the presence of at least 50 MeV of hadronic
+  // kinetic energy, and the photon starts to shower further than 3 cm from the vertex the
+  // event is removed.
+  
+  if(lepton->pdg == 22 && hadronic_E > 0.05 && (TVector3(lepton->end) - nuVtx).Mag() > 3)
+    return false;
+
+  // Remaining photons undergo a dE/dx cut resulting in a 94% background rejection.
+
+  double weight = 1.0;
+  if(lepton->pdg == 22) weight *= 0.06;
+
+  // If a misidentified photon originates from a resonant numuCC interaction, the muon
+  // lepton is identified. Events where a muon travels greater than 1 m are assumed to be
+  // from numuCC interactions and the event is removed.
+
+  if(std::abs(mctruth.GetNeutrino().Nu().PdgCode()) == 14 && mctruth.GetNeutrino().CCNC() == 0) {
+    const caf::SRTrueParticle* muon = NULL;
+    for(const auto& particle: srparticles) {
+      const int pdg = std::abs(particle.pdg);
+      const float distance_from_vertex = std::hypot(nuVtx.X() - particle.start.x,
+                                                    nuVtx.Y() - particle.start.y,
+                                                    nuVtx.Z() - particle.start.z);
+      if(pdg == 13 && distance_from_vertex < 5 && particle.start_process == caf::kG4primary
+         && (muon == NULL || muon->startE < particle.startE))
+        muon = &particle;
+    }
+    if(muon != NULL && ContainedLength(TVector3(muon->start), TVector3(muon->end), aa_volumes) < 100)
+      return false;
+  }
+
+  // Events where the shower has an energy less than 200 MeV are removed
+
+  if((lepton->plane[0][2].visE + lepton->plane[1][2].visE) < 0.2) return false;
+
+  // total up the energy to get the reco neutrino energy
+  fakereco.nuE = fake_lepton.ke + PDGMass(11) / 1000 + hadronic_E;
+
+  // save the particles
+  fakereco.lepton = fake_lepton;
+  fakereco.hadrons = fake_hadrons;
+
+  // other info
+  fakereco.vtx.x = nuVtx.X();
+  fakereco.vtx.y = nuVtx.Y();
+  fakereco.vtx.z = nuVtx.Z();
+
+  fakereco.wgt = 0.8;
+  fakereco.wgt *= weight;
+
+  fakereco.nhad = fakereco.hadrons.size();
+  fakereco.filled = true;
+
+  std::cout << "Filled fake reco\n";
 
   return true;
 }

--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -1003,7 +1003,7 @@ bool FRFillNueCC(const simb::MCTruth &mctruth,
          && (muon == NULL || muon->startE < particle.startE))
         muon = &particle;
     }
-    if(muon != NULL && ContainedLength(TVector3(muon->start), TVector3(muon->end), aa_volumes) < 100)
+    if(muon != NULL && ContainedLength(TVector3(muon->start), TVector3(muon->end), aa_volumes) > 100)
       return false;
   }
 

--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -40,14 +40,6 @@ bool isFromNuVertex(const simb::MCTruth& mc, const sim::MCTrack& track,
   return (trkStart - nuVtx).Mag() < distance;
 }
 
-bool isFromNuVertex(const simb::MCTruth& mc, const simb::MCParticle& particle,
-                    float distance=5.0) {
-  TVector3 nuVtx = mc.GetNeutrino().Nu().Trajectory().Position(0).Vect();
-  TVector3 partStart = particle.Position().Vect();
-  return (partStart - nuVtx).Mag() < distance;
-}
-
-
 // returns particle mass in MeV
 double PDGMass(int pdg) {
   const TDatabasePDG *PDGTable = TDatabasePDG::Instance();

--- a/sbncode/CAFMaker/FillTrue.h
+++ b/sbncode/CAFMaker/FillTrue.h
@@ -67,6 +67,7 @@ namespace caf
                          const cheat::ParticleInventoryService &inventory_service,
                          const detinfo::DetectorClocksData &clockData,
                          caf::SRSlice &srslice, 
+                         const std::vector<caf::SRTrueParticle> &srparticles,
                          const std::vector<art::Ptr<sim::MCTrack>> &mctracks,
                          const std::vector<geo::BoxBoundedGeo> &volumes, TRandom &rand);
 
@@ -118,6 +119,7 @@ namespace caf
                        bool allowEmpty = false);
 
   void FillFakeReco(const std::vector<art::Ptr<simb::MCTruth>> &mctruths, 
+                    const std::vector<caf::SRTrueParticle> &srparticles, 
                     const std::vector<art::Ptr<sim::MCTrack>> &mctracks, 
                     const std::vector<geo::BoxBoundedGeo> &volumes,
                     TRandom &rand,


### PR DESCRIPTION
Add fake reco for beam induced nue events (no dirt or cosmics) following the selection in section 4.3 of the oscillation tech note (docdb 27037) and the energy smearing in the [code used for the old oscillation samples](https://github.com/SBNSoftware/sbncode/tree/feature/DomBarkerNueSelection/sbnanalysis/ana/SBNOsc) (specifically [here](https://github.com/SBNSoftware/sbncode/blob/d23369eab5567d1cec7b642f99ddce9cf6bd1245/sbnanalysis/ana/SBNOsc/Utilities.cxx#L554) for the lepton and [here](https://github.com/SBNSoftware/sbncode/blob/d23369eab5567d1cec7b642f99ddce9cf6bd1245/sbnanalysis/ana/SBNOsc/Utilities.cxx#L241) for hadrons).
I decided to rewrite the selection instead of copying from that old branch since it was difficult to follow what was going on there, but the tech note didn't specify an energy smearing so I did copy that from the old branch.

This is needed for the oscillation analysis until we have actual reco for nue events.

Not sure who the right people are to review this, so I'm just putting Chris for now.
Chris or others should feel free to add reviewers if there are other people who should look at this.
