### PR TITLE
Keep CAF happy with CRT

### DIFF
--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -119,8 +119,8 @@ namespace caf
     srspacepoint.position     = SRVector3D(spacepoint.X(), spacepoint.Y(), spacepoint.Z());
     srspacepoint.position_err = SRVector3D(spacepoint.XErr(), spacepoint.YErr(), spacepoint.ZErr());
     srspacepoint.pe           = spacepoint.PE();
-    srspacepoint.time         = spacepoint.Time();
-    srspacepoint.time_err     = spacepoint.TimeErr();
+    srspacepoint.time         = spacepoint.Ts1();
+    srspacepoint.time_err     = spacepoint.Ts1Err();
     srspacepoint.complete     = spacepoint.Complete();
   }
 
@@ -131,8 +131,8 @@ namespace caf
     for(auto const& point : track.Points())
       srsbndcrttrack.points.emplace_back(point.X(), point.Y(), point.Z());
 
-    srsbndcrttrack.time    = track.Time();
-    srsbndcrttrack.time_err = track.TimeErr();
+    srsbndcrttrack.time    = track.Ts1();
+    srsbndcrttrack.time_err = track.Ts1Err();
     srsbndcrttrack.pe       = track.PE();
     srsbndcrttrack.tof      = track.ToF();
   }

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -131,7 +131,7 @@ namespace caf
     for(auto const& point : track.Points())
       srsbndcrttrack.points.emplace_back(point.X(), point.Y(), point.Z());
 
-    srsbndcrttrack.time    = track.Ts1();
+    srsbndcrttrack.time     = track.Ts1();
     srsbndcrttrack.time_err = track.Ts1Err();
     srsbndcrttrack.pe       = track.PE();
     srsbndcrttrack.tof      = track.ToF();


### PR DESCRIPTION
### Description 
This PR just ensures that CAFMaker continues to pickup the correct variable (for MC) when changes are made in `sbnobj` to the format of the CRT reconstruction objects.

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [ ] Is this PR related to an open issue / project?
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [ ] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.

This should be merged together with accompanying PRs in `sbnobj` (SBNSoftware/sbnobj#113) and `sbndcode` for compilation reasons.
