### PR TITLE
Feature/howard spillquality

### DIFF
--- a/sbncode/BeamSpillInfoRetriever/NuMIRetriever/NuMIRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/NuMIRetriever/NuMIRetriever_module.cc
@@ -109,6 +109,13 @@ void sbn::NuMIRetriever::produce(art::Event &e)
   e.getByLabel(raw_data_label_, "ICARUSTriggerV3", raw_data_ptr);
   auto const & raw_data = (*raw_data_ptr);
 
+  // NOTE: Really we should skip the first event of each trigger type, so let's make this look at that too...
+  if ( raw_data.size()==0 ) return;
+  else {
+    icarus::ICARUSTriggerV3Fragment frag(raw_data.at(0));
+    if ( frag.getTotalTriggerNuMIMaj() <= 1 ) return;
+  }
+
   double t_current_event  = 0;
   double t_previous_event = 0;
   double number_of_gates_since_previous_event = 0;
@@ -163,8 +170,8 @@ void sbn::NuMIRetriever::produce(art::Event &e)
     // plus or minus some time padding, currently using 3.3 ms
     // which is half the Booster Rep Rate
     if(e.event() != 1){//We already addressed the "first event" above 
-      if(times_temps[i] > t_current_event){continue;}
-      if(times_temps[i] <= t_previous_event){continue;}
+      if(times_temps[i] > t_current_event+fTimePad){continue;}
+      if(times_temps[i] <= t_previous_event+fTimePad){continue;}
     }
     
     //count found spills

--- a/sbncode/BeamSpillInfoRetriever/NuMIRetriever/NuMIRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/NuMIRetriever/NuMIRetriever_module.cc
@@ -110,7 +110,7 @@ void sbn::NuMIRetriever::produce(art::Event &e)
   auto const & raw_data = (*raw_data_ptr);
 
   // NOTE: Really we should skip the first event of each trigger type, so let's make this look at that too...
-  if ( raw_data.size()==0 ) return;
+  if ( raw_data.empty() ) return;
   else {
     icarus::ICARUSTriggerV3Fragment frag(raw_data.at(0));
     if ( frag.getTotalTriggerNuMIMaj() <= 1 ) return;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -2028,15 +2028,15 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     std::cout << "Found > 0 BNBInfo size and NuMIInfo size, which seems strange. Throwing..." << std::endl;
     abort();
   }
-  else if ( fHasBNBInfo ) {
-    if ( fBNBInfoEventMap.find(evt.id().event()) == fBNBInfoEventMap.end() )
-      std::cout << "We think (since fHasBNBInfo) that this event should be BNB, but did not find this event in the spill info map." << std::endl;
-    else rec.hdr.spillbnbinfo = makeSRBNBInfo(fBNBInfoEventMap.at(evt.id().event()));
+  unsigned int const eventNo = evt.id().event();
+  if ( fBNBInfoEventMap.count(eventNo) > 0 ) {
+    rec.hdr.spillbnbinfo = makeSRBNBInfo(fBNBInfoEventMap.at(eventNo));
   }
-  else if ( fHasNuMIInfo ) {
-    if ( fNuMIInfoEventMap.find(evt.id().event()) == fNuMIInfoEventMap.end() )
-      std::cout << "We think (since fHasNuMIInfo) that this event should be NuMI, but did not find this event in the spill info map." << std::endl;
-    else rec.hdr.spillnumiinfo = makeSRNuMIInfo(fNuMIInfoEventMap.at(evt.id().event()));
+  else if ( fNuMIInfoEventMap.count(eventNo) > 0 ) {
+    rec.hdr.spillnumiinfo = makeSRNuMIInfo(fNuMIInfoEventMap.at(eventNo));
+  }
+  else {
+    std::cout << "Did not find this event in the spill info map." << std::endl;
   }
 
   if(fRecTree){

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -195,6 +195,10 @@ class CAFMaker : public art::EDProducer {
   double fPrescaleEvents;
   std::vector<caf::SRBNBInfo> fBNBInfo; ///< Store detailed BNB info to save into the first StandardRecord of the output file
   std::vector<caf::SRNuMIInfo> fNuMIInfo; ///< Store detailed NuMI info to save into the first StandardRecord of the output file
+  std::map<unsigned int,sbn::BNBSpillInfo> fBNBInfoEventMap; ///< Store detailed BNB info to save for the particular spills of events
+  std::map<unsigned int,sbn::NuMISpillInfo> fNuMIInfoEventMap; ///< Store detailed NuMI info to save for the particular spills of events
+  bool fHasBNBInfo;
+  bool fHasNuMIInfo;
 
   // int fCycle;
   // int fBatch;
@@ -745,6 +749,12 @@ void CAFMaker::beginSubRun(art::SubRun& sr) {
   // get POT information
   fBNBInfo.clear();
   fNuMIInfo.clear();
+
+  fBNBInfoEventMap.clear();
+  fNuMIInfoEventMap.clear();
+  fHasBNBInfo = false;
+  fHasNuMIInfo = false;
+
   fSubRunPOT = 0;
   fOffbeamBNBGates = 0;
   fOffbeamNuMIGates = 0;
@@ -769,10 +779,38 @@ void CAFMaker::beginSubRun(art::SubRun& sr) {
   if(bnb_spill){
     FillExposure(*bnb_spill, fBNBInfo, fSubRunPOT);
     fTotalPOT += fSubRunPOT;
+
+    // Find the spill for each event and fill the event map:
+    // We take the latest spill for a given event number to be the one to keep
+    fHasBNBInfo = true;
+    for(const sbn::BNBSpillInfo& info: *bnb_spill)
+    {
+      if ( fBNBInfoEventMap.find(info.event)==fBNBInfoEventMap.end() ) {
+        fBNBInfoEventMap[info.event] = info;
+      }
+      else if ( (info.spill_time_s+(info.spill_time_ns/1.0e9)) >
+                (fBNBInfoEventMap[info.event].spill_time_s+(fBNBInfoEventMap[info.event].spill_time_ns/1.0e9)) ) {
+        fBNBInfoEventMap[info.event] = info;
+      }
+    }
   }
   else if (numi_spill) {
     FillExposureNuMI(*numi_spill, fNuMIInfo, fSubRunPOT);
     fTotalPOT += fSubRunPOT;
+
+    // Find the spill for each event and fill the event map:
+    // We take the latest spill for a given event number to be the one to keep
+    fHasNuMIInfo = true;
+    for(const sbn::NuMISpillInfo& info: *numi_spill)
+    {
+      if ( fNuMIInfoEventMap.find(info.event)==fNuMIInfoEventMap.end() ) {
+        fNuMIInfoEventMap[info.event] = info;
+      }
+      else if ( (info.spill_time_s+(info.spill_time_ns/1.0e9)) >
+                (fNuMIInfoEventMap[info.event].spill_time_s+(fNuMIInfoEventMap[info.event].spill_time_ns/1.0e9)) ) {
+        fNuMIInfoEventMap[info.event] = info;
+      }
+    }
   }
   else if (bnb_offbeam_spill){
     for(const auto& spill: *bnb_offbeam_spill) {
@@ -1984,6 +2022,20 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   // rec.hdr.blind = 0;
   // rec.hdr.filt = rb::IsFiltered(evt, slices, sliceID);
 
+  // Fill the header info for the given event's spill quality info
+  if ( fHasBNBInfo && fHasNuMIInfo ) {
+    std::cout << "Found > 0 BNBInfo size and NuMIInfo size, which seems strange. Will not fill event-specific spill quality info for this event..." << std::endl;
+  }
+  else if ( fHasBNBInfo ) {
+    if ( fBNBInfoEventMap.find(evt.id().event()) == fBNBInfoEventMap.end() )
+      std::cout << "We think (since fHasBNBInfo) that this event should be BNB, but did not find this event in the spill info map." << std::endl;
+    else rec.hdr.spillbnbinfo = makeSRBNBInfo(fBNBInfoEventMap.at(evt.id().event()));
+  }
+  else if ( fHasNuMIInfo ) {
+    if ( fNuMIInfoEventMap.find(evt.id().event()) == fNuMIInfoEventMap.end() )
+      std::cout << "We think (since fHasNuMIInfo) that this event should be NuMI, but did not find this event in the spill info map." << std::endl;
+    else rec.hdr.spillnumiinfo = makeSRNuMIInfo(fNuMIInfoEventMap.at(evt.id().event()));
+  }
 
   if(fRecTree){
     // Save the standard-record

--- a/sbncode/CAFMaker/FillExposure.cxx
+++ b/sbncode/CAFMaker/FillExposure.cxx
@@ -72,4 +72,34 @@ namespace caf
       NuMIInfo.back().daq_gates = info.daq_gates;
     }
   }
+
+  caf::SRNuMIInfo makeSRNuMIInfo(sbn::NuMISpillInfo const& info)
+  {
+    caf::SRNuMIInfo single_store;
+
+    single_store.HP121 = info.HP121;
+    single_store.VP121 = info.VP121;
+    single_store.HPTGT = info.HPTGT;
+    single_store.VPTGT = info.VPTGT;
+    single_store.HITGT = info.HITGT;
+    single_store.VITGT = info.VITGT;
+    single_store.MTGTDS = info.MTGTDS;
+    single_store.HRNDIR = info.HRNDIR;
+    single_store.NSLINA = info.NSLINA;
+    single_store.NSLINB = info.NSLINB;
+    single_store.NSLINC = info.NSLINC;
+    single_store.NSLIND = info.NSLIND;
+    single_store.TRTGTD = info.TRTGTD;
+    single_store.TR101D = info.TR101D;
+    single_store.TORTGT = info.TORTGT;
+    single_store.TOR101 = info.TOR101;
+    single_store.time = info.time;
+    single_store.spill_time_s = info.spill_time_s;
+    single_store.spill_time_ns = info.spill_time_ns;
+    single_store.event = info.event;
+    single_store.daq_gates = info.daq_gates;
+
+    return single_store;
+  }
+
 }

--- a/sbncode/CAFMaker/FillExposure.h
+++ b/sbncode/CAFMaker/FillExposure.h
@@ -20,6 +20,7 @@ namespace caf
 		    std::vector<caf::SRNuMIInfo>& NuMIInfo,
 		    double& subRunPOT);
 
+  caf::SRNuMIInfo makeSRNuMIInfo(sbn::NuMISpillInfo const& info);
   
 }
 


### PR DESCRIPTION
Putting together PR for a couple of spill info updates to try to get things into the CAFs and in a way that we can also start to do beam quality cuts. Some questions notes:

See some info in doc-33224 slides 5-13

1. IMPORTANT (!!) -- I'm not sure if I should be making this PR against develop or v09_72_00_05 e.g. There seem to be a lot of commits present in the latter but not in develop as my changes are only the last few commits...

2. Think some additional similar changes may be needed in BNB module(s) but probably would be a PR from their side — including Joseph and Jacob L in the conversation here.

3. What else do we need for validation? (See some info at doc-33224)

4. Do we want these parts `(info.spill_time_s+(info.spill_time_ns/1.0e9))` to instead do something with more precision?

5. We probably want to talk to NOvA to remember how they handle the POT sums within CAFAna and with spill quality cuts, but this PR is more about getting the info available for use rather than the internal workings. But it's possible that the way of saving them would preclude certain usage patterns.

Tagging some reviewers that I think make sense given this touches trigger info, spill accounting, CAFs, etc.