### PR TITLE
deleted second application of GReWeightResonanceDecay calculator

### DIFF
--- a/sbncode/SBNEventWeight/Calculators/CrossSections/GenieWeightCalc.cxx
+++ b/sbncode/SBNEventWeight/Calculators/CrossSections/GenieWeightCalc.cxx
@@ -605,7 +605,6 @@ void GenieWeightCalc::SetupWeightCalculators(genie::rew::GReWeight& rw,
   rw.AdoptWghtCalc( "hadro_intranuke", new GReWeightINuke           );
   rw.AdoptWghtCalc( "hadro_agky",      new GReWeightAGKY            );
   rw.AdoptWghtCalc( "xsec_nc",         new GReWeightNuXSecNC        );
-  rw.AdoptWghtCalc( "res_dk",          new GReWeightResonanceDecay  );
   rw.AdoptWghtCalc( "xsec_empmec",     new GReWeightXSecEmpiricalMEC);
   // GReWeightDISNuclMod::CalcWeight() is not implemented, so we won't
   // bother to use it here. - S. Gardiner, 9 Dec 2019


### PR DESCRIPTION
@nitish-nayak and I found an issue that causes the GReWeightResonanceDecay calculator to be applied twice, leading to squared weights for the BR1gamma, BR1eta, and Theta_Delta2Npi knobs. This was recently fixed in GENIE, described [here](https://github.com/GENIE-MC/Reweight/pull/34).
