### PR TITLE
Simple merge and SBN merge changes

### DIFF
--- a/sbncode/LArG4/CMakeLists.txt
+++ b/sbncode/LArG4/CMakeLists.txt
@@ -35,6 +35,8 @@ set(
     sbncode_LArG4_PhysicsLists
 )
 
+cet_build_plugin(PhysListLoader art::module SOURCE PhysListLoader_module.cc LIBRARIES ${MODULE_LIBRARIES})
+
 cet_make_library(SOURCE MergeSimSourcesLiteUtility.cxx
   LIBRARIES
   PUBLIC

--- a/sbncode/LArG4/CMakeLists.txt
+++ b/sbncode/LArG4/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_subdirectory(PhysicsLists)
-
 cet_build_plugin(G4InfoReducer art::module
                        LIBRARIES
                            larsim::Simulation
@@ -9,33 +7,6 @@ cet_build_plugin(G4InfoReducer art::module
                            art::Persistency_Provenance
                            art::Utilities canvas::canvas
                            BASENAME_ONLY)
-
-set(
-  MODULE_LIBRARIES
-    art::Utilities
-    cetlib_except::cetlib_except
-    ROOT::Core
-    ROOT::Hist
-    ROOT::Physics
-    ROOT::Geom
-    ROOT::MathCore
-    CLHEP::CLHEP
-    Geant4::G4digits_hits
-    Geant4::G4event
-    Geant4::G4geometry
-    Geant4::G4global
-    Geant4::G4graphics_reps
-    Geant4::G4materials
-    Geant4::G4intercoms
-    Geant4::G4particles
-    Geant4::G4physicslists
-    Geant4::G4processes
-    Geant4::G4track
-    Geant4::G4run
-    sbncode_LArG4_PhysicsLists
-)
-
-cet_build_plugin(PhysListLoader art::module SOURCE PhysListLoader_module.cc LIBRARIES ${MODULE_LIBRARIES})
 
 cet_make_library(SOURCE MergeSimSourcesLiteUtility.cxx
   LIBRARIES
@@ -58,6 +29,13 @@ cet_build_plugin(MergeSimSourcesSBN art::EDProducer
   fhiclcpp::types
   fhiclcpp::fhiclcpp
   BASENAME_ONLY
+)
+
+cet_build_plugin(SimpleMerge art::EDProducer
+  LIBRARIES
+  lardataobj::MCBase
+  larcorealg::headers
+  messagefacility::MF_MessageLogger
 )
 
 install_headers()

--- a/sbncode/LArG4/CMakeLists.txt
+++ b/sbncode/LArG4/CMakeLists.txt
@@ -8,6 +8,31 @@ cet_build_plugin(G4InfoReducer art::module
                            art::Utilities canvas::canvas
                            BASENAME_ONLY)
 
+set(
+  MODULE_LIBRARIES
+    art::Utilities
+    cetlib_except::cetlib_except
+    ROOT::Core
+    ROOT::Hist
+    ROOT::Physics
+    ROOT::Geom
+    ROOT::MathCore
+    CLHEP::CLHEP
+    Geant4::G4digits_hits
+    Geant4::G4event
+    Geant4::G4geometry
+    Geant4::G4global
+    Geant4::G4graphics_reps
+    Geant4::G4materials
+    Geant4::G4intercoms
+    Geant4::G4particles
+    Geant4::G4physicslists
+    Geant4::G4processes
+    Geant4::G4track
+    Geant4::G4run
+    sbncode_LArG4_PhysicsLists
+)
+
 cet_make_library(SOURCE MergeSimSourcesLiteUtility.cxx
   LIBRARIES
   PUBLIC

--- a/sbncode/LArG4/CMakeLists.txt
+++ b/sbncode/LArG4/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(PhysicsLists)
+
 cet_build_plugin(G4InfoReducer art::module
                        LIBRARIES
                            larsim::Simulation

--- a/sbncode/LArG4/G4InfoReducer_module.cc
+++ b/sbncode/LArG4/G4InfoReducer_module.cc
@@ -139,14 +139,10 @@ void G4InfoReducer::produce(art::Event& e)
 
   for (size_t idx = 0; idx < sed_v.size(); ++idx) {
     auto const& sed = sed_v[idx];
-    // std::cout << "G4info - orig track ID : " << sed.OrigTrackID() 
-    // << " trackID : " << sed.TrackID()
-    // << " useOrigID : " << fUseOrigTrackID
-    // << std::endl;
     // Voxelize coordinates to closest coordinate using fVoxelSize
-    double x = sed.X() - std::fmod(sed.X() - fMinX, fVoxelSizeX) + fVoxelSizeX/2.;
-    double y = sed.Y() - std::fmod(sed.Y() - fMinY, fVoxelSizeY) + fVoxelSizeY/2.;
-    double z = sed.Z() - std::fmod(sed.Z() - fMinZ, fVoxelSizeZ) + fVoxelSizeZ/2.;
+    double x = sed.X() - std::fmod(sed.X() - fMinX, fVoxelSizeX);
+    double y = sed.Y() - std::fmod(sed.Y() - fMinY, fVoxelSizeY);
+    double z = sed.Z() - std::fmod(sed.Z() - fMinZ, fVoxelSizeZ);
 
     // Copy info to SimEnergyDepositLite
     if (fUseOrigTrackID){

--- a/sbncode/LArG4/G4InfoReducer_module.cc
+++ b/sbncode/LArG4/G4InfoReducer_module.cc
@@ -140,9 +140,9 @@ void G4InfoReducer::produce(art::Event& e)
   for (size_t idx = 0; idx < sed_v.size(); ++idx) {
     auto const& sed = sed_v[idx];
     // Voxelize coordinates to closest coordinate using fVoxelSize
-    double x = sed.X() - std::fmod(sed.X() - fMinX, fVoxelSizeX);
-    double y = sed.Y() - std::fmod(sed.Y() - fMinY, fVoxelSizeY);
-    double z = sed.Z() - std::fmod(sed.Z() - fMinZ, fVoxelSizeZ);
+    double x = sed.X() - std::fmod(sed.X() - fMinX, fVoxelSizeX) + fVoxelSizeX/2.;
+    double y = sed.Y() - std::fmod(sed.Y() - fMinY, fVoxelSizeY) + fVoxelSizeY/2.;
+    double z = sed.Z() - std::fmod(sed.Z() - fMinZ, fVoxelSizeZ) + fVoxelSizeZ/2.;
 
     // Copy info to SimEnergyDepositLite
     if (fUseOrigTrackID){

--- a/sbncode/LArG4/MergeSimSourcesSBN_module.cc
+++ b/sbncode/LArG4/MergeSimSourcesSBN_module.cc
@@ -206,6 +206,10 @@ sbn::MergeSimSourcesSBN::MergeSimSourcesSBN(Parameters const& params)
   , fFillAuxDetHits(params().FillAuxDetHits())
   , fAuxDetHitsInstanceLabels(params().AuxDetHitsInstanceLabels())
 {
+  if (fFillMCParticlesAssociated && !fFillMCParticles) {
+    throw art::Exception{ art::errors::Configuration }
+      << "To save particle associations (`FillMCParticlesAssociated`) particles must be saved too (`FillMCParticles`).";
+  }
 
   if (fInputSourcesLabels.size() != fTrackIDOffsets.size()) {
     throw art::Exception(art::errors::Configuration)

--- a/sbncode/LArG4/SimpleMerge_module.cc
+++ b/sbncode/LArG4/SimpleMerge_module.cc
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       SimpleMerge
+// Plugin Type: producer (Unknown Unknown)
+// File:        producer_module.cc
+//
+// Generated at Tue Dec 19 08:26:07 2023 by Brinden Carlson using cetskelgen
+// from  version .
+//
+// Producer module for merging multiple input sources into a single output
+// without trackID offsets or other complications from merge sim sources.
+
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include <memory>
+//#include <utility>
+
+#include "nusimdata/SimulationBase/MCParticle.h"
+#include "larcorealg/CoreUtils/enumerate.h"
+
+namespace sbn {
+  class SimpleMerge;
+}
+
+
+class sbn::SimpleMerge : public art::EDProducer {
+public:
+  explicit SimpleMerge(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  SimpleMerge(SimpleMerge const&) = delete;
+  SimpleMerge(SimpleMerge&&) = delete;
+  SimpleMerge& operator=(SimpleMerge const&) = delete;
+  SimpleMerge& operator=(SimpleMerge&&) = delete;
+
+  // Required functions.
+  void produce(art::Event& e) override;
+
+private:
+
+  // Declare member data here.
+  std::vector<art::InputTag> const fInputSourcesLabels;
+  std::vector<int> fResetMotherIDs;
+  bool fResetMotherID;
+
+};
+
+
+sbn::SimpleMerge::SimpleMerge(fhicl::ParameterSet const& p)
+  : EDProducer{p}
+  , fInputSourcesLabels(p.get<std::vector<art::InputTag>>("InputSourcesLabels"))
+  , fResetMotherIDs(p.get<std::vector<int>>("ResetMotherIDs", std::vector<int>{}))
+  // Anything else you want to merge can be added here...
+{
+  produces<std::vector<simb::MCParticle>>();
+  for (art::InputTag const& tag : fInputSourcesLabels) {
+    consumes<std::vector<simb::MCParticle>>(tag);
+  }
+  fResetMotherID = fResetMotherIDs.size() > 0;
+}
+
+void sbn::SimpleMerge::produce(art::Event& e)
+{
+  auto partCol = std::make_unique<std::vector<simb::MCParticle>>();
+  for (auto const& [i_source,input_label] : util::enumerate(fInputSourcesLabels)) {
+    auto parts = e.getValidHandle<std::vector<simb::MCParticle>>(input_label);
+    for (auto part : *parts) {
+      if (fResetMotherID){
+        for (auto const& offset : fResetMotherIDs) {
+          if (part.Mother() == offset) {
+            part.SetMother(0);
+            break;
+          } // if part.Mother
+        } // for offsets
+      } // if fResetMotherID
+      partCol->push_back(part);
+    }// for parts
+  }// for input_label
+  e.put(std::move(partCol));
+}// produce
+
+DEFINE_ART_MODULE(sbn::SimpleMerge)

--- a/sbncode/LArG4/SimpleMerge_module.cc
+++ b/sbncode/LArG4/SimpleMerge_module.cc
@@ -74,8 +74,8 @@ void sbn::SimpleMerge::produce(art::Event& e)
 {
   auto partCol = std::make_unique<std::vector<simb::MCParticle>>();
   for (auto const& [i_source,input_label] : util::enumerate(fInputSourcesLabels)) {
-    auto parts = e.getValidHandle<std::vector<simb::MCParticle>>(input_label);
-    for (auto part : *parts) {
+    auto const& parts = e.getProduct<std::vector<simb::MCParticle>>(input_label);
+    for (auto part : parts) {
       if (fResetMotherID){
         for (auto const& offset : fResetMotherIDs) {
           if (part.Mother() == offset) {

--- a/sbncode/LArG4/SimpleMerge_module.cc
+++ b/sbncode/LArG4/SimpleMerge_module.cc
@@ -77,7 +77,7 @@ void sbn::SimpleMerge::produce(art::Event& e)
     auto const& parts = e.getProduct<std::vector<simb::MCParticle>>(input_label);
     for (auto part : parts) {
       if (fResetMotherID){
-        for (auto const& offset : fResetMotherIDs) {
+        for (int offset : fResetMotherIDs) {
           if (part.Mother() == offset) {
             part.SetMother(0);
             break;

--- a/sbncode/LArG4/simplemerge.fcl
+++ b/sbncode/LArG4/simplemerge.fcl
@@ -1,0 +1,9 @@
+BEGIN_PROLOG
+
+simplemerge : {
+  module_type: "SimpleMerge"
+  InputSourcesLabels: ["largeant", "largeantdropped"]
+  ResetMotherIDs: [ 10000000, 20000000 ]
+}
+
+END_PROLOG


### PR DESCRIPTION
Makes simple merge modules which combines `MCParticle` vectors, with the option to set mother IDs. Also adds a simple check to `MergeSimSourcesSBN` which checks that `MCParticle` is also merged if the associations are merged.

Replaces [this PR](https://github.com/SBNSoftware/sbncode/pull/404) so we can combine simple and sbn merge into a single PR.