### PR TITLE
updates to CNNID

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1728,8 +1728,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       FindManyPStrict<sbn::MVAPID>(fmPFPart, evt,
           fParams.PFPRazzledLabel() + slice_tag_suff);
 
-    art::FindOneP<sbn::PFPCNNScore> foCNNScores = 
-      FindOnePStrict<sbn::PFPCNNScore>(fmPFPart, evt,
+    art::FindManyP<sbn::PFPCNNScore> fmCNNScores = 
+      FindManyPStrict<sbn::PFPCNNScore>(fmPFPart, evt,
           fParams.CNNScoreLabel() + slice_tag_suff);
 
     art::FindManyP<recob::Vertex> fmVertex =
@@ -1929,8 +1929,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       const larpandoraobj::PFParticleMetadata *pfpMeta = (fmPFPMeta.at(iPart).empty()) ? NULL : fmPFPMeta.at(iPart).at(0).get();
       FillPFPVars(thisParticle, primary, pfpMeta, thisPFPT0, pfp);
 
-      if (foCNNScores.isValid()) {
-        const sbn::PFPCNNScore *cnnScores = foCNNScores.at(iPart).get();
+      if (fmCNNScores.isValid()) {
+        const sbn::PFPCNNScore *cnnScores = fmCNNScores.at(iPart).at(0).get();
         FillCNNScores(thisParticle, cnnScores, pfp);
       }
     

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -904,6 +904,7 @@ namespace caf
       auto const &propertiesMap (pfpMeta->GetPropertiesMap());
       auto const &pfpTrackScoreIter(propertiesMap.find("TrackScore"));
       srpfp.trackScore = (pfpTrackScoreIter == propertiesMap.end()) ? -5.f : pfpTrackScoreIter->second;
+      std::cout << "pfp ID: " << particle.Self() << " pandora TrackScore: " << srpfp.trackScore << std::endl;
 
       // Pfo Characterisation features
       srpfp.pfochar.setDefault();
@@ -932,6 +933,8 @@ namespace caf
                      caf::SRPFP& srpfp,
                      bool allowEmpty)
   {
+    std::cout << "pfp ID: " << particle.Self() << " nClusters: " << cnnscore->nClusters << std::endl;
+    std::cout << "pfp ID: " << particle.Self() << " CNNID track score: " << cnnscore->pfpTrackScore << std::endl;
     srpfp.cnnscore.track = cnnscore->pfpTrackScore;
     srpfp.cnnscore.shower = cnnscore->pfpShowerScore;
     srpfp.cnnscore.noise = cnnscore->pfpNoiseScore;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -932,11 +932,6 @@ namespace caf
                      caf::SRPFP& srpfp,
                      bool allowEmpty)
   {
-    // std::cout << "pfpTrackScore: " << cnnscore->pfpTrackScore << std::endl;
-    // std::cout << "pfpShowerScore: " << cnnscore->pfpShowerScore << std::endl;
-    // std::cout << "pfpNoiseScore: " << cnnscore->pfpNoiseScore << std::endl;
-    // std::cout << "pfpMichelScore: " << cnnscore->pfpMichelScore << std::endl;
-
     srpfp.cnnscore.track = cnnscore->pfpTrackScore;
     srpfp.cnnscore.shower = cnnscore->pfpShowerScore;
     srpfp.cnnscore.noise = cnnscore->pfpNoiseScore;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -904,7 +904,6 @@ namespace caf
       auto const &propertiesMap (pfpMeta->GetPropertiesMap());
       auto const &pfpTrackScoreIter(propertiesMap.find("TrackScore"));
       srpfp.trackScore = (pfpTrackScoreIter == propertiesMap.end()) ? -5.f : pfpTrackScoreIter->second;
-      std::cout << "pfp ID: " << particle.Self() << " pandora TrackScore: " << srpfp.trackScore << std::endl;
 
       // Pfo Characterisation features
       srpfp.pfochar.setDefault();
@@ -933,8 +932,6 @@ namespace caf
                      caf::SRPFP& srpfp,
                      bool allowEmpty)
   {
-    std::cout << "pfp ID: " << particle.Self() << " nClusters: " << cnnscore->nClusters << std::endl;
-    std::cout << "pfp ID: " << particle.Self() << " CNNID track score: " << cnnscore->pfpTrackScore << std::endl;
     srpfp.cnnscore.track = cnnscore->pfpTrackScore;
     srpfp.cnnscore.shower = cnnscore->pfpShowerScore;
     srpfp.cnnscore.noise = cnnscore->pfpNoiseScore;

--- a/sbncode/TPCReco/CNNHitClassification/CMakeLists.txt
+++ b/sbncode/TPCReco/CNNHitClassification/CMakeLists.txt
@@ -16,36 +16,6 @@ cet_build_plugin(CNNID art::EDProducer
     fhiclcpp::fhiclcpp
     cetlib_except::cetlib_except
 )
-
-cet_build_plugin(InspectCNNScores art::EDAnalyzer
-  LIBRARIES PRIVATE
-  lardata::ArtDataHelper
-  lardataobj::RecoBase
-  art_root_io::TFileService_service
-  art::Framework_Services_Registry
-  canvas::canvas
-  fhiclcpp::fhiclcpp
-  ROOT::Tree
-)
-
-cet_build_plugin(EmTrackMichelIdLocal art::EDProducer
-  LIBRARIES PRIVATE
-  larrecodnn::ImagePatternAlgs_Tensorflow_PointIdAlg
-  lardata::ArtDataHelper
-  lardata::DetectorClocksService
-  lardata::DetectorPropertiesService
-  lardata::AssociationUtil
-  lardataobj::RecoBase
-  larcoreobj::SimpleTypesAndConstants
-  art::Framework_Services_System_TriggerNamesService_service
-  art::Framework_Services_Registry
-  canvas::canvas
-  messagefacility::MF_MessageLogger
-  fhiclcpp::types
-  fhiclcpp::fhiclcpp
-  cetlib_except::cetlib_except
-)
-
 install_headers()
 install_fhicl()
 install_source()

--- a/sbncode/TPCReco/CNNHitClassification/CMakeLists.txt
+++ b/sbncode/TPCReco/CNNHitClassification/CMakeLists.txt
@@ -17,28 +17,34 @@ cet_build_plugin(CNNID art::EDProducer
     cetlib_except::cetlib_except
 )
 
-# cet_build_plugin(CheckCNNScoreAllHits art::EDProducer
-#   LIBRARIES PRIVATE
-#     larrecodnn::ImagePatternAlgs_Tensorflow_PointIdAlg
-#     lardata::ArtDataHelper
-#     lardata::DetectorClocksService
-#     lardata::DetectorPropertiesService
-#     lardata::AssociationUtil
-#     lardataobj::RecoBase
-#     sbnobj::Common_Reco
-#     larcoreobj::SimpleTypesAndConstants
-#     art::Framework_Services_System_TriggerNamesService_service
-#     art::Framework_Services_Registry
-#     canvas::canvas
-#     messagefacility::MF_MessageLogger
-#     fhiclcpp::types
-#     fhiclcpp::fhiclcpp
-#     cetlib_except::cetlib_except
-#     art_root_io::TFileService_service
-#     art_root_io::tfile_support
-#     art_root_io::art_root_io
-#     art_root_io::dict
-# )
+cet_build_plugin(InspectCNNScores art::EDAnalyzer
+  LIBRARIES PRIVATE
+  lardata::ArtDataHelper
+  lardataobj::RecoBase
+  art_root_io::TFileService_service
+  art::Framework_Services_Registry
+  canvas::canvas
+  fhiclcpp::fhiclcpp
+  ROOT::Tree
+)
+
+cet_build_plugin(EmTrackMichelIdLocal art::EDProducer
+  LIBRARIES PRIVATE
+  larrecodnn::ImagePatternAlgs_Tensorflow_PointIdAlg
+  lardata::ArtDataHelper
+  lardata::DetectorClocksService
+  lardata::DetectorPropertiesService
+  lardata::AssociationUtil
+  lardataobj::RecoBase
+  larcoreobj::SimpleTypesAndConstants
+  art::Framework_Services_System_TriggerNamesService_service
+  art::Framework_Services_Registry
+  canvas::canvas
+  messagefacility::MF_MessageLogger
+  fhiclcpp::types
+  fhiclcpp::fhiclcpp
+  cetlib_except::cetlib_except
+)
 
 install_headers()
 install_fhicl()

--- a/sbncode/TPCReco/CNNHitClassification/CNNID_module.cc
+++ b/sbncode/TPCReco/CNNHitClassification/CNNID_module.cc
@@ -203,20 +203,31 @@ namespace sbn {
 
     auto pfpScores = std::make_unique<std::vector<PFPCNNScore>>();
     auto pfpAssns = std::make_unique<art::Assns<recob::PFParticle, PFPCNNScore>>();
+    std::vector<float> pfpTrackScore; 
+    std::vector<float> pfpShowerScore; 
+    std::vector<float> pfpNoiseScore;
+    std::vector<float> pfpMichelScore;
+    std::vector<float> pfpEndMichelScore;
+    float pfpAvgTrackScore;
+    float pfpAvgShowerScore;
+    float pfpAvgNoiseScore;
+    float pfpAvgMichelScore;
+    float pfpAvgEndMichelScore;
+    int nClusters; 
 
     // loop over PFPs
     for (const art::Ptr<recob::PFParticle> &pfp : pfpList){
-      int nClusters = 0; 
-      std::vector<float> pfpTrackScore; 
-      std::vector<float> pfpShowerScore; 
-      std::vector<float> pfpNoiseScore;
-      std::vector<float> pfpMichelScore;
-      std::vector<float> pfpEndMichelScore;
-      float pfpAvgTrackScore;
-      float pfpAvgShowerScore;
-      float pfpAvgNoiseScore;
-      float pfpAvgMichelScore;
-      float pfpAvgEndMichelScore;
+      pfpTrackScore.clear();
+      pfpShowerScore.clear();
+      pfpNoiseScore.clear();
+      pfpMichelScore.clear();
+      pfpEndMichelScore.clear();
+      pfpAvgTrackScore = std::numeric_limits<float>::signaling_NaN();
+      pfpAvgShowerScore = std::numeric_limits<float>::signaling_NaN();
+      pfpAvgNoiseScore = std::numeric_limits<float>::signaling_NaN();
+      pfpAvgMichelScore = std::numeric_limits<float>::signaling_NaN();
+      pfpAvgEndMichelScore = std::numeric_limits<float>::signaling_NaN();
+      nClusters = 0; 
 
       if (fSkipClearCosmics) {
         std::vector<art::Ptr<larpandoraobj::PFParticleMetadata>> metas = metaFMpfp.at(pfp.key());
@@ -375,6 +386,10 @@ namespace sbn {
               }
             }
           } // run CNN end
+          cluTrackScore = cluTrackScore/nCluApplyHits;
+          cluShowerScore = cluShowerScore/nCluApplyHits;
+          cluNoiseScore = cluNoiseScore/nCluApplyHits;
+          cluMichelScore = cluMichelScore/nCluApplyHits;
           pfpTrackScore.push_back(cluTrackScore);
           pfpShowerScore.push_back(cluShowerScore);
           pfpNoiseScore.push_back(cluNoiseScore);
@@ -387,7 +402,11 @@ namespace sbn {
       pfpAvgNoiseScore = getAvgScore(pfpNoiseScore);
       pfpAvgMichelScore = getAvgScore(pfpMichelScore);
       pfpAvgEndMichelScore = getAvgScore(pfpEndMichelScore);
-      pfpScores->emplace_back(pfpAvgTrackScore, pfpAvgShowerScore, pfpAvgNoiseScore, pfpAvgMichelScore, pfpAvgEndMichelScore, nClusters); //
+      pfpScores->emplace_back(pfpAvgTrackScore, pfpAvgShowerScore, pfpAvgNoiseScore, pfpAvgMichelScore, pfpAvgEndMichelScore, nClusters);
+      //std::cout << "PFP " << pfp.key() << " has " << nClusters << " clusters" << std::endl;
+      //std::cout << "track score: " << pfpAvgTrackScore << ", shower score: " << pfpAvgShowerScore << ", noise score: " << pfpAvgNoiseScore << ", Michel score: " << pfpAvgMichelScore << ", end Michel score: " << pfpAvgEndMichelScore << std::endl;
+      //std::cout << "score sum = " << pfpAvgTrackScore+pfpAvgShowerScore+pfpAvgNoiseScore << std::endl;
+      //std::cout << "---------------------------------" << std::endl;
       util::CreateAssn(*this, evt, *pfpScores, pfp, *pfpAssns);
     }  // pfp score end
     fMVAWriter.saveOutputs(evt);

--- a/sbncode/TPCReco/CNNHitClassification/pointidalg_sbnd.fcl
+++ b/sbncode/TPCReco/CNNHitClassification/pointidalg_sbnd.fcl
@@ -4,7 +4,7 @@ BEGIN_PROLOG
 
 pointidalg_sbnd: @local::standard_dataprovideralg 
 # pointidalg_sbnd.NNetModelFile:     "CNNHitClassification/CNNID_model.pb"
-pointidalg_sbnd.NNetModelFile:     "/exp/sbnd/data/users/munjung/nn/Michelloss5_trackdown0_5.pb"
+pointidalg_sbnd.NNetModelFile:     "/exp/sbnd/data/users/munjung/nn/Michelloss5.pb"
 pointidalg_sbnd.NNetOutputs:       ["track", "em", "none", "michel"]
 pointidalg_sbnd.CalorimetryAlg:    @local::sbnd_calorimetryalgmc
 pointidalg_sbnd.CalibrateAmpl:     false
@@ -13,7 +13,7 @@ pointidalg_sbnd.PatchSizeW:        60
 pointidalg_sbnd.PatchSizeD:        60
 pointidalg_sbnd.DriftWindow:       4
 pointidalg_sbnd.DownscaleFn:       "mean"
-pointidalg_sbnd.DownscaleFullView: true
+pointidalg_sbnd.DownscaleFullView: false
 pointidalg_sbnd.AdcMin: 0 
 pointidalg_sbnd.AdcMax: 200
 pointidalg_sbnd.OutMin: 0

--- a/sbncode/TPCReco/CNNHitClassification/pointidalg_sbnd.fcl
+++ b/sbncode/TPCReco/CNNHitClassification/pointidalg_sbnd.fcl
@@ -3,7 +3,8 @@
 BEGIN_PROLOG
 
 pointidalg_sbnd: @local::standard_dataprovideralg 
-pointidalg_sbnd.NNetModelFile:     "CNNHitClassification/CNNID_model.pb"
+# pointidalg_sbnd.NNetModelFile:     "CNNHitClassification/CNNID_model.pb"
+pointidalg_sbnd.NNetModelFile:     "/exp/sbnd/data/users/munjung/nn/Michelloss5_trackdown0_5.pb"
 pointidalg_sbnd.NNetOutputs:       ["track", "em", "none", "michel"]
 pointidalg_sbnd.CalorimetryAlg:    @local::sbnd_calorimetryalgmc
 pointidalg_sbnd.CalibrateAmpl:     false

--- a/sbncode/TPCReco/CNNHitClassification/pointidalg_sbnd.fcl
+++ b/sbncode/TPCReco/CNNHitClassification/pointidalg_sbnd.fcl
@@ -3,7 +3,7 @@
 BEGIN_PROLOG
 
 pointidalg_sbnd: @local::standard_dataprovideralg 
-pointidalg_sbnd.NNetModelFile:     "/cvmfs/sbnd.opensciencegrid.org/products/sbnd/sbnd_data/v01_22_00/CNNHitClassification/CNNID_model.pb"
+pointidalg_sbnd.NNetModelFile:     "CNNHitClassification/CNNID_model.pb"
 pointidalg_sbnd.NNetOutputs:       ["track", "em", "none", "michel"]
 pointidalg_sbnd.CalorimetryAlg:    @local::sbnd_calorimetryalgmc
 pointidalg_sbnd.CalibrateAmpl:     false

--- a/sbncode/TPCReco/CNNHitClassification/pointidalg_sbnd.fcl
+++ b/sbncode/TPCReco/CNNHitClassification/pointidalg_sbnd.fcl
@@ -3,8 +3,7 @@
 BEGIN_PROLOG
 
 pointidalg_sbnd: @local::standard_dataprovideralg 
-# pointidalg_sbnd.NNetModelFile:     "CNNHitClassification/CNNID_model.pb"
-pointidalg_sbnd.NNetModelFile:     "/exp/sbnd/data/users/munjung/nn/Michelloss5.pb"
+pointidalg_sbnd.NNetModelFile:     "CNNHitClassification/CNNID_model.pb"
 pointidalg_sbnd.NNetOutputs:       ["track", "em", "none", "michel"]
 pointidalg_sbnd.CalorimetryAlg:    @local::sbnd_calorimetryalgmc
 pointidalg_sbnd.CalibrateAmpl:     false
@@ -13,7 +12,7 @@ pointidalg_sbnd.PatchSizeW:        60
 pointidalg_sbnd.PatchSizeD:        60
 pointidalg_sbnd.DriftWindow:       4
 pointidalg_sbnd.DownscaleFn:       "mean"
-pointidalg_sbnd.DownscaleFullView: false
+pointidalg_sbnd.DownscaleFullView: true
 pointidalg_sbnd.AdcMin: 0 
 pointidalg_sbnd.AdcMax: 200
 pointidalg_sbnd.OutMin: 0

--- a/sbncode/TPCReco/CNNHitClassification/run_cnnid_sbnd.fcl
+++ b/sbncode/TPCReco/CNNHitClassification/run_cnnid_sbnd.fcl
@@ -56,8 +56,7 @@ outputs:
  out1:
  {
    module_type: RootOutput
-   fileName:    "/pnfs/sbnd/scratch/users/munjung/cnnid_job/eval/run_cnn/Michelloss10/%ifb_cnn.root"
- #  fileName:    "%ifb_cnn.root"
+   fileName:    "%ifb_cnn.root"
    dataTier:    "full-reconstructed"
    fastCloning: true
  }

--- a/sbncode/TPCReco/CNNHitClassification/run_cnnid_sbnd.fcl
+++ b/sbncode/TPCReco/CNNHitClassification/run_cnnid_sbnd.fcl
@@ -30,14 +30,14 @@ physics:
     cnnid: {
       module_type: CNNID
       BatchSize:                    256 
-      WireLabel:                    "caldata"
+      WireLabel:                    "simtpc2d:gauss"
       HitModuleLabel:               "gaushit"
       ClusterModuleLabel:           "pandora"
       PFParticleModuleLabel:        "pandora"
       SkipClearCosmics:             true
       DoMichel:                     true
       MichelRegionSize:             [30, 120]
-      SparseLengthCut:              150
+      SparseLengthCut:              9999
       DoPFP:                        true
       SparseRate:                   5
       Views:                        []

--- a/sbncode/TPCReco/CNNHitClassification/run_cnnid_sbnd.fcl
+++ b/sbncode/TPCReco/CNNHitClassification/run_cnnid_sbnd.fcl
@@ -56,8 +56,8 @@ outputs:
  out1:
  {
    module_type: RootOutput
-  #  fileName:    "/pnfs/sbnd/scratch/users/munjung/cnnid_job/%ifb_cnn.root"
-   fileName:    "%ifb_cnn.root"
+   fileName:    "/pnfs/sbnd/scratch/users/munjung/cnnid_job/eval/run_cnn/Michelloss10/%ifb_cnn.root"
+ #  fileName:    "%ifb_cnn.root"
    dataTier:    "full-reconstructed"
    fastCloning: true
  }

--- a/sbncode/TPCReco/CNNHitClassification/sbn_cnnid.fcl
+++ b/sbncode/TPCReco/CNNHitClassification/sbn_cnnid.fcl
@@ -6,14 +6,14 @@ BEGIN_PROLOG
 cnnid_sbnd: {
   module_type: CNNID
   BatchSize:                    256 
-  WireLabel:                    "caldata"
+  WireLabel:                    "simtpc2d:gauss"
   HitModuleLabel:               "gaushit"
   ClusterModuleLabel:           "pandora"
   PFParticleModuleLabel:        "pandora"
   SkipClearCosmics:             true
   DoMichel:                     true
   MichelRegionSize:             [30, 120]
-  SparseLengthCut:              150
+  SparseLengthCut:              9999
   DoPFP:                        true
   SparseRate:                   5
   Views:                        []


### PR DESCRIPTION
**note**:  this module will only run with `e26` and fail for `c14` due to TensorFlow dependency 

Updates to `CNNID_module`
- fix `PointIdAlg` but where `setWireDriftData` wasn't configured correctly
- include hits associated with parent PFP for `endMichelScore` calculation (considering the case of misclustering)

Updates to fcls
- set NN model file path relative to `FW_SEARCH_PATH`
- default `WireLabel` to WireCell 2D simulation label `simtpc2d:gauss`
- don't apply sparse inference by default