### PR TITLE
Add slice charge center and width to CAFMaker for production release

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1593,6 +1593,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     FillSliceFlashMatchA(fmatch, recslc);
     FillSliceVertex(vertex, recslc);
     FillSliceCRUMBS(slcCRUMBS, recslc);
+    FillSliceBarycenter(slcHits, slcSpacePoints, recslc);
 
     // select slice
     if (!SelectSlice(recslc, fParams.CutClearCosmic())) continue;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -384,6 +384,48 @@ namespace caf
     }
   }
 
+  void FillSliceBarycenter(const std::vector<art::Ptr<recob::Hit>> &inputHits,
+                           const std::vector<art::Ptr<recob::SpacePoint>> &inputPoints,
+                           caf::SRSlice &slice)
+  {
+    unsigned int nHits = inputHits.size();
+    double sumCharge = 0.;
+    double sumX = 0.; double sumY = 0.; double sumZ = 0.;
+    double sumXX = 0.; double sumYY = 0.; double sumZZ = 0.;
+    double thisHitCharge, thisPointXYZ[3], chargeCenter[3], chargeWidth[3];
+
+    for ( unsigned int i = 0; i < nHits; i++ ) {
+      const recob::Hit &thisHit = *inputHits[i];
+      if ( thisHit.SignalType() != geo::kCollection ) continue;
+      art::Ptr<recob::SpacePoint> const& thisPoint = inputPoints.at(i);
+      if ( !thisPoint ) continue;
+
+      thisHitCharge = thisHit.Integral();
+      thisPointXYZ[0] = thisPoint->XYZ()[0];
+      thisPointXYZ[1] = thisPoint->XYZ()[1];
+      thisPointXYZ[2] = thisPoint->XYZ()[2];
+
+      sumCharge += thisHitCharge;
+      sumX += thisPointXYZ[0] * thisHitCharge;
+      sumY += thisPointXYZ[1] * thisHitCharge;
+      sumZ += thisPointXYZ[2] * thisHitCharge;
+      sumXX += thisPointXYZ[0] * thisPointXYZ[0] * thisHitCharge;
+      sumYY += thisPointXYZ[1] * thisPointXYZ[1] * thisHitCharge;
+      sumZZ += thisPointXYZ[2] * thisPointXYZ[2] * thisHitCharge;
+    }
+
+    if( sumCharge != 0 ) {
+      chargeCenter[0] = sumX / sumCharge;
+      chargeCenter[1] = sumY / sumCharge;
+      chargeCenter[2] = sumZ / sumCharge;
+      chargeWidth[0] = pow( (sumXX/sumCharge - pow(sumX/sumCharge, 2)), .5);
+      chargeWidth[1] = pow( (sumYY/sumCharge - pow(sumY/sumCharge, 2)), .5);
+      chargeWidth[2] = pow( (sumZZ/sumCharge - pow(sumZ/sumCharge, 2)), .5);
+
+      slice.charge_center.SetXYZ( chargeCenter[0], chargeCenter[1], chargeCenter[2] ); 
+      slice.charge_width.SetXYZ( chargeWidth[0], chargeWidth[1], chargeWidth[2] );
+    }
+  }
 
   //......................................................................
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -92,6 +92,10 @@ namespace caf
                        caf::SRSlice& slice,
                        bool allowEmpty = false);
 
+  void FillSliceBarycenter(const std::vector<art::Ptr<recob::Hit>> &inputHits,
+                           const std::vector<art::Ptr<recob::SpacePoint>> &inputPoints,
+                           caf::SRSlice &slice);
+
   bool SelectSlice(const caf::SRSlice &slice, bool cut_clear_cosmic);
 
   void FillTrackVars(const recob::Track& track,

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -255,7 +255,7 @@ product			version		qual	flags		<table_format=2>
 genie_xsec		v3_04_00	-
 larcv2			v2_1_0		-
 larsoft			v09_72_00	-
-sbnanaobj		v09_20_06	-
+sbnanaobj		v09_20_07	-
 sbndaq_artdaq_core	v1_06_00of0	-
 sbndata			v01_04		-
 sbnobj			v09_16_00	-


### PR DESCRIPTION
This is a duplicate of a PR #348, which was merged into v09_73_00, for the production branch. There are changes to the CAFMaker, and I update the sbnanaobj dependency from `v09_20_06` to `v09_20_07`.  Note that anything newer than `v09_20_06` will do. 