### PR TITLE
Add larcv2 dependency + Supera as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "sbncode/Supera"]
+	path = sbncode/Supera
+	url = https://github.com/DeepLearnPhysics/Supera.git
+	branch = icarus

--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ This package contains code for SBN-wide simulation and analysis. This includes:
 * `sbncode`: Common LArSoft modules and other utilities
 * `env`: Scripts to set up joint SBND/MicroBooNE/ICARUS environments (to be
   automated in future versions)
+
+Cloning submodules
+------------------
+`mrb gitCheckout` should take care of git submodules if the origin repository is the
+default one, i.e. SBNSoftware.
+If `sbncode` is cloned from any repository other than the official one (SBNSoftware),
+git submodules need to be initalized after `mrb gitCheckout` with the following command:
+
+```
+$ git submodule update --init --recursive
+```

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -28,6 +28,11 @@ add_subdirectory(GeometryTools)
 add_subdirectory(CosmicID)
 
 # Supera
+if ( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Supera/.git" )
+  execute_process(COMMAND git submodule update --init --recursive)
+endif()
+
+# We need to run Supera/setup.sh first, otherwise it won't have a CMakeLists.txt.
 execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/Supera/setup.sh icarus
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Supera )
 add_subdirectory(Supera)

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -25,3 +25,8 @@ add_subdirectory(EventGenerator)
 add_subdirectory(PID)
 add_subdirectory(GeometryTools)
 add_subdirectory(CosmicID)
+
+# Supera
+execute_process(COMMAND sh setup.sh icarus
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Supera )
+add_subdirectory(Supera)

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -28,6 +28,6 @@ add_subdirectory(GeometryTools)
 add_subdirectory(CosmicID)
 
 # Supera
-execute_process(COMMAND sh setup.sh icarus
+execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/Supera/setup.sh icarus
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Supera )
 add_subdirectory(Supera)

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -27,7 +27,22 @@ add_subdirectory(PID)
 add_subdirectory(GeometryTools)
 add_subdirectory(CosmicID)
 
+#
 # Supera
+#
+# Why are we checking explicitly for git submodule initialization?
+# ----------------------------------------------------------------
+# Because it is stored as a git submodule, it should be initialized first before
+# any build is attempted. `mrb gitCheckout` should run `--recurse-submodules` to
+# this effect. However, it is implemented in a hacky way: the option for submodules
+# is only added to `mrb gitCheckout` command if we are cloning from SBNSoftware/sbncode
+# and nothing else. This means cloning from SBNSoftware/sbncode#somePRnumber will
+# NOT carry this option. This type of cloning can happen in CI builds for example.
+# In other words, we need to fix the hack with another hack: if Supera does not
+# look initialized, we take the matter in our hands and run the git submodule
+# initialization command.
+#
+# (This explanation above might be relevant for any other git submodules.)
 if ( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Supera/.git" )
   execute_process(COMMAND git submodule update --init --recursive
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -29,7 +29,8 @@ add_subdirectory(CosmicID)
 
 # Supera
 if ( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Supera/.git" )
-  execute_process(COMMAND git submodule update --init --recursive)
+  execute_process(COMMAND git submodule update --init --recursive
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
 # We need to run Supera/setup.sh first, otherwise it won't have a CMakeLists.txt.

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -54,7 +54,7 @@ qualifier     larsoft     sbnobj     sbnanaobj  sbndaq_artdaq_core genie_xsec			
 e20:debug     e20:debug   e20:debug  e20:debug  e20:debug:s112     G1810a0211a:k250:e1000	-nq- -nq-	-nq-
 e20:prof      e20:prof    e20:prof   e20:prof   e20:prof:s112      G1810a0211a:k250:e1000   	-nq- e20:p392:prof	-nq-
 c7:debug      c7:debug    c7:debug   c7:debug   c7:debug:s112      G1810a0211a:k250:e1000	-nq- -nq-	-nq-
-c7:prof       c7:prof     c7:prof    c7:prof    c7:prof:s112       G1810a0211a:k250:e1000   	-nq- -nq-	-nq-
+c7:prof       c7:prof     c7:prof    c7:prof    c7:prof:s112       G1810a0211a:k250:e1000   	-nq- c7:p392:prof	-nq-
 end_qualifier_list
 
 # table fragment to set FW_SEARCH_PATH needed to find XML files:

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -34,7 +34,7 @@ fwdir   product_dir scripts
 # Add the dependent product and version
 
 product             version
-larsoft             v09_59_00
+larsoft             v09_60_00
 sbnobj              v09_14_09
 sbnanaobj           v09_19_04
 sbndaq_artdaq_core  v1_01_00of0

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -40,6 +40,7 @@ sbnanaobj           v09_19_01
 sbndaq_artdaq_core  v1_01_00of0
 genie_xsec          v3_00_04a
 sbndata             v01_03
+larcv2              v2_1_0
 
 # list products required ONLY for the build
 # any products here must NOT have qualifiers
@@ -49,11 +50,11 @@ end_product_list
 # We now define allowed qualifiers and the corresponding qualifiers for the dependencies.
 # Make the table by adding columns before "notes".
 
-qualifier     larsoft     sbnobj     sbnanaobj  sbndaq_artdaq_core genie_xsec			sbndata	notes
-e20:debug     e20:debug   e20:debug  e20:debug  e20:debug:s112     G1810a0211a:k250:e1000	-nq-	-nq-	
-e20:prof      e20:prof    e20:prof   e20:prof   e20:prof:s112      G1810a0211a:k250:e1000   	-nq-	-nq-
-c7:debug      c7:debug    c7:debug   c7:debug   c7:debug:s112      G1810a0211a:k250:e1000	-nq-	-nq-
-c7:prof       c7:prof     c7:prof    c7:prof    c7:prof:s112       G1810a0211a:k250:e1000   	-nq-	-nq-
+qualifier     larsoft     sbnobj     sbnanaobj  sbndaq_artdaq_core genie_xsec			sbndata	 larcv2 notes
+e20:debug     e20:debug   e20:debug  e20:debug  e20:debug:s112     G1810a0211a:k250:e1000	-nq- -nq-	-nq-
+e20:prof      e20:prof    e20:prof   e20:prof   e20:prof:s112      G1810a0211a:k250:e1000   	-nq- e20:p392:prof	-nq-
+c7:debug      c7:debug    c7:debug   c7:debug   c7:debug:s112      G1810a0211a:k250:e1000	-nq- -nq-	-nq-
+c7:prof       c7:prof     c7:prof    c7:prof    c7:prof:s112       G1810a0211a:k250:e1000   	-nq- -nq-	-nq-
 end_qualifier_list
 
 # table fragment to set FW_SEARCH_PATH needed to find XML files:


### PR DESCRIPTION
This PR is part of an effort from the ICARUS ML group to merge our pipeline back into the official production workflow.

* Add `larcv2` dependency in `ups/product_deps` because Supera needs it
* Add `Supera` as a git submodule to make it available to both ICARUS and SBND. Supera is a LArSoft module (and several LArCV modules) that 1. makes truth labels for ML-based reconstruction purpose and 2. produces a LArCV file (input format of the ML-based reconstruction chain) from LArsoft products.

**What needs to happen before this can be merged:**
1. `mrb gitCheckout` currently does not initialize nor update git submodules. I submitted a separate PR [here](https://github.com/art-framework-suite/mrb/pull/12) to make it initialize submodules by default.

3. I will update this PR with a commit for the latest Supera version once [this PR](https://github.com/DeepLearnPhysics/Supera/pull/8) (changes to work with SEDLite) is merged. These changes will be needed to run Supera as part of the official workflow.