### PR TITLE
Feature/etw icarusblinding

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -48,6 +48,10 @@ namespace caf
 	Comment("Factor by which to prescale unblind events"), "10"
     };
 
+    Atom<int> POTBlindSeed { Name("POTBlindNum"),
+	Comment("Integer used to derive POT scaling factor for blind events"), 345678
+    };
+
     Atom<std::string> DetectorOverride { Name("DetectorOverride"),
       Comment("Override the automatically detectected detector using 'sbnd' or 'icarus'. This parameter should usually be unset - ''"),
       ""

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -20,18 +20,20 @@ namespace caf
     using string   = std::string;
     using InputTag = art::InputTag;
 
-    /* Atom<bool> EnableBlindness */
-    /* { */
-    /*   Name("EnableBlindness"), */
-    /*   Comment("true = hide sensitive info, false = include full record") */
-    /* }; */
-
     Atom<bool> CreateCAF { Name("CreateCAF"),
       Comment("Whether to produce an output file in CAF format"), true
     };
 
     Atom<bool> CreateFlatCAF { Name("CreateFlatCAF"),
       Comment("Whether to produce an output file in FlatCAF format"), true
+    };
+
+    Atom<bool> CreatePrescaledCAF { Name("CreatePrescaledCAF"),
+      Comment("Whether to produce an output file consisting of a fraction of the events"), true
+    };
+
+    Atom<bool> CreateBlindedCAF { Name("CreateBlindedCAF"),
+      Comment("Whether to produce an output file consisting of the remainder of the events with crtical information "), true
     };
 
     Atom<std::string> CAFFilename { Name("CAFFilename"),
@@ -42,6 +44,10 @@ namespace caf
       Comment("Provide a string to override the automatic filename."), ""
     };
 
+    Atom<std::string> PrescaleFactor { Name("PrescaleFactor"),
+	Comment("Factor by which to prescale unblind events"), "10"
+    };
+
     Atom<std::string> DetectorOverride { Name("DetectorOverride"),
       Comment("Override the automatically detectected detector using 'sbnd' or 'icarus'. This parameter should usually be unset - ''"),
       ""
@@ -50,6 +56,10 @@ namespace caf
     Atom<string> DataTier        { Name("DataTier") };
     Atom<string> FileExtension   { Name("FileExtension"), ".caf.root" };
     Atom<string> FlatCAFFileExtension { Name("FlatCAFFileExtension"), ".flat.caf.root" };
+    Atom<string> UnblindFileExtension   { Name("UnblindFileExtension"), ".Unblind.DONOTLOOK.dum" };
+    Atom<string> BlindFileExtension { Name("BlindFileExtension"), ".Blind.OKTOLOOK.dum" };
+    Atom<string> PrescaleFileExtension { Name("PrescaleFileExtension"), ".Prescaled.OKTOLOOK.dum" };
+
     Atom<string> GeneratorLabel  { Name("GeneratorInput") };
 
     Atom<bool> StrictMode        { Name("StrictMode"),

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -33,7 +33,7 @@ namespace caf
     };
 
     Atom<bool> CreateBlindedCAF { Name("CreateBlindedCAF"),
-      Comment("Whether to produce an output file consisting of the remainder of the events with crtical information "), true
+      Comment("Whether to produce an output file consisting of the remainder of the events with critical information obscured"), true
     };
 
     Atom<std::string> CAFFilename { Name("CAFFilename"),

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -44,12 +44,12 @@ namespace caf
       Comment("Provide a string to override the automatic filename."), ""
     };
 
-    Atom<std::string> PrescaleFactor { Name("PrescaleFactor"),
-	Comment("Factor by which to prescale unblind events"), "10"
+    Atom<float> PrescaleFactor { Name("PrescaleFactor"),
+	Comment("Factor by which to prescale unblind events"), 10
     };
 
     Atom<int> POTBlindSeed { Name("POTBlindNum"),
-	Comment("Integer used to derive POT scaling factor for blind events"), 345678
+	Comment("Integer used to derive POT scaling factor for blind events"), 655277
     };
 
     Atom<std::string> DetectorOverride { Name("DetectorOverride"),

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -231,11 +231,12 @@ class CAFMaker : public art::EDProducer {
   void AddMetadataToFile(TFile* f,
                          const std::map<std::string, std::string>& metadata);
   void AddGlobalTreeToFile(TFile* outfile, caf::SRGlobal& global) const;
-  void AddHistogramsToFile(TFile* outfile) const;
+  void AddHistogramsToFile(TFile* outfile, bool isBlindPOT) const;
 
   void InitializeOutfiles();
 
   void BlindEnergyParameters(StandardRecord* brec);
+  double GetBlindPOTScale() const;
 
   void InitVolumes(); ///< Initialize volumes from Gemotry service
 
@@ -325,12 +326,24 @@ class CAFMaker : public art::EDProducer {
   // setup volume definitions
   InitVolumes();
 
-  // setup random number generator
+  // setup random number generators
   fFakeRecoTRandom = new TRandomMT64(art::ServiceHandle<rndm::NuRandomService>()->getSeed());
   fBlindTRandom = new TRandomMT64(art::ServiceHandle<rndm::NuRandomService>()->getSeed());
-
 }
 
+//......................................................................
+  double CAFMaker::GetBlindPOTScale() const {
+   std::string bstring = std::to_string(fParams.POTBlindSeed());
+   int slen = bstring.length();
+   std::string s1 = bstring.substr(0,int(slen/2));
+   std::string s2 = bstring.substr(int(slen/2));
+   double rat = stoi(s1)/stoi(s2);
+   while (abs(rat)>1){
+     rat = -1 * (abs(rat) - 1);
+   }
+   return rat;
+   
+  }
 //......................................................................
 void CAFMaker::BlindEnergyParameters(StandardRecord* brec) {
 
@@ -1767,7 +1780,7 @@ void CAFMaker::endSubRun(art::SubRun& sr) {
 }
 
 //......................................................................
-void CAFMaker::AddHistogramsToFile(TFile* outfile) const
+  void CAFMaker::AddHistogramsToFile(TFile* outfile, bool isBlindPOT=false) const
 {
   outfile->cd();
 
@@ -1776,7 +1789,13 @@ void CAFMaker::AddHistogramsToFile(TFile* outfile) const
   //    new TH1D("TotalSinglePOT", "TotalSinglePOT;; Single POT", 1, 0, 1);
   TH1* hEvents = new TH1D("TotalEvents", "TotalEvents;; Events", 1, 0, 1);
 
-  hPOT->Fill(.5, fTotalPOT);
+  if (isBlindPOT) {
+    double scale = 1 + 0.5*GetBlindPOTScale();
+    hPOT->Fill(0.5,fTotalPOT*scale);
+  }
+  else {
+    hPOT->Fill(.5, fTotalPOT);
+  }
   hEvents->Fill(.5, fTotalEvents);
 
   hPOT->Write();
@@ -1817,7 +1836,7 @@ void CAFMaker::endJob() {
     }
 
     AddHistogramsToFile(fFile);
-    AddHistogramsToFile(fFileb);
+    AddHistogramsToFile(fFileb,true);
     AddHistogramsToFile(fFilep);
 
     //CB is it ok to comment this out? Was making duplicate trees in file?
@@ -1832,7 +1851,7 @@ void CAFMaker::endJob() {
     fFlatFilep->Write();
 
     AddHistogramsToFile(fFlatFile);
-    AddHistogramsToFile(fFlatFileb);
+    AddHistogramsToFile(fFlatFileb,true);
     AddHistogramsToFile(fFlatFilep);
 
     //fFlatFile->Write();

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -221,8 +221,6 @@ class CAFMaker : public art::EDProducer {
 
   // random number generator for prescaling
   TRandom *fBlindTRandom;
-  bool keepprescale;
-
 
   /// What position in the vector each parameter set take
   std::map<std::string, unsigned int> fWeightPSetIndex;
@@ -1748,6 +1746,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     }
 
     //Generate random number to decide if event is saved in prescale or blinded file
+    bool keepprescale;
     keepprescale = fBlindTRandom->Uniform() < 1/fParams.PrescaleFactor();
     if(fRecTreeb || fRecTreep) {
       rec.hdr.evt = 0;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -352,9 +352,8 @@ void CAFMaker::BlindEnergyParameters(StandardRecord* brec) {
 
   //simple cuts for trk and shower variables
   //blind events with a potential lepton with momentum > 0.6 that starts in fiducial volume
-  for (const caf::SRTrack& trk: brk->reco.trk) {
+  for (caf::SRTrack& trk: brec->reco.trk) {
     const caf::SRVector3D start = trk.start;
-    const caf::SRVector3D end = trk.end;
     if ( ((start.x < -71.1 - 25 && start.x > -369.33 + 25 ) ||
 	  (start.x > 71.1 + 25 && start.x < 369.33 - 25 )) &&
 	 (start.y > -181.7 + 25 && start.y < 134.8 - 25 ) &&
@@ -370,16 +369,17 @@ void CAFMaker::BlindEnergyParameters(StandardRecord* brec) {
   }
 
   //Note shower energy may not be currently very functional
-  for (unsigned int i=0; i<brec->reco.nshw; ++i) {
-    if ( ((brec->reco.shw[i].start.x < -71.1 - 25 && brec->reco.shw[i].start.x > -369.33 + 25 ) ||
-	  (brec->reco.shw[i].start.x > 71.1 + 25 && brec->reco.shw[i].start.x < 369.33 - 25 )) &&
-	 (brec->reco.shw[i].start.y > -181.7 + 25 && brec->reco.shw[i].start.y < 134.8 - 25 ) &&
-	 (brec->reco.shw[i].start.z  > -895.95 + 30 && brec->reco.shw[i].start.z < 895.95 - 50)) {
-      if (brec->reco.shw[i].bestplane_energy > 0.6) {
-	brec->reco.shw[i].bestplane_energy = TMath::QuietNaN();
-	brec->reco.shw[i].plane[0].energy = TMath::QuietNaN();
-	brec->reco.shw[i].plane[1].energy = TMath::QuietNaN();
-	brec->reco.shw[i].plane[2].energy = TMath::QuietNaN();
+  for (caf::SRShower& shw: brec->reco.shw) {
+    const caf::SRVector3D start = shw.start;
+    if ( ((start.x < -71.1 - 25 && start.x > -369.33 + 25 ) ||
+	  (start.x > 71.1 + 25 && start.x < 369.33 - 25 )) &&
+	 (start.y > -181.7 + 25 && start.y < 134.8 - 25 ) &&
+	 (start.z  > -895.95 + 30 && start.z < 895.95 - 50)) {
+      if (shw.bestplane_energy > 0.6) {
+	shw.bestplane_energy = TMath::QuietNaN();
+	shw.plane[0].energy = TMath::QuietNaN();
+	shw.plane[1].energy = TMath::QuietNaN();
+	shw.plane[2].energy = TMath::QuietNaN();
       }
     }
   }

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -44,6 +44,7 @@
 #include "TFile.h"
 #include "TH1D.h"
 #include "TTree.h"
+#include "TMath.h"
 #include "TTimeStamp.h"
 #include "TRandomGen.h"
 #include "TObjString.h"
@@ -358,10 +359,10 @@ void CAFMaker::BlindEnergyParameters(StandardRecord* brec) {
 	 (brec->reco.trk[i].start.z  > -895.95 + 30 && brec->reco.trk[i].start.z < 895.95 - 50)) {
 
       if (brec->reco.trk[i].mcsP.fwdP_muon > 0.6) {
-	brec->reco.trk[i].mcsP.fwdP_muon = NAN;    
+	brec->reco.trk[i].mcsP.fwdP_muon = TMath::QuietNaN();    
       }
       if (brec->reco.trk[i].rangeP.p_muon > 0.6) {
-	brec->reco.trk[i].rangeP.p_muon = NAN;
+	brec->reco.trk[i].rangeP.p_muon = TMath::QuietNaN();
       }
     }
   }
@@ -372,10 +373,10 @@ void CAFMaker::BlindEnergyParameters(StandardRecord* brec) {
 	 (brec->reco.shw[i].start.y > -181.7 + 25 && brec->reco.shw[i].start.y < 134.8 - 25 ) &&
 	 (brec->reco.shw[i].start.z  > -895.95 + 30 && brec->reco.shw[i].start.z < 895.95 - 50)) {
       if (brec->reco.shw[i].bestplane_energy > 0.6) {
-	brec->reco.shw[i].bestplane_energy = NAN;
-	brec->reco.shw[i].plane[0].energy = NAN;
-	brec->reco.shw[i].plane[1].energy = NAN;
-	brec->reco.shw[i].plane[2].energy = NAN;
+	brec->reco.shw[i].bestplane_energy = TMath::QuietNaN();
+	brec->reco.shw[i].plane[0].energy = TMath::QuietNaN();
+	brec->reco.shw[i].plane[1].energy = TMath::QuietNaN();
+	brec->reco.shw[i].plane[2].energy = TMath::QuietNaN();
       }
     }
   }
@@ -390,17 +391,17 @@ void CAFMaker::BlindEnergyParameters(StandardRecord* brec) {
       //std::cout << brec->slc[islc].reco.ntrk << ", " brec->slc[islc].reco.trk.size() << std::endl;
       for (unsigned int itrk=0; itrk<brec->slc[islc].reco.ntrk; ++itrk) {
 	if (brec->slc[islc].reco.trk[itrk].mcsP.fwdP_muon > 0.6) {
-	  brec->slc[islc].reco.trk[itrk].mcsP.fwdP_muon = NAN;    
+	  brec->slc[islc].reco.trk[itrk].mcsP.fwdP_muon = TMath::QuietNaN();    
 	}
 	if (brec->slc[islc].reco.trk[itrk].rangeP.p_muon > 0.6) {
-	  brec->slc[islc].reco.trk[itrk].rangeP.p_muon = NAN;
+	  brec->slc[islc].reco.trk[itrk].rangeP.p_muon = TMath::QuietNaN();
 	}
       }
       for (unsigned int ishw=0; ishw<brec->slc[islc].reco.nshw; ++ishw) {
-	brec->slc[islc].reco.shw[ishw].bestplane_energy = NAN;
-	brec->slc[islc].reco.shw[ishw].plane[0].energy = NAN;
-	brec->slc[islc].reco.shw[ishw].plane[1].energy = NAN;
-	brec->slc[islc].reco.shw[ishw].plane[2].energy = NAN;
+	brec->slc[islc].reco.shw[ishw].bestplane_energy = TMath::QuietNaN();
+	brec->slc[islc].reco.shw[ishw].plane[0].energy = TMath::QuietNaN();
+	brec->slc[islc].reco.shw[ishw].plane[1].energy = TMath::QuietNaN();
+	brec->slc[islc].reco.shw[ishw].plane[2].energy = TMath::QuietNaN();
       }
     }
   }
@@ -774,12 +775,11 @@ void CAFMaker::InitializeOutfiles()
     if (fParams.CreateBlindedCAF()) {
       mf::LogInfo("CAFMaker") << "Blinded output filenames are " << fCafBlindFilename << ", and " << fCafPrescaleFilename;
       fFileb = new TFile(fCafBlindFilename.c_str(), "RECREATE");
-      fFilep = new TFile(fCafPrescaleFilename.c_str(), "RECREATE");
-
       fRecTreeb = new TTree("recTree", "records");
-      fRecTreep = new TTree("recTree", "records");
-
       fRecTreeb->Branch("rec", "caf::StandardRecord", &rec);
+
+      fFilep = new TFile(fCafPrescaleFilename.c_str(), "RECREATE");
+      fRecTreep = new TTree("recTree", "records");
       fRecTreep->Branch("rec", "caf::StandardRecord", &rec);
 
       AddEnvToFile(fFileb);
@@ -1840,9 +1840,12 @@ void CAFMaker::endJob() {
       fFlatTreep->SetDirectory(fFlatFilep);
     }
 
+    fFile->cd();
     fFile->Write();
     if (fFileb) {
+      fFileb->cd();
       fFileb->Write();
+      fFilep->cd();
       fFilep->Write();
     }
 
@@ -1850,10 +1853,11 @@ void CAFMaker::endJob() {
     AddHistogramsToFile(fFileb,true,false);
     AddHistogramsToFile(fFilep,false,true);
 
-    //CB is it ok to comment this out? Was making duplicate trees in file?
     //fFile->Write();
+    //if (fFileb) {
     //fFileb->Write();
     //fFilep->Write();
+    //}
   }
 
   if(fFlatFile){

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1748,8 +1748,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     }
 
     //Generate random number to decide if event is saved in prescale or blinded file
-    bool keepprescale;
-    keepprescale = fBlindTRandom->Uniform() < 1/fParams.PrescaleFactor();
+    const bool keepprescale = fBlindTRandom->Uniform() < 1/fParams.PrescaleFactor();
     if(fRecTreeb || fRecTreep) {
       rec.hdr.evt = 0;
       if (keepprescale) {

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1724,7 +1724,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     rec.hdr.numiinfo = fNuMIInfo;
     rec.hdr.pot   = fSubRunPOT;
   }
-
+  
   rec.hdr.ngenevt = n_gen_evt;
   rec.hdr.mctype  = mctype;
   rec.hdr.first_in_file = fFirstInFile;
@@ -1750,12 +1750,19 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     //Generate random number to decide if event is saved in prescale or blinded file
     keepprescale = fBlindTRandom->Uniform() < 1/fParams.PrescaleFactor();
     if(fRecTreeb || fRecTreep) {
+      rec.hdr.evt = 0;
       if (keepprescale) {
       	StandardRecord* precp = new StandardRecord (*prec);
 	if (fFirstPrescaleInFile) {
 	  precp->hdr.pot = fSubRunPOT*(1/fParams.PrescaleFactor());
-	  }
-      	fRecTreep->SetBranchAddress("rec", &precp);
+	  precp->hdr.first_in_file = true;
+	  precp->hdr.first_in_subrun = true;
+	  precp->hdr.nbnbinfo = fBNBInfo.size()*(1/fParams.PrescaleFactor());
+	  precp->hdr.nnumiinfo = fNuMIInfo.size()*(1/fParams.PrescaleFactor());
+	}
+	precp->hdr.ngenevt = n_gen_evt*(1/fParams.PrescaleFactor());
+	precp->hdr.evt = evtID;
+	fRecTreep->SetBranchAddress("rec", &precp);
       	fRecTreep->Fill();
 	fPrescaleEvents += 1;
 	if (fFlatTree) {
@@ -1763,14 +1770,20 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 	  fFlatRecordp->Fill(*precp);
 	  fFlatTreep->Fill();
 	}
-      fFirstPrescaleInFile = false;
+	fFirstPrescaleInFile = false;
       }
       else {
 	StandardRecord* precb = new StandardRecord (*prec);
 	BlindEnergyParameters(precb);
 	if (fFirstBlindInFile) {
 	  precb->hdr.pot = fSubRunPOT*(1-(1/fParams.PrescaleFactor()))*GetBlindPOTScale();
-	  }
+	  precb->hdr.first_in_file = true;
+	  precb->hdr.first_in_subrun = true;
+	  precb->hdr.nbnbinfo = fBNBInfo.size()*(1 - (1/fParams.PrescaleFactor()));
+	  precb->hdr.nnumiinfo = fNuMIInfo.size()*(1-(1/fParams.PrescaleFactor()));
+	}
+	precb->hdr.ngenevt = n_gen_evt*(1 - (1/fParams.PrescaleFactor()));
+	precb->hdr.evt = evtID;
 	fRecTreeb->SetBranchAddress("rec", &precb);
 	fRecTreeb->Fill();
 	fBlindEvents += 1;
@@ -1778,8 +1791,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 	  fFlatRecordb->Clear();
 	  fFlatRecordb->Fill(*precb);
 	  fFlatTreeb->Fill();
-	fFirstBlindInFile = false;
 	}
+	fFirstBlindInFile = false;
       }
     }  
   }

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -165,7 +165,12 @@ class CAFMaker : public art::EDProducer {
   CAFMakerParams fParams;
 
   std::string fCafFilename;
+  std::string fCafBlindFilename;
+  std::string fCafPrescaleFilename;
+
   std::string fFlatCafFilename;
+  std::string fFlatCafBlindFilename;
+  std::string fFlatCafPrescaleFilename;
 
   bool fFirstInSubRun;
   bool fFirstInFile;
@@ -181,12 +186,24 @@ class CAFMaker : public art::EDProducer {
   // int fBatch;
 
   TFile* fFile = 0;
+  TFile* fFileb = 0;
+  TFile* fFilep = 0;
+
   TTree* fRecTree = 0;
+  TTree* fRecTreeb = 0;
+  TTree* fRecTreep = 0;
 
   TFile* fFlatFile = 0;
+  TFile* fFlatFileb = 0;
+  TFile* fFlatFilep = 0;
+
   TTree* fFlatTree = 0;
+  TTree* fFlatTreeb = 0;
+  TTree* fFlatTreep = 0;
 
   flat::Flat<caf::StandardRecord>* fFlatRecord = 0;
+  flat::Flat<caf::StandardRecord>* fFlatRecordb = 0;
+  flat::Flat<caf::StandardRecord>* fFlatRecordp = 0;
 
   Det_t fDet;  ///< Detector ID in caf namespace typedef
 
@@ -196,6 +213,11 @@ class CAFMaker : public art::EDProducer {
 
   // random number generator for fake reco
   TRandom *fFakeRecoTRandom;
+
+  // random number generator for prescaling
+  TRandom *fBlindTRandom;
+  bool keepprescale;
+
 
   /// What position in the vector each parameter set take
   std::map<std::string, unsigned int> fWeightPSetIndex;
@@ -212,6 +234,8 @@ class CAFMaker : public art::EDProducer {
   void AddHistogramsToFile(TFile* outfile) const;
 
   void InitializeOutfiles();
+
+  void BlindEnergyParameters(StandardRecord* brec);
 
   void InitVolumes(); ///< Initialize volumes from Gemotry service
 
@@ -303,7 +327,68 @@ class CAFMaker : public art::EDProducer {
 
   // setup random number generator
   fFakeRecoTRandom = new TRandomMT64(art::ServiceHandle<rndm::NuRandomService>()->getSeed());
+  fBlindTRandom = new TRandomMT64(art::ServiceHandle<rndm::NuRandomService>()->getSeed());
 
+}
+
+//......................................................................
+void CAFMaker::BlindEnergyParameters(StandardRecord* brec) {
+
+  //simple cuts for trk and shower variables
+  //blind events with a potential lepton with momentum > 0.6 that starts in fiducial volume
+  for (unsigned int i=0; i<brec->reco.ntrk; ++i) {
+    if ( ((brec->reco.trk[i].start.x < -71.1 - 25 && brec->reco.trk[i].start.x > -369.33 + 25 ) ||
+	  (brec->reco.trk[i].start.x > 71.1 + 25 && brec->reco.trk[i].start.x < 369.33 - 25 )) &&
+	 (brec->reco.trk[i].start.y > -181.7 + 25 && brec->reco.trk[i].start.y < 134.8 - 25 ) &&
+	 (brec->reco.trk[i].start.z  > -895.95 + 30 && brec->reco.trk[i].start.z < 895.95 - 50)) {
+
+      if (brec->reco.trk[i].mcsP.fwdP_muon > 0.6) {
+	brec->reco.trk[i].mcsP.fwdP_muon = NAN;    
+      }
+      if (brec->reco.trk[i].rangeP.p_muon > 0.6) {
+	brec->reco.trk[i].rangeP.p_muon = NAN;
+      }
+    }
+  }
+
+  for (unsigned int i=0; i<brec->reco.nshw; ++i) {
+    if ( ((brec->reco.shw[i].start.x < -71.1 - 25 && brec->reco.shw[i].start.x > -369.33 + 25 ) ||
+	  (brec->reco.shw[i].start.x > 71.1 + 25 && brec->reco.shw[i].start.x < 369.33 - 25 )) &&
+	 (brec->reco.shw[i].start.y > -181.7 + 25 && brec->reco.shw[i].start.y < 134.8 - 25 ) &&
+	 (brec->reco.shw[i].start.z  > -895.95 + 30 && brec->reco.shw[i].start.z < 895.95 - 50)) {
+      if (brec->reco.shw[i].bestplane_energy > 0.6) {
+	brec->reco.shw[i].bestplane_energy = NAN;
+	brec->reco.shw[i].plane[0].energy = NAN;
+	brec->reco.shw[i].plane[1].energy = NAN;
+	brec->reco.shw[i].plane[2].energy = NAN;
+      }
+    }
+  }
+
+  // And for slices, check vertex in FV and then check tracks and showers
+  for (int islc=0; islc<brec->nslc; ++islc) {
+    if ( ((brec->slc[islc].vertex.x < -71.1 - 25 && brec->slc[islc].vertex.x > -369.33 + 25 ) ||
+	  (brec->slc[islc].vertex.x > 71.1 + 25 && brec->slc[islc].vertex.x < 369.33 - 25 )) &&
+	 (brec->slc[islc].vertex.y > -181.7 + 25 && brec->slc[islc].vertex.y < 134.8 - 25 ) &&
+	 (brec->slc[islc].vertex.z  > -895.95 + 30 && brec->slc[islc].vertex.z < 895.95 - 50)) {
+
+      //std::cout << brec->slc[islc].reco.ntrk << ", " brec->slc[islc].reco.trk.size() << std::endl;
+      for (unsigned int itrk=0; itrk<brec->slc[islc].reco.ntrk; ++itrk) {
+	if (brec->slc[islc].reco.trk[itrk].mcsP.fwdP_muon > 0.6) {
+	  brec->slc[islc].reco.trk[itrk].mcsP.fwdP_muon = NAN;    
+	}
+	if (brec->slc[islc].reco.trk[itrk].rangeP.p_muon > 0.6) {
+	  brec->slc[islc].reco.trk[itrk].rangeP.p_muon = NAN;
+	}
+      }
+      for (unsigned int ishw=0; ishw<brec->slc[islc].reco.nshw; ++ishw) {
+	brec->slc[islc].reco.shw[ishw].bestplane_energy = NAN;
+	brec->slc[islc].reco.shw[ishw].plane[0].energy = NAN;
+	brec->slc[islc].reco.shw[ishw].plane[1].energy = NAN;
+	brec->slc[islc].reco.shw[ishw].plane[2].energy = NAN;
+      }
+    }
+  }
 }
 
 void CAFMaker::InitVolumes() {
@@ -340,13 +425,24 @@ void CAFMaker::InitVolumes() {
 CAFMaker::~CAFMaker()
 {
   delete fRecTree;
+  delete fRecTreeb;
+  delete fRecTreep;
   delete fFile;
+  delete fFileb;
+  delete fFilep;
 
   delete fFlatRecord;
+  delete fFlatRecordb;
+  delete fFlatRecordp;
   delete fFlatTree;
+  delete fFlatTreeb;
+  delete fFlatTreep;
   delete fFlatFile;
+  delete fFlatFileb;
+  delete fFlatFilep;
 
   delete fFakeRecoTRandom;
+  delete fBlindTRandom;
 }
 
 //......................................................................
@@ -371,10 +467,30 @@ void CAFMaker::respondToOpenInputFile(const art::FileBlock& fb) {
     // If Filename wasn't set in the FCL, and this is the
     // first file we've seen
     if(fParams.CreateCAF() && fCafFilename.empty()){
-      fCafFilename = DeriveFilename(fb.fileName(), fParams.FileExtension());
+      if (fParams.CreateBlindedCAF()){
+	fCafFilename = DeriveFilename(fb.fileName(), fParams.UnblindFileExtension());
+	fCafFilename = DeriveFilename(fCafFilename, fParams.FileExtension());
+	fCafBlindFilename = DeriveFilename(fb.fileName(), fParams.BlindFileExtension());
+	fCafBlindFilename = DeriveFilename(fCafBlindFilename, fParams.FileExtension());
+	fCafPrescaleFilename = DeriveFilename(fb.fileName(), fParams.PrescaleFileExtension());
+	fCafPrescaleFilename = DeriveFilename(fCafPrescaleFilename, fParams.FileExtension());
+      }
+      else {
+	fCafFilename = DeriveFilename(fb.fileName(), fParams.FileExtension());
+      }
     }
     if(fParams.CreateFlatCAF() && fFlatCafFilename.empty()){
-      fFlatCafFilename = DeriveFilename(fb.fileName(), fParams.FlatCAFFileExtension());
+      if (fParams.CreateBlindedCAF()){
+	fFlatCafFilename = DeriveFilename(fb.fileName(), fParams.UnblindFileExtension());
+	fFlatCafFilename = DeriveFilename(fFlatCafFilename, fParams.FlatCAFFileExtension());
+	fFlatCafBlindFilename = DeriveFilename(fb.fileName(), fParams.BlindFileExtension());
+	fFlatCafBlindFilename = DeriveFilename(fFlatCafBlindFilename, fParams.FlatCAFFileExtension());
+	fFlatCafPrescaleFilename = DeriveFilename(fb.fileName(), fParams.PrescaleFileExtension());
+	fFlatCafPrescaleFilename = DeriveFilename(fFlatCafPrescaleFilename, fParams.FlatCAFFileExtension());
+      }
+      else {
+	fFlatCafFilename = DeriveFilename(fb.fileName(), fParams.FlatCAFFileExtension());
+      }
     }
 
     InitializeOutfiles();
@@ -498,7 +614,11 @@ void CAFMaker::beginRun(art::Run& run) {
   } // end for label
 
   if(fFile) AddGlobalTreeToFile(fFile, global);
+  if(fFileb) AddGlobalTreeToFile(fFileb, global);
+  if(fFilep) AddGlobalTreeToFile(fFilep, global);
   if(fFlatFile) AddGlobalTreeToFile(fFlatFile, global);
+  if(fFlatFileb) AddGlobalTreeToFile(fFlatFileb, global);
+  if(fFlatFilep) AddGlobalTreeToFile(fFlatFilep, global);
 }
 
 //......................................................................
@@ -623,10 +743,11 @@ void CAFMaker::AddMetadataToFile(TFile* outfile, const std::map<std::string, std
 void CAFMaker::InitializeOutfiles()
 {
   if(fParams.CreateCAF()){
+
     mf::LogInfo("CAFMaker") << "Output filename is " << fCafFilename;
 
     fFile = new TFile(fCafFilename.c_str(), "RECREATE");
-
+    
     fRecTree = new TTree("recTree", "records");
 
     // Tell the tree it's expecting StandardRecord objects
@@ -634,7 +755,23 @@ void CAFMaker::InitializeOutfiles()
     fRecTree->Branch("rec", "caf::StandardRecord", &rec);
 
     AddEnvToFile(fFile);
-  }
+ 
+    if (fParams.CreateBlindedCAF()) {
+      mf::LogInfo("CAFMaker") << "Blinded output filenames are " << fCafBlindFilename << ", and " << fCafPrescaleFilename;
+      fFileb = new TFile(fCafBlindFilename.c_str(), "RECREATE");
+      fFilep = new TFile(fCafPrescaleFilename.c_str(), "RECREATE");
+
+      fRecTreeb = new TTree("recTree", "records");
+      fRecTreep = new TTree("recTree", "records");
+
+      fRecTreeb->Branch("rec", "caf::StandardRecord", &rec);
+      fRecTreep->Branch("rec", "caf::StandardRecord", &rec);
+
+      AddEnvToFile(fFileb);
+      AddEnvToFile(fFilep);
+    }
+
+  }     
 
   if(fParams.CreateFlatCAF()){
     mf::LogInfo("CAFMaker") << "Output flat filename is " << fFlatCafFilename;
@@ -649,6 +786,29 @@ void CAFMaker::InitializeOutfiles()
     fFlatRecord = new flat::Flat<caf::StandardRecord>(fFlatTree, "rec", "", 0);
 
     AddEnvToFile(fFlatFile);
+
+    if (fParams.CreateBlindedCAF()) {
+
+      mf::LogInfo("CAFMaker") << "Blinded output flat filename are " << fFlatCafBlindFilename << ", and " << fFlatCafPrescaleFilename;
+
+      // LZ4 is the fastest format to decompress. I get 3x faster loading with
+      // this compared to the default, and the files are only slightly larger.
+      fFlatFileb = new TFile(fFlatCafBlindFilename.c_str(), "RECREATE", "",
+			     ROOT::CompressionSettings(ROOT::kLZ4, 1));
+
+      fFlatFilep = new TFile(fFlatCafPrescaleFilename.c_str(), "RECREATE", "",
+			     ROOT::CompressionSettings(ROOT::kLZ4, 1));
+
+      fFlatTreeb = new TTree("recTree", "recTree");
+      fFlatTreep = new TTree("recTree", "recTree");
+
+      fFlatRecordb = new flat::Flat<caf::StandardRecord>(fFlatTreeb, "rec", "", 0);
+      fFlatRecordp = new flat::Flat<caf::StandardRecord>(fFlatTreep, "rec", "", 0);
+
+      AddEnvToFile(fFlatFileb);
+      AddEnvToFile(fFlatFilep);
+    }
+
   }
 
   fFileNumber = -1;
@@ -661,6 +821,7 @@ void CAFMaker::InitializeOutfiles()
   // fCycle = -5;
   // fBatch = -5;
 }
+
 
 //......................................................................
 template <class T, class U>
@@ -1559,12 +1720,38 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     StandardRecord* prec = &rec;
     fRecTree->SetBranchAddress("rec", &prec);
     fRecTree->Fill();
-  }
 
-  if(fFlatTree){
-    fFlatRecord->Clear();
-    fFlatRecord->Fill(rec);
-    fFlatTree->Fill();
+    if(fFlatTree){
+      fFlatRecord->Clear();
+      fFlatRecord->Fill(rec);
+      fFlatTree->Fill();
+    }
+
+    //Generate random number to decide if event is saved in prescale or blinded file
+    keepprescale = fBlindTRandom->Uniform() < 1/std::stof(fParams.PrescaleFactor());
+    if(fRecTreeb || fRecTreep) {
+      if (keepprescale) {
+      	StandardRecord* precp = new StandardRecord (*prec);
+      	fRecTreep->SetBranchAddress("rec", &precp);
+      	fRecTreep->Fill();
+	if (fFlatTree) {
+	  fFlatRecordp->Clear();
+	  fFlatRecordp->Fill(*precp);
+	  fFlatTreep->Fill();
+	}
+      }
+      else {
+	StandardRecord* precb = new StandardRecord (*prec);
+	BlindEnergyParameters(precb);
+	fRecTreeb->SetBranchAddress("rec", &precb);
+	fRecTreeb->Fill();
+	if (fFlatTree) {
+	  fFlatRecordb->Clear();
+	  fFlatRecordb->Fill(*precb);
+	  fFlatTreeb->Fill();
+	}
+      }
+    }
   }
 
   srcol->push_back(rec);
@@ -1612,17 +1799,45 @@ void CAFMaker::endJob() {
   if(fFile){
     // Make sure the recTree is in the file before filling other items
     // for debugging.
+    fRecTree->SetDirectory(fFile);
+    fFlatTree->SetDirectory(fFlatFile);
+    if (fFileb){
+      fRecTreeb->SetDirectory(fFileb);
+      fRecTreep->SetDirectory(fFilep);
+    }
+    if (fFlatFile) {
+      fFlatTreeb->SetDirectory(fFlatFileb);
+      fFlatTreep->SetDirectory(fFlatFilep);
+    }
+
     fFile->Write();
+    if (fFileb) {
+      fFileb->Write();
+      fFilep->Write();
+    }
 
     AddHistogramsToFile(fFile);
-    fFile->Write();
+    AddHistogramsToFile(fFileb);
+    AddHistogramsToFile(fFilep);
+
+    //CB is it ok to comment this out? Was making duplicate trees in file?
+    //fFile->Write();
+    //fFileb->Write();
+    //fFilep->Write();
   }
 
   if(fFlatFile){
     fFlatFile->Write();
+    fFlatFileb->Write();
+    fFlatFilep->Write();
 
     AddHistogramsToFile(fFlatFile);
-    fFlatFile->Write();
+    AddHistogramsToFile(fFlatFileb);
+    AddHistogramsToFile(fFlatFilep);
+
+    //fFlatFile->Write();
+    //fFlatFileb->Write();
+    //fFlatFilep->Write();
   }
 
   std::map<std::string, std::string> metamap;
@@ -1647,7 +1862,11 @@ void CAFMaker::endJob() {
   }
 
   if(fFile) AddMetadataToFile(fFile, metamap);
+  if(fFileb) AddMetadataToFile(fFileb, metamap);
+  if(fFilep) AddMetadataToFile(fFilep, metamap);
   if(fFlatFile) AddMetadataToFile(fFlatFile, metamap);
+  if(fFlatFileb) AddMetadataToFile(fFlatFileb, metamap);
+  if(fFlatFilep) AddMetadataToFile(fFlatFilep, metamap);
 }
 
 


### PR DESCRIPTION
Creates "prescaled" and "blind" CAF files alongside the regular CAF files. Prescaled files have 10% of events, blinded files have 90% of events and have some momentum/energy variables set to nan and an unknown offset applied to the POT. Unblind CAFs should be unchanged. I set this up as default, but happy to switch that if desired.