### PR TITLE
exclude region feature

### DIFF
--- a/sbncode/LArRecoProducer/mcsproducer.fcl
+++ b/sbncode/LArRecoProducer/mcsproducer.fcl
@@ -2,7 +2,8 @@ BEGIN_PROLOG
 mcs_sbn: {
   module_type: MCSFitAllPID
   MCS: {
-    excludeRegions: []
+    fiducialVolumeInsets: [] 
+    excludeVolumes: [] 
   }
   TrackLabel: pandoraTrack
 }

--- a/sbncode/LArRecoProducer/mcsproducer_icarus.fcl
+++ b/sbncode/LArRecoProducer/mcsproducer_icarus.fcl
@@ -4,7 +4,8 @@ mcs_sbn: {
   MCS: {
     eLossMode: 2
     angResol: 10.0
-    excludeRegions: [190.0, 240.0, -9999.0, 9999.0, -9999.0, 9999.0]
+    fiducialVolumeInsets: [10.0, 10.0, 10.0, 10.0, 10.0, 10.0] 
+    excludeVolumes: [190.0, 240.0, -9999.0, 9999.0, -9999.0, 9999.0] 
   }
   TrackLabel: pandoraTrack
 }

--- a/sbncode/LArRecoProducer/mcsproducer_icarus.fcl
+++ b/sbncode/LArRecoProducer/mcsproducer_icarus.fcl
@@ -2,7 +2,9 @@ BEGIN_PROLOG
 mcs_sbn: {
   module_type: MCSFitAllPID
   MCS: {
-    excludeRegions: []
+    eLossMode: 2
+    angResol: 10.0
+    excludeRegions: [190.0, 240.0, -9999.0, 9999.0, -9999.0, 9999.0]
   }
   TrackLabel: pandoraTrack
 }


### PR DESCRIPTION
include a configurable option (`excludeRegions`) to exclude certain regions of the TPC in MCS calculation. 
- feature was added in a way that introduces minimal change to the existing code. Algorithm skips any breakpoints in defined bad regions, as it previously did for bad `segradlengths` values.
- excluded regions can be defined as volume boxes, and should be passed in the format of one list. Code will slice up the list in blocks of 6 numbers, and treat each block as values for boundaries of the region to be exluded: [x_low, x_high, y_low, y_high, z_low, z_high]. Code will check that the passed list is a multiple of 6, and if it is not, will log an error and not exclude any regions
- adding a fcl for ICARUS, `mcsproducer_icarus.fcl`, that uses an angular resolution value of 10mrad (default: 3mrad), uses Bethe-Bloch energy loss mode (default: Landau MPV), and defines exclude regions around the cathode (default: none)
