### PR TITLE
Restore SBN_QGSP_BERT_NNC to be QGSP_BERT with no neutron cut

### DIFF
--- a/sbncode/LArG4/PhysicsLists/SBN_QGSP_BERT_NNC.cc
+++ b/sbncode/LArG4/PhysicsLists/SBN_QGSP_BERT_NNC.cc
@@ -18,9 +18,9 @@
 #include "Geant4/G4EmExtraPhysics.hh"
 #include "Geant4/G4IonPhysics.hh"
 #include "Geant4/G4StoppingPhysics.hh"
-#include "Geant4/G4HadronElasticPhysicsHP.hh"
+#include "Geant4/G4HadronElasticPhysics.hh"
 // #include "Geant4/G4NeutronTrackingCut.hh"
-#include "Geant4/G4HadronPhysicsQGSP_BERT_HP.hh"
+#include "Geant4/G4HadronPhysicsQGSP_BERT.hh"
 
 
 // Register this new physics list
@@ -48,10 +48,10 @@ SBN_QGSP_BERT_NNC::SBN_QGSP_BERT_NNC(G4int ver)
   RegisterPhysics( new G4DecayPhysics(ver) );
 
    // Hadron Elastic scattering
-  RegisterPhysics( new G4HadronElasticPhysicsHP(ver) );
+  RegisterPhysics( new G4HadronElasticPhysics(ver) );
 
   // Hadron Physics
-  RegisterPhysics( new G4HadronPhysicsQGSP_BERT_HP(ver));
+  RegisterPhysics( new G4HadronPhysicsQGSP_BERT(ver));
 
   // Stopping Physics
   RegisterPhysics( new G4StoppingPhysics(ver) );


### PR DESCRIPTION
This PR restores the `SBN_QGSP_BERT_NNC` physics list to be "`QGSP_BERT` with no neutron cut".
Two separate PRs should follow, one for SBND and one for ICARUS, where the `QGSP_BERT_HP` physics list is adopted:

- [x] SBND: https://github.com/SBNSoftware/sbndcode/pull/468
- [ ] ICARUS: https://github.com/SBNSoftware/icaruscode/pull/737

See issue #453 for more details.