### PR TITLE
Feature/jsmedley fill barycenter

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1593,7 +1593,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     FillSliceFlashMatchA(fmatch, recslc);
     FillSliceVertex(vertex, recslc);
     FillSliceCRUMBS(slcCRUMBS, recslc);
-    FillSliceBarycenter(slcHits, fmSpacePoint, recslc);
+    FillSliceBarycenter(slcHits, slcSpacePoints, recslc);
 
     // select slice
     if (!SelectSlice(recslc, fParams.CutClearCosmic())) continue;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1593,6 +1593,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     FillSliceFlashMatchA(fmatch, recslc);
     FillSliceVertex(vertex, recslc);
     FillSliceCRUMBS(slcCRUMBS, recslc);
+    FillSliceBarycenter(slcHits, fmSpacePoint, recslc);
 
     // select slice
     if (!SelectSlice(recslc, fParams.CutClearCosmic())) continue;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -415,7 +415,13 @@ namespace caf
       }
     }
 
-    if ( sumCharge != 0. ) {
+    //Just in case there are no valid spacepoints in this slice...
+    if (  sumCharge == 0. ) {
+      slice.charge_center.SetXYZ( -9999.f, -9999f., -9999.f );
+      slice.charge_width.SetXYZ( -9999.f, -9999.f, -9999.f );
+    }
+
+    else {
       chargeCenter[0] = sumX / sumCharge;
       chargeCenter[1] = sumY / sumCharge;
       chargeCenter[2] = sumZ / sumCharge;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -388,7 +388,7 @@ namespace caf
                            const art::FindManyP<recob::SpacePoint> &inputPoints,
                            caf::SRSlice &slice)
   {
-    unsigned int nHits = inputHits.Size();
+    unsigned int nHits = inputHits.size();
     double sumCharge = 0.;
     double sumX = 0.; double sumY = 0.; double sumZ = 0.;
     double sumXX = 0.; double sumYY = 0.; double sumZZ = 0.;
@@ -417,7 +417,7 @@ namespace caf
 
     //Just in case there are no valid spacepoints in this slice...
     if (  sumCharge == 0. ) {
-      slice.charge_center.SetXYZ( -9999.f, -9999f., -9999.f );
+      slice.charge_center.SetXYZ( -9999.f, -9999.f, -9999.f );
       slice.charge_width.SetXYZ( -9999.f, -9999.f, -9999.f );
     }
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -94,7 +94,7 @@ namespace caf
                        bool allowEmpty = false);
 
   void FillSliceBarycenter(const std::vector<art::Ptr<recob::Hit>> &inputHits,
-                           const art::FindManyP<recob::SpacePoint> &inputPoints,
+                           const std::vector<art::Ptr<recob::SpacePoint>> &inputPoints,
                            caf::SRSlice &slice);
 
   bool SelectSlice(const caf::SRSlice &slice, bool cut_clear_cosmic);

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -92,6 +92,10 @@ namespace caf
                        caf::SRSlice& slice,
                        bool allowEmpty = false);
 
+  void FillSliceBarycenter(const std::vector<art::Ptr<recob::Hit>> &inputHits,
+                           const art::FindManyP<recob::SpacePoint> &inputPoints,
+                           caf::SRSlice &slice);
+
   bool SelectSlice(const caf::SRSlice &slice, bool cut_clear_cosmic);
 
   void FillTrackVars(const recob::Track& track,

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -7,6 +7,7 @@
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "larsim/MCCheater/ParticleInventoryService.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
+#include "canvas/Persistency/Common/FindManyP.h"
 
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -7,7 +7,6 @@
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "larsim/MCCheater/ParticleInventoryService.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
-#include "canvas/Persistency/Common/FindManyP.h"
 
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"


### PR DESCRIPTION
This PR would introduce to each slice in the CAF the charge weighted mean position `charge_center` and standard standard deviation `charge_width` of 3D SpacePoints. The primary use case for this is studies on barycenter flash matching, which have so far opted to use CAFs produced with the option `FillHits: true`. This would allow these studies to continue without being limited to CAFs inflated with TPC hits. 

At present, this only considers SpacePoints whose associated Hit is in the collection plane, enforced by the condition that `thisHit.SignalType() == geo::kCollection`.

Tied to sbnanaobj PR https://github.com/SBNSoftware/sbnanaobj/pull/94