### PR TITLE
Fill new fmatch.time_beam variable

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1551,6 +1551,20 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     FillSliceVertex(vertex, recslc);
     FillSliceCRUMBS(slcCRUMBS, recslc);
 
+    // Fill flash match time wrt beam spill
+    if(isRealData) {
+      // If no trigger just ignore this variable
+      if(fSRTrigger.size() > 0) {
+        // fSRTrigger is vector of events, but we should only be looking at
+        // one event at a time. So just use first trigger in the vector.
+        recslc.fmatch.time_beam = recslc.fmatch.time + fSRTrigger[0].trigger_within_gate/1000.0;
+      }
+    } else {
+      // In MC fmatch.time is currently time wrt to beam. 
+      // If this changes this code will need to change.
+      recslc.fmatch.time_beam = recslc.fmatch.time;
+    }
+
     // select slice
     if (!SelectSlice(recslc, fParams.CutClearCosmic())) continue;
 


### PR DESCRIPTION
Code to fill new time_beam variable in SRFlashMatch.

I am filling in CAFMaker_module instead of FillFlashMatch since this depends on the trigger information and the isRealData flag. It seemed simpler to just add the code to CAFMaker_module than to pass those to FillSliceFlashMatch.

Depends on https://github.com/SBNSoftware/sbnanaobj/pull/77



