### PR TITLE
Introduce Barycenter Flash Match

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -272,6 +272,12 @@ namespace caf
       "crtpmt" // this variable exists in icaruscode, pretty sure it does not yet exist in sbnd
     };
 
+    Atom<string> BarycenterMatchLabel {
+      Name("BarycenterMatchLabel"),
+      Comment("Label of Slice-OpFlash matching via barycenters."),
+      "barycentermatch"
+    };
+
     Atom<string> OpFlashLabel {
       Name("OpFlashLabel"),
       Comment("Label of PMT flash."),

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -275,7 +275,7 @@ namespace caf
     Atom<string> TPCPMTBarycenterMatchLabel {
       Name("TPCPMTBarycenterMatchLabel"),
       Comment("Label of Slice-OpFlash matching via barycenters."),
-      "tpcpmtbarycentermatch"
+      "" //Empty by default, configured in icaruscode cafmaker_defs
     };
 
     Atom<string> OpFlashLabel {

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -272,10 +272,10 @@ namespace caf
       "crtpmt" // this variable exists in icaruscode, pretty sure it does not yet exist in sbnd
     };
 
-    Atom<string> BarycenterMatchLabel {
-      Name("BarycenterMatchLabel"),
+    Atom<string> TPCPMTBarycenterMatchLabel {
+      Name("TPCPMTBarycenterMatchLabel"),
       Comment("Label of Slice-OpFlash matching via barycenters."),
-      "barycentermatch"
+      "tpcpmtbarycentermatch"
     };
 
     Atom<string> OpFlashLabel {

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1455,11 +1455,11 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       FindManyPStrict<sbn::SimpleFlashMatch>(fmPFPart, evt,
                                              fParams.FlashMatchLabel() + slice_tag_suff);
 
-    art::FindOneP<sbn::BarycenterMatch> foBarycenterMatch =
-      FindOnePStrict<sbn::BarycenterMatch>(sliceList, evt,
-          fParams.BarycenterMatchLabel() + slice_tag_suff);
-    const sbn::BarycenterMatch *barycenterMatch
-      = foBarycenterMatch.isValid()? foBarycenterMatch.at(0).get(): nullptr;
+    art::FindOneP<sbn::TPCPMTBarycenterMatch> foTPCPMTBarycenterMatch =
+      FindOnePStrict<sbn::TPCPMTBarycenterMatch>(sliceList, evt,
+          fParams.TPCPMTBarycenterMatchLabel() + slice_tag_suff);
+    const sbn::TPCPMTBarycenterMatch *barycenterMatch
+      = foTPCPMTBarycenterMatch.isValid()? foTPCPMTBarycenterMatch.at(0).get(): nullptr;
 
     art::FindManyP<larpandoraobj::PFParticleMetadata> fmPFPMeta =
       FindManyPStrict<larpandoraobj::PFParticleMetadata>(fmPFPart, evt,
@@ -1653,7 +1653,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     FillSliceCRUMBS(slcCRUMBS, recslc);
     FillSliceOpT0Finder(slcOpT0, recslc);
     FillSliceBarycenter(slcHits, slcSpacePoints, recslc);
-    FillBarycenterMatch(barycenterMatch, recslc);
+    FillTPCPMTBarycenterMatch(barycenterMatch, recslc);
 
     // select slice
     if (!SelectSlice(recslc, fParams.CutClearCosmic())) continue;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1458,10 +1458,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     art::FindOneP<sbn::BarycenterMatch> foBarycenterMatch =
       FindOnePStrict<sbn::BarycenterMatch>(sliceList, evt,
           fParams.BarycenterMatchLabel() + slice_tag_suff);
-    const sbn::BarycenterMatch *barycenterMatch = nullptr;
-    if (foBarycenterMatch.isValid()) {
-      barycenterMatch = foBarycenterMatch.at(0).get();
-    }
+    const sbn::BarycenterMatch *barycenterMatch
+      = foBarycenterMatch.isValid()? foBarycenterMatch.at(0).get(): nullptr;
 
     art::FindManyP<larpandoraobj::PFParticleMetadata> fmPFPMeta =
       FindManyPStrict<larpandoraobj::PFParticleMetadata>(fmPFPart, evt,

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -446,6 +446,9 @@ void CAFMaker::FixPMTReferenceTimes(StandardRecord &rec, double PMT_reference_ti
     s.fmatch.time += PMT_reference_time;
     s.fmatch_a.time += PMT_reference_time;
     s.fmatch_b.time += PMT_reference_time;
+
+    s.barycenterFM.flashTime +=PMT_reference_time;
+    s.barycenterFM.flashFirstHit +=PMT_reference_time;
   }
 
   // TODO: fix more?
@@ -1452,6 +1455,14 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       FindManyPStrict<sbn::SimpleFlashMatch>(fmPFPart, evt,
                                              fParams.FlashMatchLabel() + slice_tag_suff);
 
+    art::FindOneP<sbn::BarycenterMatch> foBarycenterMatch =
+      FindOnePStrict<sbn::BarycenterMatch>(sliceList, evt,
+          fParams.BarycenterMatchLabel() + slice_tag_suff);
+    const sbn::BarycenterMatch *barycenterMatch = nullptr;
+    if (foBarycenterMatch.isValid()) {
+      barycenterMatch = foBarycenterMatch.at(0).get();
+    }
+
     art::FindManyP<larpandoraobj::PFParticleMetadata> fmPFPMeta =
       FindManyPStrict<larpandoraobj::PFParticleMetadata>(fmPFPart, evt,
                fParams.PFParticleLabel() + slice_tag_suff);
@@ -1644,6 +1655,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     FillSliceCRUMBS(slcCRUMBS, recslc);
     FillSliceOpT0Finder(slcOpT0, recslc);
     FillSliceBarycenter(slcHits, slcSpacePoints, recslc);
+    FillBarycenterMatch(barycenterMatch, recslc);
 
     // select slice
     if (!SelectSlice(recslc, fParams.CutClearCosmic())) continue;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -923,6 +923,8 @@ namespace caf
       slice.barycenterFM.overlapY  = matchInfo->overlapY;
       slice.barycenterFM.overlapZ  = matchInfo->overlapZ;
       slice.barycenterFM.deltaZ_Trigger  = matchInfo->deltaZ_Trigger;
+      slice.barycenterFM.deltaY_Trigger  = matchInfo->deltaY_Trigger;
+      slice.barycenterFM.radius_Trigger  = matchInfo->radius_Trigger;
     }
   }
 

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -901,7 +901,7 @@ namespace caf
     srhit.spacepoint.ID = spacepoint.ID();
   }
 
-  void FillBarycenterMatch(const sbn::BarycenterMatch *matchInfo,
+  void FillTPCPMTBarycenterMatch(const sbn::TPCPMTBarycenterMatch *matchInfo,
                            caf::SRSlice& slice)
   { 
     slice.barycenterFM.setDefault();

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -900,6 +900,32 @@ namespace caf
     srhit.spacepoint.pfpID = particle.Self();
     srhit.spacepoint.ID = spacepoint.ID();
   }
+
+  void FillBarycenterMatch(const sbn::BarycenterMatch *matchInfo,
+                           caf::SRSlice& slice)
+  { 
+    slice.barycenterFM.setDefault();
+
+    if ( matchInfo != nullptr ) {
+      slice.barycenterFM.chargeTotal  = matchInfo->chargeTotal;
+      slice.barycenterFM.chargeCenterXLocal  = matchInfo->chargeCenterXLocal;
+      slice.barycenterFM.chargeCenter  = SRVector3D (matchInfo->chargeCenter.x(), matchInfo->chargeCenter.y(), matchInfo->chargeCenter.z());
+      slice.barycenterFM.chargeWidth  = SRVector3D (matchInfo->chargeWidth.x(), matchInfo->chargeWidth.y(), matchInfo->chargeWidth.z());
+      slice.barycenterFM.flashFirstHit  = matchInfo->flashFirstHit;
+      slice.barycenterFM.flashTime  = matchInfo->flashTime;
+      slice.barycenterFM.flashPEs  = matchInfo->flashPEs;
+      slice.barycenterFM.flashCenter  = SRVector3D (matchInfo->flashCenter.x(), matchInfo->flashCenter.y(), matchInfo->flashCenter.z());
+      slice.barycenterFM.flashWidth  = SRVector3D (matchInfo->flashWidth.x(), matchInfo->flashWidth.y(), matchInfo->flashWidth.z());
+      slice.barycenterFM.deltaT  = matchInfo->deltaT;
+      slice.barycenterFM.deltaY  = matchInfo->deltaY;
+      slice.barycenterFM.deltaZ  = matchInfo->deltaZ;
+      slice.barycenterFM.radius  = matchInfo->radius;
+      slice.barycenterFM.overlapY  = matchInfo->overlapY;
+      slice.barycenterFM.overlapZ  = matchInfo->overlapZ;
+      slice.barycenterFM.deltaZ_Trigger  = matchInfo->deltaZ_Trigger;
+    }
+  }
+
   //......................................................................
 
   void SetNuMuCCPrimary(std::vector<caf::StandardRecord> &recs,

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -34,7 +34,7 @@
 #include "sbnobj/Common/Reco/StoppingChi2Fit.h"
 #include "sbnobj/Common/Reco/CRUMBSResult.h"
 #include "sbnobj/Common/Reco/OpT0FinderResult.h"
-#include "sbnobj/Common/Reco/BarycenterMatch.h"
+#include "sbnobj/Common/Reco/TPCPMTBarycenterMatch.h"
 #include "sbnobj/Common/CRT/CRTHit.hh"
 #include "sbnobj/Common/CRT/CRTTrack.hh"
 #include "sbnobj/Common/CRT/CRTPMTMatching.hh"
@@ -202,7 +202,7 @@ namespace caf
 		  caf::SRCRTPMTMatch &srmatch,
 		  bool allowEmpty = false);
 
-  void FillBarycenterMatch(const sbn::BarycenterMatch *matchInfo,
+  void FillTPCPMTBarycenterMatch(const sbn::TPCPMTBarycenterMatch *matchInfo,
                            caf::SRSlice& slice);
 
   template<class T, class U>

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -34,6 +34,7 @@
 #include "sbnobj/Common/Reco/StoppingChi2Fit.h"
 #include "sbnobj/Common/Reco/CRUMBSResult.h"
 #include "sbnobj/Common/Reco/OpT0FinderResult.h"
+#include "sbnobj/Common/Reco/BarycenterMatch.h"
 #include "sbnobj/Common/CRT/CRTHit.hh"
 #include "sbnobj/Common/CRT/CRTTrack.hh"
 #include "sbnobj/Common/CRT/CRTPMTMatching.hh"
@@ -200,6 +201,9 @@ namespace caf
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
 		  caf::SRCRTPMTMatch &srmatch,
 		  bool allowEmpty = false);
+
+  void FillBarycenterMatch(const sbn::BarycenterMatch *matchInfo,
+                           caf::SRSlice& slice);
 
   template<class T, class U>
   void CopyPropertyIfSet( const std::map<std::string, T>& props, const std::string& search, U& value );


### PR DESCRIPTION
sbncode updates - Add barycenter flash match objects into CAFmaker and shift the data time variables to beam reference

Associated Pull Requests ---
sbnobj PR- https://github.com/SBNSoftware/sbnobj/pull/99
sbnanaobj PR- https://github.com/SBNSoftware/sbnanaobj/pull/111
sbncode PR- https://github.com/SBNSoftware/sbncode/pull/392
icaruscode PR- https://github.com/SBNSoftware/icaruscode/pull/641