### PR TITLE
Updated Flux files for the HNL simulation using the Kaon BNB flux

### DIFF
--- a/sbncode/EventGenerator/MeVPrtl/Tools/BNBKaonGen_tool.cc
+++ b/sbncode/EventGenerator/MeVPrtl/Tools/BNBKaonGen_tool.cc
@@ -113,6 +113,9 @@ BNBKaonGen::BNBKaonGen(fhicl::ParameterSet const &pset):
 {
   configure(pset);
 
+  // copy the flux files locally
+  fFluxFiles = LoadFluxFiles();
+
   // setup indices
   fFileIndex = 0;
   fEntry = 0;
@@ -156,7 +159,6 @@ void BNBKaonGen::configure(fhicl::ParameterSet const &pset)
     std::cout << "With copy method: " << fFluxCopyMethod << std::endl;
   }
 
-  fFluxFiles = pset.get<std::vector<std::string>>("FluxFilesFullPath");
 }
 
 std::vector<std::string> BNBKaonGen::LoadFluxFiles() {

--- a/sbncode/EventGenerator/MeVPrtl/Tools/HNL/HNLMakeDecay_tool.cc
+++ b/sbncode/EventGenerator/MeVPrtl/Tools/HNL/HNLMakeDecay_tool.cc
@@ -906,7 +906,7 @@ bool HNLMakeDecay::Decay(const MeVPrtlFlux &flux, const TVector3 &in, const TVec
     }
   }
 
-  std::cout << flux.C3 << std::endl;
+  // std::cout << flux.C3 << std::endl;
   if (!has_allowed_decay) {
     throw cet::exception("HNLMakeDecay Tool: BAD MASS. Configured mass (" + std::to_string(flux.mass) +
          ") is smaller than any configured decay.");

--- a/sbncode/EventGenerator/MeVPrtl/config/bnb_kaon_common.fcl
+++ b/sbncode/EventGenerator/MeVPrtl/config/bnb_kaon_common.fcl
@@ -4,18 +4,6 @@ empty_kaon: {
   tool_type: EmptyKaonGen
 }
 
-sbnd_bnb_beam2detector_rotation: [ 1, 0, 0,
-                                   0, 1, 0,
-                                   0, 0, 1] #bnb to sbnd is in z-direction, only need a translation.
-
-#sbnd_bnb_beam_origin: [-73.78, 0, -11000] # cm in beam in deterctor frame
-sbnd_bnb_beam_origin: [0, 0, 0, 73.78, 0, 11000] # cm in detector in beam frame
-
-#sbnd detector in det frame
-sbnd_detector_box: [-200, 200, -200, 200, 0, 500] #cm
-sbnd_bnb_solid_angle_box: 1.3223e-3 #front face / detector distance ^2 = 4*4/110^2
-
-sbnd_bnb_solid_angle_cryostat: 0.0133 
 
 bnb_kaon: {
   tool_type: "BNBKaonGen" # BooNe Ntuples
@@ -29,43 +17,5 @@ bnb_kaon: {
   Verbose: false
 }
 
-kaon_energy: 8 #GeV Max energy from kaon 
-kaon_pdg: 321 #K+
-
-ray_trace_box: {
-  tool_type: RayTraceBox
-  Box: @local::sbnd_detector_box
-  Verbose: false
-}
-
-rethrow_ray_trace_box: {
-  tool_type: ReThrowRayTraceBox
-  Box: @local::sbnd_detector_box
-  ReferenceLabSolidAngle: @local::sbnd_bnb_solid_angle_box
-  ReferencePrimaryEnergy: @local::kaon_energy
-  ReferencePrimPDG: @local::kaon_pdg
-  Verbose: false
-}
-
-weighted_ray_trace_box: {
-  tool_type: WeightedRayTraceBox
-  Box: @local::sbnd_detector_box
-  ReferenceLabSolidAngle: @local::sbnd_bnb_solid_angle_box
-  ReferencePrimaryEnergy: @local::kaon_energy 
-  ReferencePrimPDG: @local::kaon_pdg
-  Verbose: false
-}
-
-mixedweight_ray_trace_box: {
-  tool_type: MixedWeightRayTraceBox
-  Box: @local::sbnd_detector_box
-  ReferenceLabSolidAngle: @local::sbnd_bnb_solid_angle_box
-  ReferencePrimaryEnergy: @local::kaon_energy
-  ReferencePrimPDG: @local::kaon_pdg
-  MaxWeightFudge: 2.
-  NThrow: 250
-  FixNSuccess: false
-  Verbose: false
-}
 
 END_PROLOG

--- a/sbncode/EventGenerator/MeVPrtl/config/bnb_kaon_common.fcl
+++ b/sbncode/EventGenerator/MeVPrtl/config/bnb_kaon_common.fcl
@@ -1,0 +1,71 @@
+BEGIN_PROLOG
+
+empty_kaon: {
+  tool_type: EmptyKaonGen
+}
+
+sbnd_bnb_beam2detector_rotation: [ 1, 0, 0,
+                                   0, 1, 0,
+                                   0, 0, 1] #bnb to sbnd is in z-direction, only need a translation.
+
+#sbnd_bnb_beam_origin: [-73.78, 0, -11000] # cm in beam in deterctor frame
+sbnd_bnb_beam_origin: [0, 0, 0, 73.78, 0, 11000] # cm in detector in beam frame
+
+#sbnd detector in det frame
+sbnd_detector_box: [-200, 200, -200, 200, 0, 500] #cm
+sbnd_bnb_solid_angle_box: 1.3223e-3 #front face / detector distance ^2 = 4*4/110^2
+
+sbnd_bnb_solid_angle_cryostat: 0.0133 
+
+bnb_kaon: {
+  tool_type: "BNBKaonGen" # BooNe Ntuples
+  SearchPath: "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics-rodrigoa/bnbflux/"
+  FluxFiles: ["*.root"]
+  TreeName: "h101"
+  MetaTreeName: "meta"
+  MaxFluxFileMB: 8192 # 8GB
+  FluxCopyMethod: DIRECT
+  RandomizeFiles: false
+  Verbose: false
+}
+
+kaon_energy: 8 #GeV Max energy from kaon 
+kaon_pdg: 321 #K+
+
+ray_trace_box: {
+  tool_type: RayTraceBox
+  Box: @local::sbnd_detector_box
+  Verbose: false
+}
+
+rethrow_ray_trace_box: {
+  tool_type: ReThrowRayTraceBox
+  Box: @local::sbnd_detector_box
+  ReferenceLabSolidAngle: @local::sbnd_bnb_solid_angle_box
+  ReferencePrimaryEnergy: @local::kaon_energy
+  ReferencePrimPDG: @local::kaon_pdg
+  Verbose: false
+}
+
+weighted_ray_trace_box: {
+  tool_type: WeightedRayTraceBox
+  Box: @local::sbnd_detector_box
+  ReferenceLabSolidAngle: @local::sbnd_bnb_solid_angle_box
+  ReferencePrimaryEnergy: @local::kaon_energy 
+  ReferencePrimPDG: @local::kaon_pdg
+  Verbose: false
+}
+
+mixedweight_ray_trace_box: {
+  tool_type: MixedWeightRayTraceBox
+  Box: @local::sbnd_detector_box
+  ReferenceLabSolidAngle: @local::sbnd_bnb_solid_angle_box
+  ReferencePrimaryEnergy: @local::kaon_energy
+  ReferencePrimPDG: @local::kaon_pdg
+  MaxWeightFudge: 2.
+  NThrow: 250
+  FixNSuccess: false
+  Verbose: false
+}
+
+END_PROLOG

--- a/sbncode/EventGenerator/MeVPrtl/config/bnb_kaon_sbnd.fcl
+++ b/sbncode/EventGenerator/MeVPrtl/config/bnb_kaon_sbnd.fcl
@@ -1,0 +1,58 @@
+#include "bnb_kaon_common.fcl"
+
+BEGIN_PROLOG
+
+sbnd_bnb_beam2detector_rotation: [ 1, 0, 0,
+                                   0, 1, 0,
+                                   0, 0, 1] #bnb to sbnd is in z-direction, only need a translation.
+
+#sbnd_bnb_beam_origin: [-73.78, 0, -11000] # cm in beam in deterctor frame
+sbnd_bnb_beam_origin: [0, 0, 0, 73.78, 0, 11000] # cm in detector in beam frame
+
+#sbnd detector in det frame
+sbnd_detector_box: [-200, 200, -200, 200, 0, 500] #cm
+sbnd_bnb_solid_angle_box: 1.3223e-3 #front face / detector distance ^2 = 4*4/110^2
+
+sbnd_bnb_solid_angle_cryostat: 0.0133 
+
+
+kaon_energy: 8 #GeV Max energy from kaon 
+kaon_pdg: 321 #K+
+
+ray_trace_box: {
+  tool_type: RayTraceBox
+  Box: @local::sbnd_detector_box
+  Verbose: false
+}
+
+rethrow_ray_trace_box: {
+  tool_type: ReThrowRayTraceBox
+  Box: @local::sbnd_detector_box
+  ReferenceLabSolidAngle: @local::sbnd_bnb_solid_angle_box
+  ReferencePrimaryEnergy: @local::kaon_energy
+  ReferencePrimPDG: @local::kaon_pdg
+  Verbose: false
+}
+
+weighted_ray_trace_box: {
+  tool_type: WeightedRayTraceBox
+  Box: @local::sbnd_detector_box
+  ReferenceLabSolidAngle: @local::sbnd_bnb_solid_angle_box
+  ReferencePrimaryEnergy: @local::kaon_energy 
+  ReferencePrimPDG: @local::kaon_pdg
+  Verbose: false
+}
+
+mixedweight_ray_trace_box: {
+  tool_type: MixedWeightRayTraceBox
+  Box: @local::sbnd_detector_box
+  ReferenceLabSolidAngle: @local::sbnd_bnb_solid_angle_box
+  ReferencePrimaryEnergy: @local::kaon_energy
+  ReferencePrimPDG: @local::kaon_pdg
+  MaxWeightFudge: 2.
+  NThrow: 250
+  FixNSuccess: false
+  Verbose: false
+}
+
+END_PROLOG


### PR DESCRIPTION
Re weighted flux files in boone ntuple format to keep up with most  recent SciBooNE measures. I collaborated with Zarko Pavlovic to make the reweigh of the original files. More info can be found in [docdb 31883](
https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=31883).
The code, previous files and re weighted flux files can be found in:
`/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics-rodrigoa/`
To make sure reweigh was properly done, validation plots like this one were performed in different kinematic variables, showing a small difference within 5%, which was the expected behavior.
![image](https://github.com/SBNSoftware/sbncode/assets/70945401/b11054db-bd98-4475-9a79-931c2be1f0af)

This PR is linked to  [sbncode PR #415](https://github.com/SBNSoftware/sbndcode/pull/415) 
 