### PR TITLE
CRTPMTMatching fix: remove unused counters 

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1559,12 +1559,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   if(crtpmtmatch_handle.isValid()){
     const std::vector<sbn::crt::CRTPMTMatching> &crtpmtmatches = *crtpmtmatch_handle;
     for (unsigned i = 0; i < crtpmtmatches.size(); i++) {
-      unsigned int topen = 0, topex = 0, sideen = 0, sideex = 0; // bottomen = 0, bottomex = 0;
       srcrtpmtmatches.emplace_back();
-      FillCRTPMTMatch(crtpmtmatches[i],
-		      topen, topex, sideen, sideex, 
-		      //bottomen, bottomex,
-		      srcrtpmtmatches.back());
+      FillCRTPMTMatch(crtpmtmatches[i], srcrtpmtmatches.back());
     }
   }
 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1559,7 +1559,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   if(crtpmtmatch_handle.isValid()){
     const std::vector<sbn::crt::CRTPMTMatching> &crtpmtmatches = *crtpmtmatch_handle;
     for (unsigned i = 0; i < crtpmtmatches.size(); i++) {
-      int topen = 0, topex = 0, sideen = 0, sideex = 0; // bottomen = 0, bottomex = 0;
+      unsigned int topen = 0, topex = 0, sideen = 0, sideex = 0; // bottomen = 0, bottomex = 0;
       srcrtpmtmatches.emplace_back();
       FillCRTPMTMatch(crtpmtmatches[i],
 		      topen, topex, sideen, sideex, 

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -141,8 +141,9 @@ namespace caf
   }
 
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
-		       int &topen, int &topex, int &sideen, int &sideex,
-		       //int &bottomen, int &bottomex,
+		       unsigned int topen, unsigned int topex, 
+		       unsigned int sideen, unsigned int sideex,
+		       //unsigned int &bottomen, unsigned int &bottomex,
 		       caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty){
     // allowEmpty does not (yet) matter here                                                           

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -141,9 +141,6 @@ namespace caf
   }
 
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
-		       unsigned int topen, unsigned int topex, 
-		       unsigned int sideen, unsigned int sideex,
-		       //unsigned int &bottomen, unsigned int &bottomex,
 		       caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty){
     // allowEmpty does not (yet) matter here                                                           
@@ -160,6 +157,7 @@ namespace caf
     srmatch.flashPosition = SRVector3D (match.flashPosition.X(), match.flashPosition.Y(), match.flashPosition.Z());
     srmatch.flashYWidth = match.flashYWidth;
     srmatch.flashZWidth = match.flashZWidth;
+    unsigned int topen = 0, topex = 0, sideen = 0, sideex = 0;
     for(const auto& matchedCRTHit : match.matchedCRTHits){
       caf::SRMatchedCRT matchedCRT;
       matchedCRT.PMTTimeDiff = matchedCRTHit.PMTTimeDiff; 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -222,8 +222,9 @@ namespace caf
                   caf::SROpFlash &srflash,
                   bool allowEmpty = false);
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
-		       int &topen, int &topex, int &sideen, int &sidex,
-		       //int &bottomen, int &bottomex,
+		       unsigned int topen, unsigned int topex, 
+		       unsigned int sideen, unsigned int sidex,
+		       //unsigned int &bottomen, unsigned int &bottomex,
 		       caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty = false);
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -222,9 +222,6 @@ namespace caf
                   caf::SROpFlash &srflash,
                   bool allowEmpty = false);
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
-		       unsigned int topen, unsigned int topex, 
-		       unsigned int sideen, unsigned int sidex,
-		       //unsigned int &bottomen, unsigned int &bottomex,
 		       caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty = false);
 


### PR DESCRIPTION
### Description 

This PR addresses some final comments by @PetrilloAtWork on sbncode PR #482 that reassigns the CRT-PMT flashClassification while filling CAFs using a function.
In this PR I've removed some unused counters in the FillCRTPMTMatch function definition (pointed out in [this comment](https://github.com/SBNSoftware/sbncode/pull/482#pullrequestreview-2455712535) ). 
This PR should be merged alongside sbnobj PR#[116](https://github.com/SBNSoftware/sbnobj/pull/116). 

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [X] Is this PR related to an open issue / project?
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [ ] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.