### PR TITLE
Fix units for flashGateTime to be in microseconds

### DIFF
--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -121,7 +121,7 @@ namespace caf
     std::cout << "filling CRTPMT Match : flash time = " << match.flashTime << "\n";
     srmatch.flashID = match.flashID;
     srmatch.flashTime = match.flashTime;
-    srmatch.flashGateTime = match.flashGateTime/1e3; //  ns -> us 
+    srmatch.flashGateTime = match.flashGateTime; 
     srmatch.firstOpHitPeakTime = match.firstOpHitPeakTime;
     srmatch.firstOpHitStartTime = match.firstOpHitStartTime;
     srmatch.flashInGate = match.flashInGate;


### PR DESCRIPTION
I was accidentally diving by 1e3 twice trying to convert from ns to µs, so flashGateTime was accidentally being saved in ms, but it should be in µs for the CAFs. 