### PR TITLE
Changes to allow g4info reducer to use track ID instead of just origT…

### DIFF
--- a/sbncode/LArG4/g4inforeducer.fcl
+++ b/sbncode/LArG4/g4inforeducer.fcl
@@ -6,6 +6,7 @@ sbn_largeant_info_reducer: {
 	VoxelSizeX: 0.3
 	VoxelSizeY: 0.3
 	VoxelSizeZ: 0.3
+	useOrigTrackID: true
 }
 
 END_PROLOG


### PR DESCRIPTION
…rackID through a fcl param. These changes are necessary to store the proper trackID for SBND