### PR TITLE
Fill opflash firsttime

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1321,12 +1321,12 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       int cryostat = ( pandora_tag_suffix.find("W") != std::string::npos ) ? 1 : 0;
 
       // get associated OpHits for each OpFlash
-      art::FindManyP<recob::OpHit> findManyHits(flashes_handle, evt, fParams.OpFlashLabel() + pandora_tag_suffix);
+      art::FindMany<recob::OpHit> findManyHits(flashes_handle, evt, fParams.OpFlashLabel() + pandora_tag_suffix);
 
       int iflash=0;
       for (const recob::OpFlash& flash : opflashes) {
 
-        std::vector<art::Ptr<recob::OpHit>> ophits = findManyHits.at(iflash);
+        std::vector<recob::OpHit const*> const& ophits = findManyHits.at(iflash);
 
         srflashes.emplace_back();
         FillOpFlash(flash, ophits, cryostat, srflashes.back());

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1319,9 +1319,17 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     if (flashes_handle.isValid()) {
       const std::vector<recob::OpFlash> &opflashes = *flashes_handle;
       int cryostat = ( pandora_tag_suffix.find("W") != std::string::npos ) ? 1 : 0;
+
+      // get associated OpHits for each OpFlash
+      art::FindManyP<recob::OpHit> findManyHits(flashes_handle, evt, fParams.OpFlashLabel() + pandora_tag_suffix);
+
+      int iflash=0;
       for (const recob::OpFlash& flash : opflashes) {
+
+        std::vector<art::Ptr<recob::OpHit>> ophits = findManyHits.at(iflash);
+
         srflashes.emplace_back();
-        FillOpFlash(flash, cryostat, srflashes.back());
+        FillOpFlash(flash, ophits, cryostat, srflashes.back());
       }
     }
   }

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1330,6 +1330,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 
         srflashes.emplace_back();
         FillOpFlash(flash, ophits, cryostat, srflashes.back());
+        iflash++;
       }
     }
   }

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -113,6 +113,7 @@ namespace caf
   }
 
   void FillOpFlash(const recob::OpFlash &flash,
+                  const std::vector<art::Ptr<recob::OpHit>> &hits,
                   int cryo, 
                   caf::SROpFlash &srflash,
                   bool allowEmpty) {
@@ -121,6 +122,14 @@ namespace caf
 
     srflash.time = flash.Time();
     srflash.timewidth = flash.TimeWidth();
+
+    double firstTime = 999999;
+    for(const auto& hit: hits){
+      if (firstTime > hit->PeakTime())
+        firstTime = hit->PeakTime();
+    }
+    srflash.firsttime = firstTime;
+
     srflash.cryo = cryo; // 0 in SBND, 0/1 for E/W in ICARUS
 
     // Sum over each wall, not very SBND-compliant

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -113,7 +113,7 @@ namespace caf
   }
 
   void FillOpFlash(const recob::OpFlash &flash,
-                  const std::vector<art::Ptr<recob::OpHit>> &hits,
+                  std::vector<recob::OpHit const*> const& hits,
                   int cryo, 
                   caf::SROpFlash &srflash,
                   bool allowEmpty) {
@@ -123,10 +123,11 @@ namespace caf
     srflash.time = flash.Time();
     srflash.timewidth = flash.TimeWidth();
 
-    double firstTime = 999999;
+    double firstTime = std::numeric_limits<double>::max();
     for(const auto& hit: hits){
-      if (firstTime > hit->PeakTime())
-        firstTime = hit->PeakTime();
+      double const hitTime = hit->HasStartTime()? hit->StartTime(): hit->PeakTime();
+      if (firstTime > hitTime)
+        firstTime = hitTime;
     }
     srflash.firsttime = firstTime;
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -20,6 +20,7 @@
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/SpacePoint.h"
 #include "lardataobj/RecoBase/OpFlash.h"
+#include "lardataobj/RecoBase/OpHit.h"
 #include "lardataobj/AnalysisBase/Calorimetry.h"
 #include "lardataobj/AnalysisBase/ParticleID.h"
 #include "lardataobj/AnalysisBase/T0.h"
@@ -183,6 +184,7 @@ namespace caf
                   bool allowEmpty = false);
 
   void FillOpFlash(const recob::OpFlash &flash,
+                  const std::vector<art::Ptr<recob::OpHit>> &hits,
                   int cryo,
                   caf::SROpFlash &srflash,
                   bool allowEmpty = false);

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -184,7 +184,7 @@ namespace caf
                   bool allowEmpty = false);
 
   void FillOpFlash(const recob::OpFlash &flash,
-                  const std::vector<art::Ptr<recob::OpHit>> &hits,
+                  std::vector<recob::OpHit const*> const& hits,
                   int cryo,
                   caf::SROpFlash &srflash,
                   bool allowEmpty = false);


### PR DESCRIPTION
Filling `caf::SROpFlash::firsttime` as the first peaktime of the associated OpHit; copied from [icaruscode/Filters/FilterCRTPMTMatching_module.cc#349](https://github.com/SBNSoftware/icaruscode/blob/eff5062ee5f8c61559b505b000511e9f2e383efa/icaruscode/Filters/FilterCRTPMTMatching_module.cc#L349). The "trigger requirement" (https://github.com/SBNSoftware/icaruscode/blob/develop/icaruscode/Filters/FilterCRTPMTMatching_module.cc#L375) part is not available yet; how do we want this to be implemented to caf?