### PR TITLE
opt0finder objects in cafmaker

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -143,6 +143,12 @@ namespace caf
       "crumbs"
     };
 
+    Atom<string> OpT0Label { 
+      Name("OpT0Label"),
+      Comment("Base label of OpT0Finder producer"),
+      "opt0finder"
+    };
+
     Atom<bool> FillHits {
       Name("FillHits"),
       Comment("Label deciding if you want to fill SRHits"),

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -109,7 +109,7 @@
 #include "sbnobj/Common/POTAccounting/NuMISpillInfo.h"
 #include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
 #include "sbnobj/Common/Reco/CRUMBSResult.h"
-
+#include "sbnobj/Common/Reco/OpT0FinderResult.h"
 
 #include "canvas/Persistency/Provenance/ProcessConfiguration.h"
 #include "larcoreobj/SummaryData/POTSummary.h"
@@ -1415,6 +1415,12 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       slcCRUMBS = foSlcCRUMBS.at(0).get();
     }
 
+    art::FindManyP<sbn::OpT0Finder> fmOpT0 = 
+      FindManyPStrict<sbn::OpT0Finder>(sliceList, evt, fParams.OpT0Label() + slice_tag_suff);
+    std::vector<art::Ptr<sbn::OpT0Finder>> slcOpT0;
+    if (fmOpT0.isValid())  
+      slcOpT0 = fmOpT0.at(0);
+
     art::FindManyP<sbn::SimpleFlashMatch> fm_sFM =
       FindManyPStrict<sbn::SimpleFlashMatch>(fmPFPart, evt,
                                              fParams.FlashMatchLabel() + slice_tag_suff);
@@ -1609,6 +1615,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     FillSliceFlashMatchA(fmatch, recslc);
     FillSliceVertex(vertex, recslc);
     FillSliceCRUMBS(slcCRUMBS, recslc);
+    FillSliceOpT0Finder(slcOpT0, recslc);
     FillSliceBarycenter(slcHits, slcSpacePoints, recslc);
 
     // select slice

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -419,6 +419,54 @@ namespace caf
     }
   }
 
+  void FillSliceOpT0Finder(const std::vector<art::Ptr<sbn::OpT0Finder>> &opt0_v,
+                           caf::SRSlice &slice)
+  {
+    if (opt0_v.empty()==false){
+      unsigned int nopt0 = opt0_v.size();
+      double max_score=-1.; // score of the opt0 object with the highest score 
+      double sec_score=-1.; // score of the opt0 object with the 2nd highest score 
+
+      unsigned int max_idx = 0;
+      unsigned int sec_idx = 0;
+
+      // fill the default, which is the maximum 
+      for (unsigned int i = 0; i < nopt0; i++ ) {
+        const sbn::OpT0Finder &thisOpT0 = *opt0_v[i];
+        if (thisOpT0.score > max_score){
+          max_score = thisOpT0.score;
+          max_idx = i;
+        }
+      }
+
+      const sbn::OpT0Finder &maxOpT0 = *opt0_v[max_idx];
+      slice.opt0.tpc    = maxOpT0.tpc;
+      slice.opt0.time   = maxOpT0.time;
+      slice.opt0.score  = maxOpT0.score;
+      slice.opt0.measPE = maxOpT0.measPE;
+      slice.opt0.hypoPE = maxOpT0.hypoPE;
+      
+      // in case there are more matches, find the opt0 object with the second highest score
+      // usually this is filled for a slice that is split across two tpcs
+      if (nopt0>1){    
+        for (unsigned int i = 0; i < nopt0; i++ ) {
+          if (i == max_idx) continue;
+          const sbn::OpT0Finder &thisOpT0 = *opt0_v[i];
+          if (thisOpT0.score > sec_score){
+            sec_score = thisOpT0.score;
+            sec_idx = i;
+          }
+        }
+        const sbn::OpT0Finder &secOpT0 = *opt0_v[sec_idx];
+        slice.opt0_sec.tpc    = secOpT0.tpc;
+        slice.opt0_sec.time   = secOpT0.time;
+        slice.opt0_sec.score  = secOpT0.score;
+        slice.opt0_sec.measPE = secOpT0.measPE;
+        slice.opt0_sec.hypoPE = secOpT0.hypoPE;
+      }
+    }
+  }
+
   void FillSliceBarycenter(const std::vector<art::Ptr<recob::Hit>> &inputHits,
                            const std::vector<art::Ptr<recob::SpacePoint>> &inputPoints,
                            caf::SRSlice &slice)

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -33,6 +33,7 @@
 #include "sbnobj/Common/Reco/ScatterClosestApproach.h"
 #include "sbnobj/Common/Reco/StoppingChi2Fit.h"
 #include "sbnobj/Common/Reco/CRUMBSResult.h"
+#include "sbnobj/Common/Reco/OpT0FinderResult.h"
 #include "sbnobj/Common/CRT/CRTHit.hh"
 #include "sbnobj/Common/CRT/CRTTrack.hh"
 #include "sbnobj/Common/CRT/CRTPMTMatching.hh"
@@ -92,6 +93,9 @@ namespace caf
   void FillSliceCRUMBS(const sbn::CRUMBSResult *crumbs,
                        caf::SRSlice& slice,
                        bool allowEmpty = false);
+
+  void FillSliceOpT0Finder(const std::vector<art::Ptr<sbn::OpT0Finder>> &opt0_v,
+                           caf::SRSlice &slice);
 
   void FillSliceBarycenter(const std::vector<art::Ptr<recob::Hit>> &inputHits,
                            const std::vector<art::Ptr<recob::SpacePoint>> &inputPoints,


### PR DESCRIPTION
Moving OpT0 variables into the cafs. There are _two_ caf variables created:  `slc.opt0` and `slc.opt0_sec`, where the latter is the "secondary" OpT0 object. 

OpT0Finder (in SBND for one-to-many matching) can output more than one match per slice if the slice is split up between two TPCs (matches are TPC specific) or if there are multiple in-time flashes. The default `slc.opt0` is filled with the OpT0 object with the **highest** OpT0 score (best match), and `slc.opt0_sec` is filled with the OpT0 object with the **second highest** OpT0 score. 

For flash-matching, looking at `slc.opt0` would be sufficient. For Q->L charge-likelihood studies, one would likely want information from both TPCs (so look at both `slc.opt0` and `slc.opt0_sec`). 

Dependent on accompanying PR in sbnanaobj [#103](https://github.com/SBNSoftware/sbnanaobj/pull/103) and sbnobj [#90](https://github.com/SBNSoftware/sbnobj/pull/90). 