### PR TITLE
Moving to HadronHP for low energy hadron simulation.

### DIFF
--- a/sbncode/LArG4/PhysicsLists/SBN_QGSP_BERT_NNC.cc
+++ b/sbncode/LArG4/PhysicsLists/SBN_QGSP_BERT_NNC.cc
@@ -18,9 +18,9 @@
 #include "Geant4/G4EmExtraPhysics.hh"
 #include "Geant4/G4IonPhysics.hh"
 #include "Geant4/G4StoppingPhysics.hh"
-#include "Geant4/G4HadronElasticPhysics.hh"
+#include "Geant4/G4HadronElasticPhysicsHP.hh"
 // #include "Geant4/G4NeutronTrackingCut.hh"
-#include "Geant4/G4HadronPhysicsQGSP_BERT.hh"
+#include "Geant4/G4HadronPhysicsQGSP_BERT_HP.hh"
 
 
 // Register this new physics list
@@ -48,10 +48,10 @@ SBN_QGSP_BERT_NNC::SBN_QGSP_BERT_NNC(G4int ver)
   RegisterPhysics( new G4DecayPhysics(ver) );
 
    // Hadron Elastic scattering
-  RegisterPhysics( new G4HadronElasticPhysics(ver) );
+  RegisterPhysics( new G4HadronElasticPhysicsHP(ver) );
 
   // Hadron Physics
-  RegisterPhysics( new G4HadronPhysicsQGSP_BERT(ver));
+  RegisterPhysics( new G4HadronPhysicsQGSP_BERT_HP(ver));
 
   // Stopping Physics
   RegisterPhysics( new G4StoppingPhysics(ver) );


### PR DESCRIPTION

![Screenshot from 2024-02-22 13-56-43](https://github.com/SBNSoftware/sbncode/assets/53352772/da3e8a09-7eb1-4848-9468-14cf1a69c93d)
Validated via de-excitation light spectrum.