### PR TITLE
Fix bug in filling exposure information in CAFs

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -184,6 +184,8 @@ class CAFMaker : public art::EDProducer {
 
   bool fFirstInSubRun;
   unsigned int fIndexInFile = SRHeader::NoSourceIndex;
+  bool fFirstBlindInSubRun;
+  bool fFirstPrescaleInSubRun;
   bool fFirstBlindInFile;
   bool fFirstPrescaleInFile;
   int fFileNumber;
@@ -779,6 +781,8 @@ void CAFMaker::beginSubRun(art::SubRun& sr) {
   std::cout << "POT: " << fSubRunPOT << std::endl;
 
   fFirstInSubRun = true;
+  fFirstBlindInSubRun = true;
+  fFirstPrescaleInSubRun = true;
 }
 
 //......................................................................
@@ -936,6 +940,8 @@ void CAFMaker::InitializeOutfiles()
   fPrescaleEvents = 0;
   fIndexInFile = SRHeader::NoSourceIndex;
   fFirstInSubRun = false;
+  fFirstBlindInSubRun = false;
+  fFirstPrescaleInSubRun = false;
   // fCycle = -5;
   // fBatch = -5;
 }
@@ -1935,7 +1941,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   rec.hdr.ismc    = !isRealData;
   rec.hdr.det     = fDet;
   rec.hdr.fno     = fFileNumber;
-  if(firstInFile)
+  if(fFirstInSubRun)
   {
     rec.hdr.nbnbinfo = fBNBInfo.size();
     rec.hdr.bnbinfo = fBNBInfo;
@@ -1978,46 +1984,48 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       if (keepprescale) {
         mf::LogVerbatim("CAFMaker") << "CAFMaker: " << evt.id() << " is not blinded.";
         StandardRecord* precp = new StandardRecord (*prec);
-	if (fFirstPrescaleInFile) {
-	  precp->hdr.pot = fSubRunPOT*(1/fParams.PrescaleFactor());
-	  precp->hdr.first_in_file = true;
-	  precp->hdr.first_in_subrun = true;
-	  precp->hdr.nbnbinfo = fBNBInfo.size()*(1/fParams.PrescaleFactor());
-	  precp->hdr.nnumiinfo = fNuMIInfo.size()*(1/fParams.PrescaleFactor());
-	}
-	precp->hdr.ngenevt = n_gen_evt*(1/fParams.PrescaleFactor());
-	precp->hdr.evt = evtID;
-	fRecTreep->SetBranchAddress("rec", &precp);
-      	fRecTreep->Fill();
-	fPrescaleEvents += 1;
-	if (fFlatTreep) {
-	  fFlatRecordp->Clear();
-	  fFlatRecordp->Fill(*precp);
-	  fFlatTreep->Fill();
-	}
-	fFirstPrescaleInFile = false;
+        if (fFirstPrescaleInSubRun) {
+          precp->hdr.pot = fSubRunPOT*(1/fParams.PrescaleFactor());
+          precp->hdr.first_in_file = fFirstPrescaleInFile;
+          precp->hdr.first_in_subrun = true;
+          precp->hdr.nbnbinfo = fBNBInfo.size()*(1/fParams.PrescaleFactor());
+          precp->hdr.nnumiinfo = fNuMIInfo.size()*(1/fParams.PrescaleFactor());
+        }
+        precp->hdr.ngenevt = n_gen_evt*(1/fParams.PrescaleFactor());
+        precp->hdr.evt = evtID;
+        fRecTreep->SetBranchAddress("rec", &precp);
+        fRecTreep->Fill();
+        fPrescaleEvents += 1;
+        if (fFlatTreep) {
+          fFlatRecordp->Clear();
+          fFlatRecordp->Fill(*precp);
+          fFlatTreep->Fill();
+        }
+        fFirstPrescaleInFile = false;
+        fFirstPrescaleInSubRun = false;
       }
       else {
-	StandardRecord* precb = new StandardRecord (*prec);
-	BlindEnergyParameters(precb);
-	if (fFirstBlindInFile) {
-	  precb->hdr.pot = fSubRunPOT*(1-(1/fParams.PrescaleFactor()))*GetBlindPOTScale();
-	  precb->hdr.first_in_file = true;
-	  precb->hdr.first_in_subrun = true;
-	  precb->hdr.nbnbinfo = fBNBInfo.size()*(1 - (1/fParams.PrescaleFactor()));
-	  precb->hdr.nnumiinfo = fNuMIInfo.size()*(1-(1/fParams.PrescaleFactor()));
-	}
-	precb->hdr.ngenevt = n_gen_evt*(1 - (1/fParams.PrescaleFactor()));
-	precb->hdr.evt = evtID;
-	fRecTreeb->SetBranchAddress("rec", &precb);
-	fRecTreeb->Fill();
-	fBlindEvents += 1;
-	if (fFlatTreeb) {
-	  fFlatRecordb->Clear();
-	  fFlatRecordb->Fill(*precb);
-	  fFlatTreeb->Fill();
-	}
-	fFirstBlindInFile = false;
+        StandardRecord* precb = new StandardRecord (*prec);
+        BlindEnergyParameters(precb);
+        if (fFirstBlindInSubRun) {
+          precb->hdr.pot = fSubRunPOT*(1-(1/fParams.PrescaleFactor()))*GetBlindPOTScale();
+          precb->hdr.first_in_file = fFirstBlindInFile;
+          precb->hdr.first_in_subrun = true;
+          precb->hdr.nbnbinfo = fBNBInfo.size()*(1 - (1/fParams.PrescaleFactor()));
+          precb->hdr.nnumiinfo = fNuMIInfo.size()*(1-(1/fParams.PrescaleFactor()));
+        }
+        precb->hdr.ngenevt = n_gen_evt*(1 - (1/fParams.PrescaleFactor()));
+        precb->hdr.evt = evtID;
+        fRecTreeb->SetBranchAddress("rec", &precb);
+        fRecTreeb->Fill();
+        fBlindEvents += 1;
+        if (fFlatTreeb) {
+          fFlatRecordb->Clear();
+          fFlatRecordb->Fill(*precb);
+          fFlatTreeb->Fill();
+        }
+        fFirstBlindInFile = false;
+        fFirstBlindInSubRun = false;
       }
     }
   }
@@ -2027,9 +2035,12 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   srcol->push_back(rec);
   evt.put(std::move(srcol));
 
-  fBNBInfo.clear();
-  fNuMIInfo.clear();
-  rec.hdr.pot = 0;
+  // Only clear these if we've filled into all file types
+  if(!fFirstInSubRun && (!fParams.CreateBlindedCAF() || (!fFirstBlindInSubRun && !fFirstPrescaleInSubRun))) {
+    fBNBInfo.clear();
+    fNuMIInfo.clear();
+    rec.hdr.pot = 0;
+  }
 }
 
 void CAFMaker::endSubRun(art::SubRun& sr) {


### PR DESCRIPTION
Fill pot and beam information in the CAFs per subrun instead of per file and make sure it is filled in both blind and prescaled files.