### PR TITLE
Offbeam gate counting for CAFMaker

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -95,6 +95,18 @@ namespace caf
       "numiinfo"
     };
 
+    Atom<string> OffbeamBNBCountDataLabel {
+      Name("OffbeamBNBCountDataLabel"),
+      Comment("Label of offbeam BNB EXT producer"),
+      "extinfo"
+    };
+
+    Atom<string> OffbeamNuMICountDataLabel {
+      Name("OffbeamNuMICountDataLabel"),
+      Comment("Label of offbeam NuMI EXT producer"),
+      "extinfo"
+    };
+
     Atom<string> G4Label {
       Name("G4Label"),
       Comment("Label of G4 module."),

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -97,14 +97,14 @@ namespace caf
 
     Atom<string> OffbeamBNBCountDataLabel {
       Name("OffbeamBNBCountDataLabel"),
-      Comment("Label of offbeam BNB EXT producer"),
-      "extinfo"
+      Comment("Label of BNB EXT module"),
+      "bnbextinfo"
     };
 
     Atom<string> OffbeamNuMICountDataLabel {
       Name("OffbeamNuMICountDataLabel"),
-      Comment("Label of offbeam NuMI EXT producer"),
-      "extinfo"
+      Comment("Label of NuMI EXT module"),
+      "numiextinfo"
     };
 
     Atom<string> G4Label {

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -737,8 +737,7 @@ void CAFMaker::beginSubRun(art::SubRun& sr) {
   auto bnb_offbeam_spill  = sr.getHandle<std::vector<sbn::EXTCountInfo>>(fParams.OffbeamBNBCountDataLabel());
   auto numi_offbeam_spill = sr.getHandle<std::vector<sbn::EXTCountInfo>>(fParams.OffbeamNuMICountDataLabel());
 
-  if((bnb_spill && numi_spill) || (bnb_spill && bnb_offbeam_spill) || (bnb_spill && numi_offbeam_spill) ||
-     (numi_spill && bnb_offbeam_spill) || (numi_spill && numi_offbeam_spill) || (bnb_offbeam_spill && numi_offbeam_spill)) {
+  if(bool(bnb_spill) + bool(numi_spill) + bool(bnb_offbeam_spill) + bool(numi_offbeam_spill) > 1) {
     std::cout << "Expected at most one of " << fParams.BNBPOTDataLabel() << ", "
               << fParams.NuMIPOTDataLabel() << ", " << fParams.OffbeamBNBCountDataLabel() << ", and "
               << fParams.OffbeamNuMICountDataLabel() << ". Found ";

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -729,6 +729,8 @@ void CAFMaker::beginSubRun(art::SubRun& sr) {
   fBNBInfo.clear();
   fNuMIInfo.clear();
   fSubRunPOT = 0;
+  fOffbeamBNBGates = 0;
+  fOffbeamNuMIGates = 0;
 
   if(auto bnb_spill = sr.getHandle<std::vector<sbn::BNBSpillInfo>>(fParams.BNBPOTDataLabel())){
     FillExposure(*bnb_spill, fBNBInfo, fSubRunPOT);


### PR DESCRIPTION
Fill new variables in the CAFs which count the offbeam gates.

Depends on https://github.com/SBNSoftware/sbnanaobj/pull/99

Does not depend on Joseph's PR (https://github.com/SBNSoftware/sbncode/pull/362) explicitly, but will only fill the CAF variables for input files made using that code.

Tested on ICARUS run 2 numi and bnb offbeam data.