### PR TITLE
fill Matched CRT Hit positions into SRCRTPMTMatch in CAFs

### DIFF
--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -118,7 +118,6 @@ namespace caf
     // allowEmpty does not (yet) matter here                                                           
     (void) allowEmpty;
     //srmatch.setDefault();
-    std::cout << "filling CRTPMT Match : flash time = " << match.flashTime << "\n";
     srmatch.flashID = match.flashID;
     srmatch.flashTime_us = match.flashTime;
     srmatch.flashGateTime = match.flashGateTime;
@@ -131,9 +130,6 @@ namespace caf
     srmatch.flashYWidth = match.flashYWidth;
     srmatch.flashZWidth = match.flashZWidth;
     srmatch.flashClassification = static_cast<int>(match.flashClassification);
-    //srmatch.flashClassification = match.flashClassification;
-    std::cout << "match type : " << std::to_string(static_cast<int>(match.flashClassification)) << "\n";
-    std::cout << "matchedCRThits.size : "<< match.matchedCRTHits.size() << "\n";
     for(const auto& matchedCRTHit : match.matchedCRTHits){
       std::cout << "CRTPMTTimeDiff = "<< matchedCRTHit.PMTTimeDiff << "\n";
       caf::SRMatchedCRT matchedCRT;
@@ -141,9 +137,9 @@ namespace caf
       matchedCRT.time = matchedCRTHit.time;
       matchedCRT.sys = matchedCRTHit.sys;
       matchedCRT.region = matchedCRTHit.region;
+      matchedCRT.position = SRVector3D(matchedCRTHit.position.X(), matchedCRTHit.position.Y(), matchedCRTHit.position.Z());
       srmatch.matchedCRTHits.push_back(matchedCRT);
     }
-    std::cout << "srmatch.matchedCRTHits.size = " << srmatch.matchedCRTHits.size() << "\n";
   }
 
 


### PR DESCRIPTION
This PR fills the Matched CRT Hit X,Y,Z positions in the CAFs (I simply forgot to add the line that actually fills the variable). This is close to a duplicate of PR #378, apart from the fix in that PR to the flashGateTime, as this was already being saved in µs in develop. 