### PR TITLE
Fill slice barycenter in production branch, take 2

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1650,6 +1650,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     FillSliceFlashMatchA(fmatch, recslc);
     FillSliceVertex(vertex, recslc);
     FillSliceCRUMBS(slcCRUMBS, recslc);
+    FillSliceBarycenter(slcHits, slcSpacePoints, recslc);
 
     // select slice
     if (!SelectSlice(recslc, fParams.CutClearCosmic())) continue;

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -93,6 +93,10 @@ namespace caf
                        caf::SRSlice& slice,
                        bool allowEmpty = false);
 
+  void FillSliceBarycenter(const std::vector<art::Ptr<recob::Hit>> &inputHits,
+                           const std::vector<art::Ptr<recob::SpacePoint>> &inputPoints,
+                           caf::SRSlice &slice);
+
   bool SelectSlice(const caf::SRSlice &slice, bool cut_clear_cosmic);
 
   void FillTrackVars(const recob::Track& track,


### PR DESCRIPTION
This is meant to replace [PR #355](https://github.com/SBNSoftware/sbncode/pull/355), which had some CI issues based dependency mismatches and became outdate once the patch v09_72_00_04 came out. Hopefully there will be no such issues here! 

Associated with sbnanaobj [PR #105](https://github.com/SBNSoftware/sbnanaobj/pull/105)