### PR TITLE
Saving non-primaries in cafs for g4 study [release/SBN2023A_NuMI]

### DIFF
--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -470,7 +470,9 @@ namespace caf {
     for(const caf::SRTrueParticle& part: srparticles){
       // save the G4 particles that came from this interaction
       if(part.interaction_id == (int)i) {
-        if(part.start_process == caf::kG4primary) srneutrino.prim.push_back(part);
+        //if(part.start_process == caf::kG4primary) srneutrino.prim.push_back(part);
+        // Feb. 15th 2024, Jaesung Kim: Saving non-primaries for G4Reweight study
+        srneutrino.prim.push_back(part);
 
         // total up the deposited energy
         for(int p = 0; p < 3; ++p) { 


### PR DESCRIPTION
For G4 (reweight) study, we save non-primaries to truth.prim.