### PR TITLE
Catch Bad Slices

### DIFF
--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -347,7 +347,7 @@ namespace caf
     // collect the properties
     if (primary_meta != NULL) {
       auto const &properties = primary_meta->GetPropertiesMap();
-      if (properties.count("IsClearCosmic")) {
+      if (properties.count("IsClearCosmic") || (properties.count("NuScore") && properties.at("NuScore") < 0)) {
         assert(!properties.count("IsNeutrino"));
         srslice.is_clear_cosmic = true;
       }


### PR DESCRIPTION
Occasionally one of the variables pandora calculates to describe slices for the SliceID BDT fails. In this scenario most of the metadata isn't filled and the default value (-1 for SBND) is set for the slice ID score. We can use this as a flag for "bad slices" and we should be treating these as clear cosmics anyway (more accurately _not treating them as neutrino slices_).

This PR ensures we check for that default value before this labelling the slices.