### PR TITLE
Fix units for flashGateTime to be in microseconds

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -250,6 +250,12 @@ namespace caf
       Comment("Label of sbn CRT tracks."),
       "crttrack" // same for icarus and sbnd
     };
+    
+    Atom<string> CRTPMTLabel {
+      Name("CRTPMTLabel"),
+      Comment("Label for the CRTPMT Matched variables from the crtpmt data product"),
+      "crtpmt" // this variable exists in icaruscode, pretty sure it does not yet exist in sbnd
+    };
 
     Atom<string> OpFlashLabel {
       Name("OpFlashLabel"),

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1313,6 +1313,23 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     }
   }
 
+  // Get all of the CRTPMT Matches .. 
+  std::vector<caf::SRCRTPMTMatch> srcrtpmtmatches;
+  std::cout << "srcrtpmtmatches.size = " << srcrtpmtmatches.size() << "\n";
+  art::Handle<std::vector<sbn::crt::CRTPMTMatching>> crtpmtmatch_handle;
+  GetByLabelStrict(evt, fParams.CRTPMTLabel(), crtpmtmatch_handle);
+  if(crtpmtmatch_handle.isValid()){
+    std::cout << "valid handle! label: " << fParams.CRTPMTLabel() << "\n";
+    const std::vector<sbn::crt::CRTPMTMatching> &crtpmtmatches = *crtpmtmatch_handle;
+    for (unsigned i = 0; i < crtpmtmatches.size(); i++) {
+      srcrtpmtmatches.emplace_back();
+      FillCRTPMTMatch(crtpmtmatches[i],srcrtpmtmatches.back());
+    }
+  }
+  else{
+    std::cout << "crtpmtmatch_handle.isNOTValid!\n";
+  }
+
   // Get all of the OpFlashes
   std::vector<caf::SROpFlash> srflashes;
 
@@ -1832,6 +1849,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     rec.true_particles  = true_particles;
   }
   rec.ntrue_particles = true_particles.size();
+  rec.crtpmt_matches = srcrtpmtmatches;
+  rec.ncrtpmt_matches = srcrtpmtmatches.size();
 
   // Fix the Reference time
   //

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -120,8 +120,8 @@ namespace caf
     //srmatch.setDefault();
     std::cout << "filling CRTPMT Match : flash time = " << match.flashTime << "\n";
     srmatch.flashID = match.flashID;
-    srmatch.flashTime_us = match.flashTime;
-    srmatch.flashGateTime = match.flashGateTime;
+    srmatch.flashTime = match.flashTime;
+    srmatch.flashGateTime = match.flashGateTime/1e3; //  ns -> us 
     srmatch.firstOpHitPeakTime = match.firstOpHitPeakTime;
     srmatch.firstOpHitStartTime = match.firstOpHitStartTime;
     srmatch.flashInGate = match.flashInGate;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -121,7 +121,7 @@ namespace caf
     std::cout << "filling CRTPMT Match : flash time = " << match.flashTime << "\n";
     srmatch.flashID = match.flashID;
     srmatch.flashTime = match.flashTime;
-    srmatch.flashGateTime = match.flashGateTime/1e3; //  ns -> us 
+    srmatch.flashGateTime = match.flashGateTime; //  ns -> us 
     srmatch.firstOpHitPeakTime = match.firstOpHitPeakTime;
     srmatch.firstOpHitStartTime = match.firstOpHitStartTime;
     srmatch.flashInGate = match.flashInGate;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -112,6 +112,41 @@ namespace caf
     srtrack.hitb.plane = track.plane2;
   }
 
+  void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
+		       caf::SRCRTPMTMatch &srmatch,
+		       bool allowEmpty){
+    // allowEmpty does not (yet) matter here                                                           
+    (void) allowEmpty;
+    //srmatch.setDefault();
+    std::cout << "filling CRTPMT Match : flash time = " << match.flashTime << "\n";
+    srmatch.flashID = match.flashID;
+    srmatch.flashTime_us = match.flashTime;
+    srmatch.flashGateTime = match.flashGateTime;
+    srmatch.firstOpHitPeakTime = match.firstOpHitPeakTime;
+    srmatch.firstOpHitStartTime = match.firstOpHitStartTime;
+    srmatch.flashInGate = match.flashInGate;
+    srmatch.flashInBeam = match.flashInBeam;
+    srmatch.flashPE = match.flashPE;
+    srmatch.flashPosition = SRVector3D (match.flashPosition.X(), match.flashPosition.Y(), match.flashPosition.Z());
+    srmatch.flashYWidth = match.flashYWidth;
+    srmatch.flashZWidth = match.flashZWidth;
+    srmatch.flashClassification = static_cast<int>(match.flashClassification);
+    //srmatch.flashClassification = match.flashClassification;
+    std::cout << "match type : " << std::to_string(static_cast<int>(match.flashClassification)) << "\n";
+    std::cout << "matchedCRThits.size : "<< match.matchedCRTHits.size() << "\n";
+    for(const auto& matchedCRTHit : match.matchedCRTHits){
+      std::cout << "CRTPMTTimeDiff = "<< matchedCRTHit.PMTTimeDiff << "\n";
+      caf::SRMatchedCRT matchedCRT;
+      matchedCRT.PMTTimeDiff = matchedCRTHit.PMTTimeDiff; 
+      matchedCRT.time = matchedCRTHit.time;
+      matchedCRT.sys = matchedCRTHit.sys;
+      matchedCRT.region = matchedCRTHit.region;
+      srmatch.matchedCRTHits.push_back(matchedCRT);
+    }
+    std::cout << "srmatch.matchedCRTHits.size = " << srmatch.matchedCRTHits.size() << "\n";
+  }
+
+
   void FillOpFlash(const recob::OpFlash &flash,
                   std::vector<recob::OpHit const*> const& hits,
                   int cryo, 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -35,6 +35,7 @@
 #include "sbnobj/Common/Reco/CRUMBSResult.h"
 #include "sbnobj/Common/CRT/CRTHit.hh"
 #include "sbnobj/Common/CRT/CRTTrack.hh"
+#include "sbnobj/Common/CRT/CRTPMTMatching.hh"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
 
@@ -188,6 +189,9 @@ namespace caf
                   int cryo,
                   caf::SROpFlash &srflash,
                   bool allowEmpty = false);
+  void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
+		  caf::SRCRTPMTMatch &srmatch,
+		  bool allowEmpty = false);
 
   template<class T, class U>
   void CopyPropertyIfSet( const std::map<std::string, T>& props, const std::string& search, U& value );


### PR DESCRIPTION
Was accidentally diving by 1e3 twice trying to convert from ns to µs, so flashGateTime was accidentally being saved in ms,