### PR TITLE
Reference PMT times and Update SRTrigger

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -263,7 +263,7 @@ namespace caf
       0,
     };
 
-    Atom<art::InputTag> TriggerLabel {
+    Atom<string> TriggerLabel {
       Name("TriggerLabel"),
       Comment("Label of trigger."),
       "daqTrigger"
@@ -321,6 +321,12 @@ namespace caf
       Name("TrackHitFillRREndCut"),
       Comment("How long from the end of a track to save calo-point information. Set to -1 to save nothing"),
       25.
+    };
+
+    Atom<bool> ReferencePMTFromTriggerToBeam {
+      Name("ReferencePMTFromTriggerToBeam"),
+      Comment("Whether to switch the reference time of PMT reco from 'trigger' to 'beam spill' time."),
+      true,
     };
   };
 }

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -263,7 +263,7 @@ namespace caf
       0,
     };
 
-    Atom<string> TriggerLabel {
+    Atom<art::InputTag> TriggerLabel {
       Name("TriggerLabel"),
       Comment("Label of trigger."),
       "daqTrigger"
@@ -326,7 +326,7 @@ namespace caf
     Atom<bool> ReferencePMTFromTriggerToBeam {
       Name("ReferencePMTFromTriggerToBeam"),
       Comment("Whether to switch the reference time of PMT reco from 'trigger' to 'beam spill' time."),
-      true,
+      true
     };
   };
 }

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1088,7 +1088,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   }
 
   art::Handle<std::vector<simb::MCFlux>> mcflux_handle;
-  GetByLabelStrict(evt, "generator", mcflux_handle);
+  GetByLabelStrict(evt, std::string("generator"), mcflux_handle);
 
   std::vector<art::Ptr<simb::MCFlux>> mcfluxes;
   if (mcflux_handle.isValid()) {
@@ -1097,7 +1097,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 
   // get the MCReco for the fake-reco
   art::Handle<std::vector<sim::MCTrack>> mctrack_handle;
-  GetByLabelStrict(evt, "mcreco", mctrack_handle);
+  GetByLabelStrict(evt, std::string("mcreco"), mctrack_handle);
   std::vector<art::Ptr<sim::MCTrack>> mctracks;
   if (mctrack_handle.isValid()) {
     art::fill_ptr_vector(mctracks, mctrack_handle);

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -284,6 +284,9 @@ class CAFMaker : public art::EDProducer {
   template <class EvtT, class T>
   void GetByLabelStrict(const EvtT& evt, const std::string& label,
                         art::Handle<T>& handle) const;
+  template <class EvtT, class T>
+  void GetByLabelStrict(const EvtT& evt, const art::InputTag& label,
+                        art::Handle<T>& handle) const;
 
   /// Equivalent of evt.getByLabel(label, handle) except failedToGet
   /// prints a message.
@@ -965,6 +968,20 @@ bool CAFMaker::GetAssociatedProduct(const art::FindManyP<T>& fm, int idx,
 //......................................................................
 template <class EvtT, class T>
 void CAFMaker::GetByLabelStrict(const EvtT& evt, const std::string& label,
+                                art::Handle<T>& handle) const {
+  evt.getByLabel(label, handle);
+  if (!label.empty() && handle.failedToGet() && fParams.StrictMode()) {
+    std::cout << "CAFMaker: No product of type '"
+              << cet::demangle_symbol(typeid(*handle).name())
+              << "' found under label '" << label << "'. "
+              << "Set 'StrictMode: false' to continue anyway." << std::endl;
+    abort();
+  }
+}
+
+//......................................................................
+template <class EvtT, class T>
+void CAFMaker::GetByLabelStrict(const EvtT& evt, const art::InputTag& label,
                                 art::Handle<T>& handle) const {
   evt.getByLabel(label, handle);
   if (!label.empty() && handle.failedToGet() && fParams.StrictMode()) {

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -245,7 +245,7 @@ class CAFMaker : public art::EDProducer {
 
   void InitVolumes(); ///< Initialize volumes from Gemotry service
 
-  void ReferencePMTTimes(StandardRecord &rec, double PMT_refernce_time);
+  void FixPMTReferenceTimes(StandardRecord &rec, double PMT_reference_time);
 
   /// Equivalent of FindManyP except a return that is !isValid() prints a
   /// messsage and aborts if StrictMode is true.
@@ -418,19 +418,19 @@ void CAFMaker::BlindEnergyParameters(StandardRecord* brec) {
   }
 }
 
-void CAFMaker::ReferencePMTTimes(StandardRecord &rec, double PMT_refernce_time) {
+void CAFMaker::FixPMTReferenceTimes(StandardRecord &rec, double PMT_reference_time) {
   // Fix the flashes
   for (SROpFlash &f: rec.opflashes) {
-    f.time += PMT_refernce_time;
-    f.timemean += PMT_refernce_time;
-    f.firsttime += PMT_refernce_time;
+    f.time += PMT_reference_time;
+    f.timemean += PMT_reference_time;
+    f.firsttime += PMT_reference_time;
   }
 
   // Fix the flash matches
   for (SRSlice &s: rec.slc) {
-    s.fmatch.time += PMT_refernce_time;
-    s.fmatch_a.time += PMT_refernce_time;
-    s.fmatch_b.time += PMT_refernce_time;
+    s.fmatch.time += PMT_reference_time;
+    s.fmatch_a.time += PMT_reference_time;
+    s.fmatch_b.time += PMT_reference_time;
   }
 
   // TODO: fix more?
@@ -1277,7 +1277,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       }
       else{
         std::cout << "Unexpected in " << evt.id() << ": there are " << trgs.size()
-          << " triggers in '" << fParams.TriggerLabel() << "' data product."
+          << " triggers in '" << fParams.TriggerLabel().encode() << "' data product."
           << " Please contact CAFmaker maintainer." << std::endl;
         abort();
       }
@@ -1817,7 +1817,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   //
   // PMT's:
   double PMT_reference_time = fParams.ReferencePMTFromTriggerToBeam() ? srtrigger.trigger_within_gate : 0.;
-  ReferencePMTTimes(rec, PMT_reference_time);
+  FixPMTReferenceTimes(rec, PMT_reference_time);
   // TODO: CRT, TPC?
 
   // Get metadata information for header

--- a/sbncode/CAFMaker/FillTrigger.cxx
+++ b/sbncode/CAFMaker/FillTrigger.cxx
@@ -13,10 +13,10 @@ namespace caf
     triggerInfo.beam_gate_time_abs = addltrig_info.beamGateTimestamp;
     beam_ts = addltrig_info.beamGateTimestamp;
     trigger_ts = addltrig_info.triggerTimestamp;
-    double diff_ts = (trigger_ts - beam_ts) / 1000.;
-    triggerInfo.trigger_within_gate = diff_ts;
     triggerInfo.beam_gate_det_time = trig.BeamGateTime();
     triggerInfo.global_trigger_det_time = trig.TriggerTime();
+    double diff_ts = triggerInfo.global_trigger_det_time - triggerInfo.beam_gate_det_time;
+    triggerInfo.trigger_within_gate = diff_ts;
   }
     
 }

--- a/sbncode/CAFMaker/FillTrigger.cxx
+++ b/sbncode/CAFMaker/FillTrigger.cxx
@@ -4,23 +4,19 @@
 namespace caf
 {
   void FillTrigger(const sbn::ExtraTriggerInfo& addltrig_info,
-		   const std::vector<raw::Trigger>& trig_info,
-		   std::vector<caf::SRTrigger>& triggerInfo)
+		   const raw::Trigger& trig,
+		   caf::SRTrigger& triggerInfo)
   {
     uint64_t beam_ts = 0;
     uint64_t trigger_ts = 0;
-    triggerInfo.emplace_back();
-    triggerInfo.back().global_trigger_time = addltrig_info.triggerTimestamp;
-    triggerInfo.back().beam_gate_time_abs = addltrig_info.beamGateTimestamp;
+    triggerInfo.global_trigger_time = addltrig_info.triggerTimestamp;
+    triggerInfo.beam_gate_time_abs = addltrig_info.beamGateTimestamp;
     beam_ts = addltrig_info.beamGateTimestamp;
     trigger_ts = addltrig_info.triggerTimestamp;
-    int64_t diff_ts = trigger_ts - beam_ts;
-    triggerInfo.back().trigger_within_gate = diff_ts;
-    for(const raw::Trigger& trig: trig_info)
-    {
-      triggerInfo.back().beam_gate_det_time = trig.BeamGateTime();
-      triggerInfo.back().global_trigger_det_time = trig.TriggerTime();
-    }
+    double diff_ts = (trigger_ts - beam_ts) / 1000.;
+    triggerInfo.trigger_within_gate = diff_ts;
+    triggerInfo.beam_gate_det_time = trig.BeamGateTime();
+    triggerInfo.global_trigger_det_time = trig.TriggerTime();
   }
     
 }

--- a/sbncode/CAFMaker/FillTrigger.h
+++ b/sbncode/CAFMaker/FillTrigger.h
@@ -11,8 +11,8 @@ namespace caf
 {
 
   void FillTrigger(const sbn::ExtraTriggerInfo& addltrig_info,
-                   const std::vector<raw::Trigger>& trig_info,
-                   std::vector<caf::SRTrigger>& triggerInfo);
+                   const raw::Trigger& trig_info,
+                   caf::SRTrigger& triggerInfo);
 
 }
 


### PR DESCRIPTION
Change SRTrigger filling code to be more in line with the rest of CAFMaker. Setup code to reference all PMT times to the same t0.

Depends on https://github.com/SBNSoftware/sbnanaobj/pull/85.