### PR TITLE
Fix how CRT-PMT entries are stored in CAFs [release/SBN2024A]

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1480,8 +1480,17 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     std::cout << "valid handle! label: " << fParams.CRTPMTLabel() << "\n";
     const std::vector<sbn::crt::CRTPMTMatching> &crtpmtmatches = *crtpmtmatch_handle;
     for (unsigned i = 0; i < crtpmtmatches.size(); i++) {
-      srcrtpmtmatches.emplace_back();
-      FillCRTPMTMatch(crtpmtmatches[i],srcrtpmtmatches.back());
+      if(!crtpmtmatches[i].matchedCRTHits.empty()){
+	for(const auto& crthitmatch :  crtpmtmatches[i].matchedCRTHits){
+	  srcrtpmtmatches.emplace_back();
+	  FillCRTPMTMatch(crtpmtmatches[i], crthitmatch, srcrtpmtmatches.back());
+	}
+      }
+      else{
+	sbn::crt::MatchedCRT dummy_CRTmatch;
+	srcrtpmtmatches.emplace_back();
+	FillCRTPMTMatch(crtpmtmatches[i], dummy_CRTmatch, srcrtpmtmatches.back());
+      }
     }
   }
   else{

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -139,7 +139,8 @@ namespace caf
 
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
 		       const sbn::crt::MatchedCRT &crtmatch,
-		       caf::SRCRTPMTMatch &srmatch,
+		       int &topen, int &topex, int &sideen, int &sideex,
+	               caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty){
     (void) allowEmpty;
     srmatch.flashID = match.flashID;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -138,6 +138,7 @@ namespace caf
   }
 
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
+		       const sbn::crt::MatchedCRT &crtmatch,
 		       caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty){
     // allowEmpty does not (yet) matter here                                                           
@@ -155,8 +156,20 @@ namespace caf
     srmatch.flashYWidth = match.flashYWidth;
     srmatch.flashZWidth = match.flashZWidth;
     srmatch.flashClassification = static_cast<int>(match.flashClassification);
-    for(const auto& matchedCRTHit : match.matchedCRTHits){
-      std::cout << "CRTPMTTimeDiff = "<< matchedCRTHit.PMTTimeDiff << "\n";
+    srmatch.matchedCRTHits.clear();
+    caf::SRMatchedCRT matchedCRT;
+    if(!match.matchedCRTHits.empty()){
+      matchedCRT.PMTTimeDiff = crtmatch.PMTTimeDiff; 
+      matchedCRT.time = crtmatch.time;
+      matchedCRT.sys = crtmatch.sys;
+      matchedCRT.region = crtmatch.region;
+      matchedCRT.position = SRVector3D(crtmatch.position.X(), crtmatch.position.Y(), crtmatch.position.Z());
+      std::cout << "CRTPMTTimeDiff = "<< matchedCRT.PMTTimeDiff << "\n";
+    }
+    std::cout << "CRTPMTTimeDiff = "<< matchedCRT.PMTTimeDiff << "\n";
+    srmatch.matchedCRTHits.push_back(matchedCRT);
+    /*for(const auto& matchedCRTHit : match.matchedCRTHits){
+     
       caf::SRMatchedCRT matchedCRT;
       matchedCRT.PMTTimeDiff = matchedCRTHit.PMTTimeDiff; 
       matchedCRT.time = matchedCRTHit.time;
@@ -164,7 +177,7 @@ namespace caf
       matchedCRT.region = matchedCRTHit.region;
       matchedCRT.position = SRVector3D(matchedCRTHit.position.X(), matchedCRTHit.position.Y(), matchedCRTHit.position.Z());
       srmatch.matchedCRTHits.push_back(matchedCRT);
-    }
+      }*/
   }
 
 

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -141,9 +141,7 @@ namespace caf
 		       const sbn::crt::MatchedCRT &crtmatch,
 		       caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty){
-    // allowEmpty does not (yet) matter here                                                           
     (void) allowEmpty;
-    //srmatch.setDefault();
     srmatch.flashID = match.flashID;
     srmatch.flashTime_us = match.flashTime;
     srmatch.flashGateTime = match.flashGateTime;
@@ -155,7 +153,6 @@ namespace caf
     srmatch.flashPosition = SRVector3D (match.flashPosition.X(), match.flashPosition.Y(), match.flashPosition.Z());
     srmatch.flashYWidth = match.flashYWidth;
     srmatch.flashZWidth = match.flashZWidth;
-    srmatch.flashClassification = static_cast<int>(match.flashClassification);
     srmatch.matchedCRTHits.clear();
     caf::SRMatchedCRT matchedCRT;
     if(!match.matchedCRTHits.empty()){
@@ -164,20 +161,22 @@ namespace caf
       matchedCRT.sys = crtmatch.sys;
       matchedCRT.region = crtmatch.region;
       matchedCRT.position = SRVector3D(crtmatch.position.X(), crtmatch.position.Y(), crtmatch.position.Z());
-      std::cout << "CRTPMTTimeDiff = "<< matchedCRT.PMTTimeDiff << "\n";
+      if(crtmatch.PMTTimeDiff < 0){
+        if(matchedCRT.sys == 0) topen++;
+        else if(matchedCRT.sys == 1) sideen++;
+      }
+      else if(crtmatch.PMTTimeDiff >= 0){
+        if(matchedCRT.sys == 0) topex++;
+        else if(matchedCRT.sys == 1) sideex++;
+      }
     }
-    std::cout << "CRTPMTTimeDiff = "<< matchedCRT.PMTTimeDiff << "\n";
+    if(topen == 0 && sideen == 0 && topex == 0 && sideex == 0) srmatch.flashClassification = 0;
+    else if (topen == 1 && sideen == 0 && topex == 0 && sideex == 0) srmatch.flashClassification = 1;
+    else if (topen == 0 && sideen == 1 && topex == 0 && sideex == 0) srmatch.flashClassification = 2;
+    else if (topen == 0 && sideen == 0 && topex == 1 && sideex == 0) srmatch.flashClassification = 4;
+    else if (topen == 0 && sideen == 0 && topex == 0 && sideex == 1) srmatch.flashClassification = 5;
+    else srmatch.flashClassification = 9;
     srmatch.matchedCRTHits.push_back(matchedCRT);
-    /*for(const auto& matchedCRTHit : match.matchedCRTHits){
-     
-      caf::SRMatchedCRT matchedCRT;
-      matchedCRT.PMTTimeDiff = matchedCRTHit.PMTTimeDiff; 
-      matchedCRT.time = matchedCRTHit.time;
-      matchedCRT.sys = matchedCRTHit.sys;
-      matchedCRT.region = matchedCRTHit.region;
-      matchedCRT.position = SRVector3D(matchedCRTHit.position.X(), matchedCRTHit.position.Y(), matchedCRTHit.position.Z());
-      srmatch.matchedCRTHits.push_back(matchedCRT);
-      }*/
   }
 
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -226,7 +226,8 @@ namespace caf
                   bool allowEmpty = false);
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
 		       const sbn::crt::MatchedCRT &crtmatch,
-		       caf::SRCRTPMTMatch &srmatch,
+		       int &topen, int &topex, int &sideen, int &sidex,
+	               caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty = false);
 
   void FillTPCPMTBarycenterMatch(const sbn::TPCPMTBarycenterMatch *matchInfo,

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -225,8 +225,9 @@ namespace caf
                   caf::SROpFlash &srflash,
                   bool allowEmpty = false);
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
-		  caf::SRCRTPMTMatch &srmatch,
-		  bool allowEmpty = false);
+		       const sbn::crt::MatchedCRT &crtmatch,
+		       caf::SRCRTPMTMatch &srmatch,
+		       bool allowEmpty = false);
 
   void FillTPCPMTBarycenterMatch(const sbn::TPCPMTBarycenterMatch *matchInfo,
                            caf::SRSlice& slice);


### PR DESCRIPTION
### Description 
This pull request fixes a bug in how the CRT-PMT Matching information was stored in the CAFs. 
When there is no CRT-PMT match (flashClassification==0), we should have no CRT Hit match information (orPMTTimeDiff, time, sys, region, position values equal to their defaults, but it seems that CRT Hit match values were getting filled in from later CRT Hit matches. This is fixed by adding srmatch.matchedCRTHits.clear(); which results in the CRT Hit match variables getting set to their defaults defined in the [StandardRecord](https://github.com/SBNSoftware/sbnanaobj/blob/develop/sbnanaobj/StandardRecord/SRCRTPMTMatch.cxx).

When we have a PMT Flash matched to more than one CRT Hits (flashClassification==3, flashClassification==6, flashClassification==7), we should have entries saved from both CRT hit matches (with two CRT-PMT Match entries being saved for a single flash). This is fixed by calling FillCRTPMTMatch once for every CRT Hit in the matchedCRTHits vector.

This sbncode pull request addresses a separate issue than the bug fix in [icaruscode PR #760](https://github.com/SBNSoftware/icaruscode/pull/760) that updates the flashTime used to assign a CRT-PMT match classification. 

