### PR TITLE
Add ability to shift sim::AuxDetIDEs by the trigger time.

### DIFF
--- a/sbncode/DetSim/AdjustSimForTrigger_module.cc
+++ b/sbncode/DetSim/AdjustSimForTrigger_module.cc
@@ -74,7 +74,7 @@ AdjustSimForTrigger::AdjustSimForTrigger(fhicl::ParameterSet const& p)
   , fShiftAuxDetIDEs{p.get<bool>("ShiftAuxDetIDEs", false)}
   , fShiftBeamGateInfo{p.get<bool>("ShiftBeamGateInfo", false)}
 {
-  if (!(fShiftSimEnergyDeposits | fShiftSimPhotons | fShiftWaveforms | fShiftAuxDetIDEs | fShiftBeamGateInfo)) {
+  if (!(fShiftSimEnergyDeposits || fShiftSimPhotons || fShiftWaveforms || fShiftAuxDetIDEs || fShiftBeamGateInfo)) {
     throw art::Exception(art::errors::EventProcessorFailure)
       << "NO SHIFTS ENABLED!\n"
       << "SHIFTING SIMENERGYDEPOSITS? " << fShiftSimEnergyDeposits << '\n'

--- a/sbncode/DetSim/AdjustSimForTrigger_module.cc
+++ b/sbncode/DetSim/AdjustSimForTrigger_module.cc
@@ -45,50 +45,52 @@ public:
   void produce(art::Event& e) override;
 
 private:
-  art::InputTag fInputSimEnergyDepositLabel;
-  art::InputTag fInputSimPhotonsLabel;
   art::InputTag fInputTriggerLabel;
-  art::InputTag fInputWaveformLabel;
-  art::InputTag fInputAuxDetSimChannelLabel;
-  art::InputTag fInputBeamGateInfoLabel;
-  double fAdditionalOffset;
+  art::InputTag fInitAuxDetSimChannelLabel;
+  art::InputTag fInitBeamGateInfoLabel;
+  art::InputTag fInitSimEnergyDepositLabel;
+  art::InputTag fInitSimPhotonsLabel;
+  art::InputTag fInitWaveformLabel;
+  bool fShiftAuxDetIDEs;
+  bool fShiftBeamGateInfo;
   bool fShiftSimEnergyDeposits;
   bool fShiftSimPhotons;
   bool fShiftWaveforms;
-  bool fShiftAuxDetIDEs;
-  bool fShiftBeamGateInfo;
+  double fAdditionalOffset;
+  static constexpr auto& kModuleName = "AdjustSimForTrigger";
 };
 
 AdjustSimForTrigger::AdjustSimForTrigger(fhicl::ParameterSet const& p)
   : EDProducer{p}
-  , fInputSimEnergyDepositLabel{p.get<art::InputTag>("InputSimEnergyDepositLabel", "")}
-  , fInputSimPhotonsLabel{p.get<art::InputTag>("InputSimPhotonsLabel", "")}
-  , fInputTriggerLabel{p.get<art::InputTag>("InputTriggerLabel", "")}
-  , fInputWaveformLabel(p.get<art::InputTag>("InputWaveformLabel", ""))
-  , fInputAuxDetSimChannelLabel(p.get<art::InputTag>("InputAuxDetSimChannelLabel", ""))
-  , fInputBeamGateInfoLabel{p.get<art::InputTag>("InputBeamGateInfoLabel", "")}
-  , fAdditionalOffset{p.get<double>("AdditionalOffset")}
+  , fInputTriggerLabel{p.get<art::InputTag>("InputTriggerLabel", "undefined")}
+  , fInitAuxDetSimChannelLabel(p.get<art::InputTag>("InitAuxDetSimChannelLabel", "undefined"))
+  , fInitBeamGateInfoLabel{p.get<art::InputTag>("InitBeamGateInfoLabel", "undefined")}
+  , fInitSimEnergyDepositLabel{p.get<art::InputTag>("InitSimEnergyDepositLabel", "undefined")}
+  , fInitSimPhotonsLabel{p.get<art::InputTag>("InitSimPhotonsLabel", "undefined")}
+  , fInitWaveformLabel(p.get<art::InputTag>("InitWaveformLabel", "undefined"))
+  , fShiftAuxDetIDEs{p.get<bool>("ShiftAuxDetIDEs", false)}
+  , fShiftBeamGateInfo{p.get<bool>("ShiftBeamGateInfo", false)}
   , fShiftSimEnergyDeposits{p.get<bool>("ShiftSimEnergyDeposits", false)}
   , fShiftSimPhotons{p.get<bool>("ShiftSimPhotons", false)}
   , fShiftWaveforms{p.get<bool>("ShiftWaveforms", false)}
-  , fShiftAuxDetIDEs{p.get<bool>("ShiftAuxDetIDEs", false)}
-  , fShiftBeamGateInfo{p.get<bool>("ShiftBeamGateInfo", false)}
+  , fAdditionalOffset{p.get<double>("AdditionalOffset", 0.)}
 {
-  if (!(fShiftSimEnergyDeposits || fShiftSimPhotons || fShiftWaveforms || fShiftAuxDetIDEs || fShiftBeamGateInfo)) {
+  if (!(fShiftSimEnergyDeposits || fShiftSimPhotons || fShiftWaveforms || fShiftAuxDetIDEs ||
+        fShiftBeamGateInfo)) {
     throw art::Exception(art::errors::EventProcessorFailure)
-      << "NO SHIFTS ENABLED!\n"
-      << "SHIFTING SIMENERGYDEPOSITS? " << fShiftSimEnergyDeposits << '\n'
-      << "SHIFTING SIMPHOTONS? " << fShiftSimPhotons << '\n'
-      << "SHIFTING OPDETWAVEFORMS? " << fShiftWaveforms << '\n'
-      << "SHIFTING AUXDETIDES? " << fShiftAuxDetIDEs << '\n'
-      << "SHIFTING BEAMGATEINFO? " << fShiftBeamGateInfo << '\n';
+      << kModuleName << ": NO SHIFTS ENABLED!\n";
   }
+  mf::LogInfo(kModuleName) << std::boolalpha << "SHIFTING AUXDETIDES? " << fShiftAuxDetIDEs << '\n'
+                           << "SHIFTING BEAMGATEINFO? " << fShiftBeamGateInfo << '\n'
+                           << "SHIFTING SIMENERGYDEPOSITS? " << fShiftSimEnergyDeposits << '\n'
+                           << "SHIFTING SIMPHOTONS? " << fShiftSimPhotons << '\n'
+                           << "SHIFTING OPDETWAVEFORMS? " << fShiftWaveforms;
 
+  if (fShiftAuxDetIDEs) { produces<std::vector<sim::AuxDetSimChannel>>(); }
+  if (fShiftBeamGateInfo) { produces<std::vector<sim::BeamGateInfo>>(); }
   if (fShiftSimEnergyDeposits) { produces<std::vector<sim::SimEnergyDeposit>>(); }
   if (fShiftSimPhotons) { produces<std::vector<sim::SimPhotons>>(); }
   if (fShiftWaveforms) { produces<std::vector<raw::OpDetWaveform>>(); }
-  if (fShiftAuxDetIDEs) { produces<std::vector<sim::AuxDetSimChannel>>(); }
-  if (fShiftBeamGateInfo) { produces<std::vector<sim::BeamGateInfo>>(); }
 }
 
 void AdjustSimForTrigger::produce(art::Event& e)
@@ -98,10 +100,11 @@ void AdjustSimForTrigger::produce(art::Event& e)
 
   if (triggers.size() != 1) {
     if (triggers.empty()) {
-      throw art::Exception(art::errors::EventProcessorFailure) << "NO TRIGGER IDENTIFIED!\n";
+      throw art::Exception(art::errors::EventProcessorFailure)
+        << kModuleName << ": NO TRIGGER IDENTIFIED!";
     }
     throw art::Exception(art::errors::EventProcessorFailure)
-      << "MORE THAN ONE TRIGGER IN EVENT... why?\n";
+      << kModuleName << ": MORE THAN ONE TRIGGER IN EVENT... why?";
   }
 
   // Assuming there is a trigger, get time shift
@@ -117,13 +120,59 @@ void AdjustSimForTrigger::produce(art::Event& e)
     hasValidTriggerTime ? clock_data.TriggerTime() - trigger.TriggerTime() + fAdditionalOffset : 0.;
   const double timeShiftForTrigger_ns = 1000. * timeShiftForTrigger_us;
 
-  mf::LogInfo("AdjustSimForTrigger")
-    << "FOR THIS EVENT THE TIME SHIFT BEING ASSUMED IS " << timeShiftForTrigger_ns << " ns ...\n";
+  mf::LogInfo(kModuleName) << "FOR THIS EVENT THE TIME SHIFT BEING ASSUMED IS "
+                           << timeShiftForTrigger_ns << " ns ...";
 
-  // Loop over the SimEnergyDeposit objects and shift time BACK by the TRIGGER
+  // Loop over the sim::AuxDetIDE and shift time BACK by the TRIGGER
+  if (fShiftAuxDetIDEs) {
+    auto const& simChannels =
+      e.getProduct<std::vector<sim::AuxDetSimChannel>>(fInitAuxDetSimChannelLabel);
+    auto pSimChannels = std::make_unique<std::vector<sim::AuxDetSimChannel>>();
+
+    pSimChannels->reserve(simChannels.size());
+
+    for (auto const& simChannel : simChannels) {
+      std::vector<sim::AuxDetIDE> shiftedAuxDetIDEs = simChannel.AuxDetIDEs();
+      for (auto& auxDetIDE : shiftedAuxDetIDEs) {
+        auxDetIDE.entryT += timeShiftForTrigger_ns;
+        auxDetIDE.exitT += timeShiftForTrigger_ns;
+      }
+      pSimChannels->emplace_back(sim::AuxDetSimChannel(
+        simChannel.AuxDetID(), shiftedAuxDetIDEs, simChannel.AuxDetSensitiveID()));
+    }
+    e.put(std::move(pSimChannels));
+  }
+
+  // Repeat for sim::BeamGateInfo
+  if (fShiftBeamGateInfo) {
+    auto const& beamGates = e.getProduct<std::vector<sim::BeamGateInfo>>(fInitBeamGateInfoLabel);
+
+    if (beamGates.size() != 1) {
+      if (beamGates.empty()) {
+        throw art::Exception(art::errors::EventProcessorFailure)
+          << kModuleName << ": THERE IS NO BEAM GATE INFO!\n";
+      }
+      throw art::Exception(art::errors::EventProcessorFailure)
+        << kModuleName << ": MORE THAN ONE BEAM GATE?\n";
+    }
+
+    const auto& beamGate = beamGates[0];
+
+    const double shiftedBeamGateStart = beamGate.Start() + timeShiftForTrigger_ns;
+    const double gateWidth = beamGate.Width();
+    const sim::BeamType_t beam = beamGate.BeamType();
+
+    const sim::BeamGateInfo shiftedBeamGate(shiftedBeamGateStart, gateWidth, beam);
+
+    auto pBeamGateInfos = std::make_unique<std::vector<sim::BeamGateInfo>>(1, shiftedBeamGate);
+
+    e.put(std::move(pBeamGateInfos));
+  }
+
+  // Repeat for sim::SimEnergyDeposit
   if (fShiftSimEnergyDeposits) {
     auto const& simEDeps =
-      e.getProduct<std::vector<sim::SimEnergyDeposit>>(fInputSimEnergyDepositLabel);
+      e.getProduct<std::vector<sim::SimEnergyDeposit>>(fInitSimEnergyDepositLabel);
 
     auto pSimEDeps = std::make_unique<std::vector<sim::SimEnergyDeposit>>();
     pSimEDeps->reserve(simEDeps.size());
@@ -143,23 +192,23 @@ void AdjustSimForTrigger::produce(art::Event& e)
       const int origID = inSimEDep.OrigTrackID();
 
       pSimEDeps->emplace_back(sim::SimEnergyDeposit(numphotons,
-                                                 numelectrons,
-                                                 syratio,
-                                                 energy,
-                                                 start,
-                                                 end,
-                                                 startT,
-                                                 endT,
-                                                 thisID,
-                                                 thisPDG,
-                                                 origID));
+                                                    numelectrons,
+                                                    syratio,
+                                                    energy,
+                                                    start,
+                                                    end,
+                                                    startT,
+                                                    endT,
+                                                    thisID,
+                                                    thisPDG,
+                                                    origID));
     }
     e.put(std::move(pSimEDeps));
   }
 
   // Repeat for sim::SimPhotons
   if (fShiftSimPhotons) {
-    auto const& simPhotons = e.getProduct<std::vector<sim::SimPhotons>>(fInputSimPhotonsLabel);
+    auto const& simPhotons = e.getProduct<std::vector<sim::SimPhotons>>(fInitSimPhotonsLabel);
     auto pSimPhotonss = std::make_unique<std::vector<sim::SimPhotons>>(simPhotons);
 
     for (auto& photons : *pSimPhotonss) {
@@ -172,57 +221,13 @@ void AdjustSimForTrigger::produce(art::Event& e)
 
   // Repeat for raw::OpDetWaveform
   if (fShiftWaveforms) {
-    auto const& waveforms = e.getProduct<std::vector<raw::OpDetWaveform>>(fInputWaveformLabel);
+    auto const& waveforms = e.getProduct<std::vector<raw::OpDetWaveform>>(fInitWaveformLabel);
     auto pWaveforms = std::make_unique<std::vector<raw::OpDetWaveform>>(waveforms);
 
     for (auto& waveform : *pWaveforms) {
       waveform.SetTimeStamp(waveform.TimeStamp() + timeShiftForTrigger_us);
     }
     e.put(std::move(pWaveforms));
-  }
-
-  // Repeat for sim::AuxDetIDE
-  if (fShiftAuxDetIDEs) {
-    auto const& simChannels = e.getProduct<std::vector<sim::AuxDetSimChannel>>(fInputAuxDetSimChannelLabel);
-    auto pSimChannels = std::make_unique<std::vector<sim::AuxDetSimChannel>>();
-
-    pSimChannels->reserve(simChannels.size());
-
-    for (auto const& simChannel : simChannels) {
-      std::vector<sim::AuxDetIDE> shiftedAuxDetIDEs = simChannel.AuxDetIDEs();
-      for (auto& auxDetIDE : shiftedAuxDetIDEs) {
-        auxDetIDE.entryT += timeShiftForTrigger_ns;
-        auxDetIDE.exitT += timeShiftForTrigger_ns;
-      }
-      pSimChannels->emplace_back(sim::AuxDetSimChannel(simChannel.AuxDetID(),
-                                 shiftedAuxDetIDEs,
-                                 simChannel.AuxDetSensitiveID()));
-    }
-    e.put(std::move(pSimChannels));
-  }
-
-  // Repeat for sim::BeamGateInfo
-  if (fShiftBeamGateInfo) {
-    auto const& beamGates = e.getProduct<std::vector<sim::BeamGateInfo>>(fInputBeamGateInfoLabel);
-
-    if (beamGates.size() != 1) {
-      if (beamGates.empty()) {
-        throw art::Exception(art::errors::EventProcessorFailure) << "THERE IS NO BEAM GATE INFO!\n";
-      }
-      throw art::Exception(art::errors::EventProcessorFailure) << "MORE THAN ONE BEAM GATE?\n";
-    }
-
-    const auto& beamGate = beamGates[0];
-
-    const double shiftedBeamGateStart = beamGate.Start() + timeShiftForTrigger_ns;
-    const double gateWidth = beamGate.Width();
-    const sim::BeamType_t beam = beamGate.BeamType();
-
-    const sim::BeamGateInfo shiftedBeamGate(shiftedBeamGateStart, gateWidth, beam);
-
-    auto pBeamGateInfos = std::make_unique<std::vector<sim::BeamGateInfo>>(1, shiftedBeamGate);
-
-    e.put(std::move(pBeamGateInfos));
   }
 }
 


### PR DESCRIPTION
In the process of reviewing [`icaruscode` #673](https://github.com/SBNSoftware/icaruscode/pull/673), it was discovered that the CRT hits were not being shifted and therefore CRT-PMT matching was broken by this module as the CRT hit times no longer matched the OpFlash times. To rectify this, I have updated the module allowing it to now shift the `sim::AuxDetIDE` according to the emulated trigger time, which can then be used as input to the CRT DetSim. This is accomplished by recreating the collection of `std::vector<sim::AuxDetSimChannel>` and reconstructing each channel with a new `std::vector<std::AuxDetIDE>`, which has `entryT` and `exitT` shifted by the value of the trigger time.