### PR TITLE
Added setup stage where normalization tools are used.

### DIFF
--- a/sbncode/TPCReco/VertexStub/StubBuilder.cxx
+++ b/sbncode/TPCReco/VertexStub/StubBuilder.cxx
@@ -144,6 +144,9 @@ void sbn::StubBuilder::Setup(const art::Event &e, const art::InputTag &pfplabel,
 
   art::FindManyP<recob::PFParticle> slicePFPs(slices, e, pfplabel);
   art::FindManyP<recob::Hit> sliceHits(slices, e, pfplabel);
+  
+  for (auto const &nt: fNormTools)
+    nt->setup(e);
 
   for (unsigned i_slc = 0; i_slc < slices.size(); i_slc++) {
     const std::vector<art::Ptr<recob::PFParticle>> thisSlicePFPs = slicePFPs.at(i_slc);

--- a/sbncode/TPCReco/VertexStub/VertexChargeVacuum_module.cc
+++ b/sbncode/TPCReco/VertexStub/VertexChargeVacuum_module.cc
@@ -257,6 +257,9 @@ void sbn::VertexChargeVacuum::produce(art::Event& evt)
   // If we are not correcting for SCE, then blank out the service
   if (!fCorrectSCE) sce = nullptr;
 
+  for (auto const &nt: fNormTools)
+    nt->setup(evt);
+  
   // get the PFParticle's and the associated data
   art::Handle<std::vector<recob::PFParticle>> pfparticle_handle;
   evt.getByLabel(fPFParticleLabel, pfparticle_handle);


### PR DESCRIPTION
Following PR LArSoft/larreco#54, the normalisation tools are supposed to undergo a "setup" stage, which one of ICARUS tools uses to extract the detector clocks data.

This stage was added in `GnocchiCalorimetry` module but not in two modules from `sbncode`.
Without it, for `NormalizeDriftSQLite` tool:
 * `debug` code will complain about a failed assertion (verified)
 * `prof` code will likely break with a memory access violation

Note that `NormalizeDrift` tool is not affected because it was not optimised like the SQLite twin was (probably just slipped under the radar because it was not included in the workflow).
I expect this issue to have manifested from `v09_71_00` on (when the tools were changed), but I am not aware of reports of failure with that version.

Recommended reviewers: @grayputnam, the original author of the code.

This is a commit on top of `develop` branch, but it needs to be merged in the production branch too.
