### PR TITLE
Feature/etw icarusblinding

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -530,7 +530,7 @@ void CAFMaker::respondToOpenInputFile(const art::FileBlock& fb) {
       fCafPrescaleFilename = DeriveFilename(basename, fParams.PrescaleFileExtension());
       fCafPrescaleFilename = DeriveFilename(fCafPrescaleFilename, fParams.FileExtension());
     }
-    if (fParams.CreateBlindedCAF() && fFlatCafBlindFilename.empty()) {
+    if (fParams.CreateBlindedCAF() && fParams.CreateFlatCAF() && fFlatCafBlindFilename.empty()) {
       const std::string basename = fFlatCafFilename;
       fFlatCafBlindFilename = DeriveFilename(basename, fParams.BlindFileExtension());
       fFlatCafBlindFilename = DeriveFilename(fFlatCafBlindFilename, fParams.FlatCAFFileExtension());

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1961,18 +1961,13 @@ void CAFMaker::endJob() {
 
 
   if(fFile){
+
     AddHistogramsToFile(fFile);
     fRecTree->SetDirectory(fFile);
-    fFlatTree->SetDirectory(fFlatFile);
     if (fParams.CreateBlindedCAF()) {
       fRecTreeb->SetDirectory(fFileb);
       fRecTreep->SetDirectory(fFilep);
     }
-    if (fParams.CreateBlindedCAF() && fFlatFileb) {
-      fFlatTreeb->SetDirectory(fFlatFileb);
-      fFlatTreep->SetDirectory(fFlatFilep);
-    }
-
     fFile->cd();
     fFile->Write();
     if (fParams.CreateBlindedCAF()) {
@@ -1987,13 +1982,21 @@ void CAFMaker::endJob() {
   }
 
   if(fFlatFile){
-    AddHistogramsToFile(fFlatFile);
-    fFlatFile->Write();
 
+    AddHistogramsToFile(fFlatFile);
+    fFlatTree->SetDirectory(fFlatFile);
+    if (fParams.CreateBlindedCAF() && fFlatFileb) {
+      fFlatTreeb->SetDirectory(fFlatFileb);
+      fFlatTreep->SetDirectory(fFlatFilep);
+    }
+    fFlatFile->cd();
+    fFlatFile->Write();
     if (fParams.CreateBlindedCAF()) {
       AddHistogramsToFile(fFlatFileb,true,false);
+      fFlatFileb->cd();
       fFlatFileb->Write();
       AddHistogramsToFile(fFlatFilep,false,true);
+      fFlatFilep->cd();
       fFlatFilep->Write();
     }
   }


### PR DESCRIPTION
Two things - this fixes yet another bug in the output files - this time the flat cafs were corrupted, which has been fixed with this update. The second thing is to fill a flag in the header which labels whether a file is blinded/prescaled or not. The second thing depends on sbnanaobj PR #78, which adds that flag to SRHeader.