### PR TITLE
update to follow art conventions

### DIFF
--- a/sbncode/BeamSpillInfoRetriever/NuMIEXTRetriever/NuMIEXTRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/NuMIEXTRetriever/NuMIEXTRetriever_module.cc
@@ -147,7 +147,7 @@ void sbn::NuMIEXTRetriever::endSubRun(art::SubRun& sr)
   // art::SubRun so it persists 
   auto p =  std::make_unique< std::vector< sbn::EXTCountInfo > >(fOutExtInfos);
 
-  sr.put(std::move(p));
+  sr.put(std::move(p), art::subRunFragment());
 
   return;
 }


### PR DESCRIPTION
The `put` command needed to be updated to follow the latest art convention. This shouldn't change functionality but resolves the `warning` that appears during build.