### PR TITLE
Fix CRT time references in CAFs for data and MC 

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1288,8 +1288,11 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   art::Handle<std::vector<sbn::crt::CRTHit>> crthits_handle;
   GetByLabelStrict(evt, fParams.CRTHitLabel(), crthits_handle);
   // fill into event
-  int64_t CRT_T0_reference_time = fParams.ReferenceCRTT0ToBeam() ? -srtrigger.beam_gate_time_abs : 0; // ns, signed
-  double CRT_T1_reference_time = fParams.ReferenceCRTT1FromTriggerToBeam() ? srtrigger.trigger_within_gate : 0.;
+  //int64_t CRT_T0_reference_time = fParams.ReferenceCRTT0ToBeam() ? -srtrigger.beam_gate_time_abs : 0; // ns, signed
+  //double CRT_T1_reference_time = fParams.ReferenceCRTT1FromTriggerToBeam() ? srtrigger.trigger_within_gate : 0.;
+  int64_t CRT_T0_reference_time = isRealData ?  -srtrigger.beam_gate_time_abs : -fParams.CRTSimT0Offset();
+  double CRT_T1_reference_time = isRealData ? srtrigger.trigger_within_gate : -fParams.CRTSimT0Offset();
+
   if (crthits_handle.isValid()) {
     const std::vector<sbn::crt::CRTHit> &crthits = *crthits_handle;
     for (unsigned i = 0; i < crthits.size(); i++) {

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -68,7 +68,7 @@ namespace caf
                   bool allowEmpty) {
 
     srhit.t0 = ( (long long)(hit.ts0()) /*u_int64_t to int64_t*/ + CRT_T0_reference_time )/1000.;
-    srhit.t1 = hit.ts1()/1000.-CRT_T1_reference_time; // ns -> us
+    srhit.t1 = hit.ts1()/1000.+CRT_T1_reference_time; // ns -> us
     srhit.time = use_ts0 ? srhit.t0 : srhit.t1;
 
     srhit.position.x = hit.x_pos;


### PR DESCRIPTION
This PR fixes the CRT time references for both data and MC files. In general, we use the CRT Hit T0 variable for MC and CRT Hit T1 variable for data files. 
`CRT Hit T0: CRT Hit timestamp wrt beamgate timestamp`
`CRT Hit T1: CRT Hit timestamp wrt global trigger timestamp` 

For the CAFs, we can use the same time reference (wrt beamgate) for both data and MC CRT Times by shifting the data CRT Hit timestamp to be wrt the beamgate, this is done [here](https://github.com/SBNSoftware/sbncode/blob/develop/sbncode/CAFMaker/FillReco.cxx#L71), `where trigger_within_gate` is the difference between the global trigger and beam gate timestamps.

This PR: 
* Makes sure to use the value stored in fParams.CRTSimT0Offset() for the time reference for MC files. after adding the trigger emulation,  [these lines](https://github.com/SBNSoftware/sbncode/blob/develop/sbncode/CAFMaker/CAFMaker_module.cc#LL1268C3-L1273C1) don't seem to be doing whats intended. (comment on this offset needed)
   * Note: [ReferenceCRTT0ToBeam](https://github.com/SBNSoftware/sbncode/blob/develop/sbncode/CAFMaker/CAFMakerParams.h#LL344C16-L344C36) and [ReferenceCRTT1FromTriggerToBeam](https://github.com/SBNSoftware/sbncode/blob/develop/sbncode/CAFMaker/CAFMakerParams.h#LL350C16-L350C47) may no longer be needed? 
* Fixes a sign error when shifting the CRT Hit T1 time for data to be wrt the beamgate 

We should now have the `CRT Hit timestamp wrt beamgate timestamp` saved correctly in both data and MC files
