### PR TITLE
Shifting CRT T0 and T1 properly in CAFMaker

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -329,11 +329,18 @@ namespace caf
       true
     };
 
-    Atom<bool> ReferenceCRTToBeam {
-      Name("ReferenceCRTToBeam"),
-      Comment("Whether to switch the reference time of CRT reco to the 'beam spill' time."),
+    Atom<bool> ReferenceCRTT0ToBeam {
+      Name("ReferenceCRTT0ToBeam"),
+      Comment("Whether to switch the reference time of CRT T0 reco to the 'beam spill' time."),
       true
     };
+
+    Atom<bool> ReferenceCRTT1FromTriggerToBeam {
+      Name("ReferenceCRTT1FromTriggerToBeam"),
+      Comment("Whether to switch the reference time of CRT T1 reco from 'trigger' to the 'beam spill' time."),
+      true
+    };
+
   };
 }
 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -455,10 +455,14 @@ void CAFMaker::FixCRTReferenceTimes(StandardRecord &rec, double CRTT0_reference_
   // Fix the hit matches
   for (SRSlice &s: rec.slc) {
     for (SRPFP &pfp: s.reco.pfp) {
+      pfp.trk.crthit.hit.t0 += CRTT0_reference_time; 
+      pfp.trk.crthit.hit.t1 += CRTT1_reference_time;
       pfp.trk.crthit.hit.time += crttime_to_shift;
     }
   }
   for (SRPFP &pfp: rec.reco.pfp) {
+    pfp.trk.crthit.hit.t0 += CRTT0_reference_time;
+    pfp.trk.crthit.hit.t1 += CRTT1_reference_time;
     pfp.trk.crthit.hit.time += crttime_to_shift;
   }
 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1820,7 +1820,9 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   FixPMTReferenceTimes(rec, PMT_reference_time);
 
   // CRT's
-  double CRT_reference_time = fParams.ReferenceCRTToBeam() ? -srtrigger.beam_gate_time_abs/1e3 /* ns -> us*/  : 0.;
+  double CRT_reference_time = fParams.ReferenceCRTToBeam() ? 
+                              (fParams.CRTUseTS0() ? -srtrigger.beam_gate_time_abs/1e3 : srtrigger.trigger_within_gate)/* ns -> us*/  
+                              : 0.;
   FixCRTReferenceTimes(rec, CRT_reference_time);
 
   // TODO: TPC?

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1821,7 +1821,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 
   // CRT's
   double CRT_reference_time = fParams.ReferenceCRTToBeam() ? 
-                              (fParams.CRTUseTS0() ? -srtrigger.beam_gate_time_abs/1e3 : srtrigger.trigger_within_gate)/* ns -> us*/  
+                              (fParams.CRTUseTS0() ? -srtrigger.beam_gate_time_abs/1e3 : srtrigger.trigger_within_gate)
                               : 0.;
   FixCRTReferenceTimes(rec, CRT_reference_time);
 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1289,11 +1289,13 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   art::Handle<std::vector<sbn::crt::CRTHit>> crthits_handle;
   GetByLabelStrict(evt, fParams.CRTHitLabel(), crthits_handle);
   // fill into event
+  int64_t CRT_T0_reference_time = fParams.ReferenceCRTT0ToBeam() ? -srtrigger.beam_gate_time_abs : 0; // ns, signed
+  double CRT_T1_reference_time = fParams.ReferenceCRTT1FromTriggerToBeam() ? srtrigger.trigger_within_gate : 0.;
   if (crthits_handle.isValid()) {
     const std::vector<sbn::crt::CRTHit> &crthits = *crthits_handle;
     for (unsigned i = 0; i < crthits.size(); i++) {
       srcrthits.emplace_back();
-      FillCRTHit(crthits[i], fParams.CRTUseTS0(), srcrthits.back());
+      FillCRTHit(crthits[i], fParams.CRTUseTS0(), CRT_T0_reference_time, CRT_T1_reference_time, srcrthits.back());
     }
   }
 
@@ -1740,7 +1742,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
           std::vector<art::Ptr<sbn::crt::CRTHit>> crthitmatch;
           if (CRTT02Hit.isValid() && CRTT02Hit.size() == 1) crthitmatch = CRTT02Hit.at(0);
 
-          FillTrackCRTHit(fmCRTHitMatch.at(iPart), crthitmatch, fParams.CRTUseTS0(), trk);
+          FillTrackCRTHit(fmCRTHitMatch.at(iPart), crthitmatch, fParams.CRTUseTS0(), CRT_T0_reference_time, CRT_T1_reference_time, trk);
         }
         // NOTE: SEE TODO AT fmCRTTrackMatch
         if (fmCRTTrackMatch.isValid()) {
@@ -1830,11 +1832,6 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   // PMT's:
   double PMT_reference_time = fParams.ReferencePMTFromTriggerToBeam() ? srtrigger.trigger_within_gate : 0.;
   FixPMTReferenceTimes(rec, PMT_reference_time);
-
-  // CRT's
-  double CRT_T0_reference_time = fParams.ReferenceCRTT0ToBeam() ? -srtrigger.beam_gate_time_abs/1e3 /* ns -> us*/  : 0.;
-  double CRT_T1_reference_time = fParams.ReferenceCRTT1FromTriggerToBeam() ? srtrigger.trigger_within_gate : 0.;
-  FixCRTReferenceTimes(rec, CRT_T0_reference_time, CRT_T1_reference_time);
 
   // TODO: TPC?
 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -246,7 +246,7 @@ class CAFMaker : public art::EDProducer {
   void InitVolumes(); ///< Initialize volumes from Gemotry service
 
   void FixPMTReferenceTimes(StandardRecord &rec, double PMT_reference_time);
-  void FixCRTReferenceTimes(StandardRecord &rec, double CRT_reference_time);
+  void FixCRTReferenceTimes(StandardRecord &rec, double CRTT0_reference_time, double CRTT1_reference_time);
 
   /// Equivalent of FindManyP except a return that is !isValid() prints a
   /// messsage and aborts if StrictMode is true.
@@ -438,20 +438,28 @@ void CAFMaker::FixPMTReferenceTimes(StandardRecord &rec, double PMT_reference_ti
 
 }
 
-void CAFMaker::FixCRTReferenceTimes(StandardRecord &rec, double CRT_reference_time) {
+void CAFMaker::FixCRTReferenceTimes(StandardRecord &rec, double CRTT0_reference_time, double CRTT1_reference_time) {
   // Fix the hits
+
+  double crttime_to_shift = fParams.CRTUseTS0() ? CRTT0_reference_time : CRTT1_reference_time;
+
+  // As discussed/described in https://github.com/SBNSoftware/sbncode/pull/251,
+  // we added CRTHit::t0 and CRTHit::t1 in addition to CRTHit::time,
+  // not to break any existing studies that still use "CRTHit::time"
   for (SRCRTHit &h: rec.crt_hits) {
-    h.time += CRT_reference_time;
+    h.t0 += CRTT0_reference_time;
+    h.t1 += CRTT1_reference_time;
+    h.time += crttime_to_shift;
   }
 
   // Fix the hit matches
   for (SRSlice &s: rec.slc) {
     for (SRPFP &pfp: s.reco.pfp) {
-      pfp.trk.crthit.hit.time += CRT_reference_time;
+      pfp.trk.crthit.hit.time += crttime_to_shift;
     }
   }
   for (SRPFP &pfp: rec.reco.pfp) {
-    pfp.trk.crthit.hit.time += CRT_reference_time;
+    pfp.trk.crthit.hit.time += crttime_to_shift;
   }
 
   // TODO: fix more?
@@ -1820,10 +1828,9 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   FixPMTReferenceTimes(rec, PMT_reference_time);
 
   // CRT's
-  double CRT_reference_time = fParams.ReferenceCRTToBeam() ? 
-                              (fParams.CRTUseTS0() ? -srtrigger.beam_gate_time_abs/1e3 : srtrigger.trigger_within_gate)
-                              : 0.;
-  FixCRTReferenceTimes(rec, CRT_reference_time);
+  double CRT_T0_reference_time = fParams.ReferenceCRTT0ToBeam() ? -srtrigger.beam_gate_time_abs/1e3 /* ns -> us*/  : 0.;
+  double CRT_T1_reference_time = fParams.ReferenceCRTT1FromTriggerToBeam() ? srtrigger.trigger_within_gate : 0.;
+  FixCRTReferenceTimes(rec, CRT_T0_reference_time, CRT_T1_reference_time);
 
   // TODO: TPC?
 

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -62,11 +62,13 @@ namespace caf
 
   void FillCRTHit(const sbn::crt::CRTHit &hit,
                   bool use_ts0,
+                  int64_t CRT_T0_reference_time, // ns, signed
+                  double CRT_T1_reference_time, // us
                   caf::SRCRTHit &srhit,
                   bool allowEmpty) {
 
-    srhit.t0 = hit.ts0()/1000.; // ns -> us
-    srhit.t1 = hit.ts1()/1000.; // ns -> us
+    srhit.t0 = ( (long long)(hit.ts0()) /*u_int64_t to int64_t*/ + CRT_T0_reference_time )/1000.;
+    srhit.t1 = hit.ts1()/1000.-CRT_T1_reference_time; // ns -> us
     srhit.time = use_ts0 ? srhit.t0 : srhit.t1;
 
     srhit.position.x = hit.x_pos;
@@ -378,6 +380,8 @@ namespace caf
   void FillTrackCRTHit(const std::vector<art::Ptr<anab::T0>> &t0match,
                        const std::vector<art::Ptr<sbn::crt::CRTHit>> &hitmatch,
                        bool use_ts0,
+                       int64_t CRT_T0_reference_time, // ns, signed
+                       double CRT_T1_reference_time, // us
                        caf::SRTrack &srtrack,
                        bool allowEmpty)
   {
@@ -387,7 +391,7 @@ namespace caf
       srtrack.crthit.hit.time = t0match[0]->fTime / 1e3; /* ns -> us */
     }
     if (hitmatch.size()) {
-      FillCRTHit(*hitmatch[0], use_ts0, srtrack.crthit.hit, allowEmpty);
+      FillCRTHit(*hitmatch[0], use_ts0, CRT_T0_reference_time, CRT_T1_reference_time, srtrack.crthit.hit, allowEmpty);
     }
   }
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -115,6 +115,8 @@ namespace caf
   void FillTrackCRTHit(const std::vector<art::Ptr<anab::T0>> &t0match,
                        const std::vector<art::Ptr<sbn::crt::CRTHit>> &hitmatch,
                        bool use_ts0,
+                       int64_t CRT_T0_reference_time, // ns, signed
+                       double CRT_T1_reference_time, // us
                        caf::SRTrack &srtrack,
                        bool allowEmpty = false);
 
@@ -171,6 +173,8 @@ namespace caf
 
   void FillCRTHit(const sbn::crt::CRTHit &hit,
                   bool use_ts0,
+                  int64_t CRT_T0_reference_time, // ns, signed
+                  double CRT_T1_reference_time, // us
                   caf::SRCRTHit &srhit,
                   bool allowEmpty = false);
   void FillCRTTrack(const sbn::crt::CRTTrack &track,


### PR DESCRIPTION
CRT T1 is a time reference to the trigger unlike T0 which is an absolute timestamp. When `CRTUseTS0` is set to false and we are saving `T1` in `CRTHit::time`, it should be shift by `+srtrigger.trigger_within_gate`