### PR TITLE
SBNB POT Accounting Producer Modules

### DIFF
--- a/sbncode/BeamSpillInfoRetriever/CMakeLists.txt
+++ b/sbncode/BeamSpillInfoRetriever/CMakeLists.txt
@@ -1,4 +1,7 @@
 add_subdirectory(BNBRetriever)
+add_subdirectory(SBNDBNBRetriever)
+add_subdirectory(SBNDBNBZEROBIASRetriever)
+add_subdirectory(SBNDBNBEXTRetriever)
 add_subdirectory(NuMIRetriever)
 add_subdirectory(BNBEXTRetriever)
 add_subdirectory(NuMIEXTRetriever)

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBEXTRetriever/CMakeLists.txt
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBEXTRetriever/CMakeLists.txt
@@ -1,0 +1,27 @@
+find_package(ifbeam)
+find_package(ifdh_art)
+
+cet_build_plugin(SBNDBNBEXTRetriever art::module
+    LIBRARIES
+        art::Persistency_Common
+        art::Utilities canvas::canvas
+        cetlib::cetlib cetlib_except::cetlib_except
+        ROOT::X3d
+        Boost::system
+        messagefacility::MF_MessageLogger
+        ifbeam::ifbeam
+        ifdh_art::IFBeam_service
+	SQLite::SQLite3
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_Common
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_ICARUS
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_SBND
+        artdaq_core::artdaq-core_Utilities
+        sbnobj::Common_POTAccounting
+        larcorealg::CoreUtils
+)
+
+install_headers()
+install_fhicl()
+install_source()
+

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBEXTRetriever/SBNDBNBEXTRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBEXTRetriever/SBNDBNBEXTRetriever_module.cc
@@ -1,0 +1,230 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       SBNDBNBEXTRetriever
+// Plugin Type: producer 
+// File:        SBNDBNBEXTRetriever_module.cc
+//
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include <memory>
+#include <bitset>
+#include <tuple>
+#include <algorithm>
+
+#include "sbndaq-artdaq-core/Overlays/SBND/PTBFragment.hh"
+#include "sbndaq-artdaq-core/Overlays/SBND/TDCTimestampFragment.hh"
+#include "artdaq-core/Data/ContainerFragment.hh"
+//#include "sbndcode/Decoders/PTB/sbndptb.h"
+#include "sbnobj/Common/POTAccounting/EXTCountInfo.h"
+
+#include "ifdh_art/IFBeamService/IFBeam_service.h"
+#include "ifbeam_c.h"
+
+#include "larcorealg/CoreUtils/counter.h"
+
+namespace sbn {
+  class SBNDBNBEXTRetriever;
+}
+
+class sbn::SBNDBNBEXTRetriever : public art::EDProducer {
+public:
+  explicit SBNDBNBEXTRetriever(fhicl::ParameterSet const & params);
+  // Required functions.
+  void produce(art::Event & e) override;
+  void beginSubRun(art::SubRun& sr) override;
+  void endSubRun(art::SubRun& sr) override;
+
+  // Plugins should not be copied or assigned.
+  SBNDBNBEXTRetriever(SBNDBNBEXTRetriever const &) = delete;
+  SBNDBNBEXTRetriever(SBNDBNBEXTRetriever &&) = delete;
+  SBNDBNBEXTRetriever & operator = (SBNDBNBEXTRetriever const &) = delete;
+  SBNDBNBEXTRetriever & operator = (SBNDBNBEXTRetriever &&) = delete;
+
+
+private:
+  // Declare member data here.
+  std::vector< sbn::EXTCountInfo > fOutExtInfos;
+  struct PTBInfo_t {
+    double currPTBTimeStamp  = 0;
+    double prevPTBTimeStamp  = 0;
+    unsigned int GateCounter = 0; // FIXME needs to be integral type
+  };
+
+  struct TriggerInfo_t {
+    double t_current_event  = 0;
+    double t_previous_event = 0;
+    unsigned int number_of_gates_since_previous_event = 0; // FIXME needs to be integral type
+  };
+
+  TriggerInfo_t extractTriggerInfo(art::Event const& e) const;
+  PTBInfo_t extractPTBInfo(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const;
+  double extractTDCTimeStamp(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const;
+
+  // input labels
+  std::string raw_data_label_;
+  float TotalEXTCounts;  
+  float totalMinBias;
+  float evtCount;
+};
+
+sbn::SBNDBNBEXTRetriever::SBNDBNBEXTRetriever(fhicl::ParameterSet const & params)
+  : EDProducer{params} {
+  produces< std::vector< sbn::EXTCountInfo >, art::InSubRun >();
+  TotalEXTCounts = 0;
+  totalMinBias = 0;
+  evtCount = 0;
+}
+
+int eventNum =0;
+int _run;
+int _subrun;
+int _event;
+
+void sbn::SBNDBNBEXTRetriever::produce(art::Event & e)
+{
+
+
+  TriggerInfo_t const triggerInfo = extractTriggerInfo(e);
+
+  TotalEXTCounts += triggerInfo.number_of_gates_since_previous_event;
+
+  if(triggerInfo.number_of_gates_since_previous_event > 0){
+    evtCount++;  
+    totalMinBias += triggerInfo.number_of_gates_since_previous_event;
+  }
+   
+  //Store everything in our data-product
+  sbn::EXTCountInfo extInfo;
+  extInfo.gates_since_last_trigger = triggerInfo.number_of_gates_since_previous_event;
+  fOutExtInfos.push_back(extInfo);
+}
+
+sbn::SBNDBNBEXTRetriever::PTBInfo_t sbn::SBNDBNBEXTRetriever::extractPTBInfo(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const {
+  int HLT_count = 0;
+
+  int numcont = 0;
+  PTBInfo_t PTBInfo;
+  for (auto const& cont : *cont_frags)
+  { 
+    artdaq::ContainerFragment cont_frag(cont);
+    numcont++;
+    int numfrag = 0;
+    for (size_t fragi = 0; fragi < cont_frag.block_count(); ++fragi)
+    {
+      numfrag++;
+      artdaq::Fragment frag = *cont_frag[fragi];
+      sbndaq::CTBFragment ctb_frag(frag);   // somehow the name CTBFragment stuck
+      for(size_t word_i = 0; word_i < ctb_frag.NWords(); ++word_i)
+      {
+        if(ctb_frag.Trigger(word_i)){
+          uint32_t wt = 0;
+          uint32_t word_type = ctb_frag.Word(word_i)->word_type;
+          wt = word_type;
+	  if (wt == 2 && ctb_frag.Trigger(word_i)->IsTrigger(4))
+	  {
+            HLT_count++;
+
+	    uint64_t RawprevPTBTimeStamp = ctb_frag.PTBWord(word_i)->prevTS * 20; 
+	    uint64_t RawcurrPTBTimeStamp = ctb_frag.Trigger(word_i)->timestamp * 20;
+            PTBInfo.prevPTBTimeStamp = std::bitset<64>(RawprevPTBTimeStamp / 20).to_ullong()/50e6; 
+            PTBInfo.currPTBTimeStamp = std::bitset<64>(RawcurrPTBTimeStamp / 20).to_ullong()/50e6; 
+            PTBInfo.GateCounter = ctb_frag.Trigger(word_i)->gate_counter;
+            break;
+	  }
+        }
+      } //End of loop over the number of trigger words
+    } //End of loop over the number of fragments per container
+  } //End of loop over the number of containers
+
+  return PTBInfo; 
+}
+
+double sbn::SBNDBNBEXTRetriever::extractTDCTimeStamp(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const {
+  int numcont = 0;
+  double TDCTimeStamp = 0;
+  for (auto const& cont : *cont_frags)
+  { 
+    artdaq::ContainerFragment cont_frag(cont);
+    numcont++;
+    int numfrag = 0;
+    for (size_t fragi = 0; fragi < cont_frag.block_count(); ++fragi)
+    {
+      numfrag++;
+      artdaq::Fragment frag = *cont_frag[fragi];
+      sbndaq::TDCTimestampFragment tdc_frag(frag); 
+      TDCTimeStamp = static_cast<double>(tdc_frag.getTDCTimestamp()->timestamp_ns())/1e9;
+    } //End of loop over the number of fragments per container
+  } //End of loop over the number of containers
+  return TDCTimeStamp;
+}
+
+sbn::SBNDBNBEXTRetriever::TriggerInfo_t sbn::SBNDBNBEXTRetriever::extractTriggerInfo(art::Event const& e) const {
+  // Using TDC for current event, but PTB for previous event
+  art::InputTag PTB_itag("daq", "ContainerPTB");
+  auto PTB_cont_frags = e.getHandle<artdaq::Fragments>(PTB_itag);
+
+  art::InputTag TDC_itag("daq", "ContainerTDCTIMESTAMP");
+  auto TDC_cont_frags = e.getHandle<artdaq::Fragments>(TDC_itag);
+
+  PTBInfo_t PTBInfo;
+  TriggerInfo_t triggerInfo;
+  PTBInfo = extractPTBInfo(PTB_cont_frags);
+
+  if (TDC_cont_frags) {
+    double TDCTimeStamp = extractTDCTimeStamp(TDC_cont_frags);
+    triggerInfo.t_current_event = TDCTimeStamp;
+  }
+  else{
+    mf::LogDebug("SBNDBNBEXTRetriever") << " Missing TDC Contaienr Fragments!!! " << std::endl;
+    triggerInfo.t_current_event = PTBInfo.currPTBTimeStamp;
+  }
+
+  triggerInfo.t_previous_event = PTBInfo.prevPTBTimeStamp;
+  triggerInfo.number_of_gates_since_previous_event = PTBInfo.GateCounter;
+
+  if(triggerInfo.t_current_event - PTBInfo.currPTBTimeStamp >= 1){
+    mf::LogDebug("SBNDBNBEXTRetriever") << "Caught PTB bug, PTB late" << std::endl;
+    mf::LogDebug("SBNDBNBEXTRetriever") << "Before: " << triggerInfo.t_previous_event << std::endl;
+    triggerInfo.t_previous_event+=1;
+    mf::LogDebug("SBNDBNBEXTRetriever") << "After: " << triggerInfo.t_previous_event << std::endl;
+  }
+  else if(triggerInfo.t_current_event - PTBInfo.currPTBTimeStamp <= -1){
+    mf::LogDebug("SBNDBNBEXTRetriever") << "Caught PTB bug, PTB early" << std::endl;
+    mf::LogDebug("SBNDBNBEXTRetriever") << "Before: " << triggerInfo.t_previous_event << std::endl;
+    triggerInfo.t_previous_event-=1;
+    mf::LogDebug("SBNDBNBEXTRetriever") << "After: " << triggerInfo.t_previous_event << std::endl;
+  }
+
+  return triggerInfo;
+}
+
+void sbn::SBNDBNBEXTRetriever::beginSubRun(art::SubRun& sr)
+{
+  TotalEXTCounts = 0;
+  totalMinBias = 0;
+  evtCount = 0;
+  return;
+}
+
+void sbn::SBNDBNBEXTRetriever::endSubRun(art::SubRun& sr)
+{
+   // We will add all of the EXTCountInfo data-products to the 
+  // art::SubRun so it persists 
+
+  auto p =  std::make_unique< std::vector< sbn::EXTCountInfo > >(fOutExtInfos);
+
+  sr.put(std::move(p), art::subRunFragment());
+
+  return; 
+}
+
+DEFINE_ART_MODULE(sbn::SBNDBNBEXTRetriever)

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBRetriever/CMakeLists.txt
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBRetriever/CMakeLists.txt
@@ -1,0 +1,34 @@
+find_package(ifbeam)
+find_package(ifdh_art)
+
+
+art_make_library(LIBRARIES Boost::system
+        LIBRARY_NAME sbn_SBNDBNBSpillInfoRetriever_MWRData
+        SOURCE MWRData.cpp
+)
+
+cet_build_plugin(SBNDBNBRetriever art::module
+    LIBRARIES
+        art::Persistency_Common
+        art::Utilities canvas::canvas
+        cetlib::cetlib cetlib_except::cetlib_except
+        ROOT::X3d
+        Boost::system
+        messagefacility::MF_MessageLogger
+        ifbeam::ifbeam
+        ifdh_art::IFBeam_service
+	SQLite::SQLite3
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_Common
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_ICARUS
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_SBND
+        artdaq_core::artdaq-core_Utilities
+        sbn_SBNDBNBSpillInfoRetriever_MWRData
+        sbnobj::Common_POTAccounting
+        larcorealg::CoreUtils
+)
+
+install_headers()
+install_fhicl()
+install_source()
+

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBRetriever/MWRData.cpp
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBRetriever/MWRData.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <boost/algorithm/string.hpp>
+#include "MWRData.h"
+
+using namespace std;
+
+namespace sbn{
+
+  std::vector< std::vector < int > > MWRData::unpackMWR(std::string packed_data, std::vector<double> &time_stamp, double timeoffset) const
+{
+
+  std::vector<std::vector<int> > unpacked_data;
+  unpacked_data.resize(4);
+  short data[444];
+
+  std::vector<std::string> row(0);
+  boost::split(row, packed_data, boost::is_any_of(","));
+  if (row.size()==447) {
+    for (int i=3;i<447;i++) {
+      data[i-3]=atoi(row[i].c_str());
+    }
+    string devname=row[1].substr(0,8);
+    for (int idev=0;idev<4;idev++) {
+      mwrpulse_t mwr=getMWRdata(data,idev);
+      time_stamp.push_back(mwr.sheader.timesec+mwr.sheader.timensec/1000000000.+timeoffset);
+      for (int ich=0;ich<48;ich++) {
+	unpacked_data[idev].push_back(mwr.hor[ich]);
+      }
+      for (int ich=0;ich<48;ich++) {
+	unpacked_data[idev].push_back(mwr.ver[ich]);
+      }
+    }
+  } else {
+    cout <<"BeamSpillInfoRetriever: MRWData: Bad data!"<<endl;
+    return unpacked_data;
+  }
+
+  return unpacked_data;
+}
+
+MWRData::mwrpulse_t MWRData::getMWRdata(short* data, int nblock) const
+{
+  mwrpulse_t mwrdata;
+
+  memcpy(&mwrdata.hor,                  data+nblock*111,    96);
+  memcpy(&mwrdata.ver,                  data+nblock*111+48, 96);
+  memcpy(&mwrdata.sheader.timesec,      data+nblock*111+96,  4);
+  memcpy(&mwrdata.sheader.timensec,     data+nblock*111+98,  4);
+  memcpy(&mwrdata.sheader.gpstime1,     data+nblock*111+100, 4);
+  memcpy(&mwrdata.sheader.gpstime2,     data+nblock*111+102, 4);
+  memcpy(&mwrdata.sheader.boosterevent, data+nblock*111+104, 2);
+  memcpy(&mwrdata.sheader.mievent,      data+nblock*111+105, 2);
+  memcpy(&mwrdata.sheader.hz15micnt,    data+nblock*111+106, 2);
+  memcpy(&mwrdata.sheader.delta1f,      data+nblock*111+107, 4);
+  memcpy(&mwrdata.sheader.pulsemi,      data+nblock*111+109, 2);
+  memcpy(&mwrdata.sheader.pulsesc,      data+nblock*111+110, 2);
+
+  mwrdata.sheader.timesec=flipByte(mwrdata.sheader.timesec);
+  mwrdata.sheader.timensec=flipByte(mwrdata.sheader.timensec);
+  mwrdata.sheader.gpstime1=flipByte(mwrdata.sheader.gpstime1);
+  mwrdata.sheader.gpstime2=flipByte(mwrdata.sheader.gpstime2);
+  mwrdata.sheader.delta1f=flipByte(mwrdata.sheader.delta1f);
+
+  return mwrdata;
+
+}
+}

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBRetriever/MWRData.h
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBRetriever/MWRData.h
@@ -1,0 +1,39 @@
+#ifndef _MWRDATA_H
+#define _MWRDATA_H
+
+#include <string.h>
+namespace sbn{
+class MWRData
+{
+  typedef struct swicheader_t {
+    long timesec;
+    long timensec;
+    long gpstime1;
+    long gpstime2;
+    short boosterevent;
+    short mievent;
+    short hz15micnt;
+    long delta1f;
+    short pulsemi;
+    short pulsesc;
+  } swicheader_t;
+  
+  typedef struct mwrpulse_t {
+    short hor[48];
+    short ver[48];
+    swicheader_t sheader;
+  } mwrpulse_t;  
+  
+  static long flipByte(long data)
+  {
+    return ((data>>16)&0x0000FFFF) | ((data<<16)&0xFFFF0000);
+  }
+  
+  mwrpulse_t getMWRdata(short* data, int nblock) const;
+  
+ public:
+  std::vector< std::vector < int > > unpackMWR(std::string packed_data, std::vector<double> &time_stamp, double timeoffset=0) const;
+};
+}
+
+#endif /* #ifndef _MWRDATA_H */

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBRetriever/SBNDBNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBRetriever/SBNDBNBRetriever_module.cc
@@ -1,0 +1,632 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       SBNDBNBRetriever
+// Plugin Type: producer 
+// File:        SBNDBNBRetriever_module.cc
+//
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "canvas/Utilities/Exception.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include <cxxabi.h>
+#include <memory>
+#include <bitset>
+#include <tuple>
+#include <algorithm>
+
+#include "sbndaq-artdaq-core/Overlays/SBND/PTBFragment.hh"
+#include "sbndaq-artdaq-core/Overlays/SBND/TDCTimestampFragment.hh"
+#include "artdaq-core/Data/ContainerFragment.hh"
+//#include "sbndcode/Decoders/PTB/sbndptb.h"
+#include "sbnobj/Common/POTAccounting/BNBSpillInfo.h"
+
+#include "ifdh_art/IFBeamService/IFBeam_service.h"
+#include "ifbeam_c.h"
+#include "MWRData.h"
+
+#include "larcorealg/CoreUtils/counter.h"
+
+namespace sbn {
+  class SBNDBNBRetriever;
+}
+
+class sbn::SBNDBNBRetriever : public art::EDProducer {
+public:
+  explicit SBNDBNBRetriever(fhicl::ParameterSet const & params);
+  // Required functions.
+  void produce(art::Event & e) override;
+  void beginSubRun(art::SubRun& sr) override;
+  void endSubRun(art::SubRun& sr) override;
+
+  // Plugins should not be copied or assigned.
+  SBNDBNBRetriever(SBNDBNBRetriever const &) = delete;
+  SBNDBNBRetriever(SBNDBNBRetriever &&) = delete;
+  SBNDBNBRetriever & operator = (SBNDBNBRetriever const &) = delete;
+  SBNDBNBRetriever & operator = (SBNDBNBRetriever &&) = delete;
+
+
+private:
+  // Declare member data here.
+  std::vector< sbn::BNBSpillInfo > fOutbeamInfos;
+  double fTimePad;
+  std::string fInputLabel;
+  std::string fInputNonContainerInstance;
+  std::string fDeviceUsedForTiming;
+  std::string fOutputInstance;
+  std::string raw_data_label;
+  int fDebugLevel;
+  sbn::MWRData mwrdata;
+  art::ServiceHandle<ifbeam_ns::IFBeam> ifbeam_handle;
+  std::unique_ptr<ifbeam_ns::BeamFolder> bfp;
+  std::unique_ptr<ifbeam_ns::BeamFolder> bfp_mwr;
+
+  struct PTBInfo_t {
+    double currPTBTimeStamp  = 0;
+    double prevPTBTimeStamp  = 0;
+    unsigned int GateCounter = 0; // FIXME needs to be integral type
+  };
+
+  struct TriggerInfo_t {
+    double t_current_event  = 0;
+    double t_previous_event = 0;
+    unsigned int number_of_gates_since_previous_event = 0; // FIXME needs to be integral type
+  };
+
+  struct MWRdata_t {
+    std::vector< std::vector<double> > MWR_times;
+    std::vector< std::vector< std::vector< int > > > unpacked_MWR;
+  };
+
+  static constexpr double MWRtoroidDelay = -0.035; ///< the same time point is measured _t_ by MWR and _t + MWRtoroidDelay`_ by the toroid [ms]
+
+  TriggerInfo_t extractTriggerInfo(art::Event const& e) const;
+  PTBInfo_t extractPTBInfo(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const;
+  double extractTDCTimeStamp(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const;
+  MWRdata_t extractSpillTimes(TriggerInfo_t const& triggerInfo) const; 
+  int matchMultiWireData(
+    art::EventID const& eventID, 
+    TriggerInfo_t const& triggerInfo,
+    MWRdata_t const& MWRdata, bool isFirstEventInRun,
+    std::vector< sbn::BNBSpillInfo >& beamInfos
+    ) const;
+  unsigned int TotalBeamSpills;
+  sbn::BNBSpillInfo makeBNBSpillInfo
+    (art::EventID const& eventID, double time, MWRdata_t const& MWRdata, std::vector<int> const& matched_MWR) const;
+};
+
+sbn::SBNDBNBRetriever::SBNDBNBRetriever(fhicl::ParameterSet const & params)
+  : EDProducer{params} {
+  produces< std::vector< sbn::BNBSpillInfo >, art::InSubRun >();
+  raw_data_label = params.get<std::string>("raw_data_label", "daq");
+  fInputLabel = params.get<std::string>("InputLabel");
+  fDeviceUsedForTiming = params.get<std::string>("DeviceUsedForTiming");
+  fTimePad = params.get<double>("TimePadding");
+  fInputNonContainerInstance = params.get<std::string>("InputNonContainerInstance");
+  fOutputInstance = params.get<std::string>("OutputInstance");
+  fDebugLevel = params.get<int>("DebugLevel",0);
+  bfp = ifbeam_handle->getBeamFolder(params.get<std::string>("Bundle"), params.get<std::string>("URL"), std::stod(params.get<std::string>("TimeWindow")));
+  bfp->set_epsilon(0.02);
+  bfp_mwr = ifbeam_handle->getBeamFolder(params.get<std::string>("MultiWireBundle"), params.get<std::string>("URL"), std::stod(params.get<std::string>("MWR_TimeWindow")));
+  bfp_mwr->set_epsilon(0.5);
+  bfp_mwr->setValidWindow(3605);
+  TotalBeamSpills = 0;
+}
+
+int eventNum =0;
+int _run;
+int _subrun;
+int _event;
+
+void sbn::SBNDBNBRetriever::produce(art::Event & e)
+{
+
+  // If this is the first event in the run, then ignore it
+  // We do not currently have the ability to figure out the first
+  // spill that the DAQ was sensitive to, so don't try to save any
+  // spill information
+
+  TriggerInfo_t const triggerInfo = extractTriggerInfo(e);
+
+
+  TotalBeamSpills += triggerInfo.number_of_gates_since_previous_event;
+  MWRdata_t const MWRdata = extractSpillTimes(triggerInfo);
+
+  int const spill_count = matchMultiWireData(e.id(), triggerInfo, MWRdata, e.event() == 1, fOutbeamInfos);
+
+  if(spill_count > int(triggerInfo.number_of_gates_since_previous_event))
+    mf::LogDebug("SBNDBNBRetriever")<< "Event Spills : " << spill_count << ", DAQ Spills : " << triggerInfo.number_of_gates_since_previous_event << " \t \t ::: WRONG!"<< std::endl;
+  else
+    mf::LogDebug("SBNDBNBRetriever")<< "Event Spills : " << spill_count << ", DAQ Spills : " << triggerInfo.number_of_gates_since_previous_event << std::endl;
+}
+
+sbn::SBNDBNBRetriever::PTBInfo_t sbn::SBNDBNBRetriever::extractPTBInfo(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const {
+
+  int numcont = 0;
+  PTBInfo_t PTBInfo;
+  for (auto const& cont : *cont_frags)
+  { 
+    artdaq::ContainerFragment cont_frag(cont);
+    numcont++;
+    int numfrag = 0;
+    for (size_t fragi = 0; fragi < cont_frag.block_count(); ++fragi)
+    {
+      numfrag++;
+      artdaq::Fragment frag = *cont_frag[fragi];
+      sbndaq::CTBFragment ctb_frag(frag);   // somehow the name CTBFragment stuck
+      for(size_t word_i = 0; word_i < ctb_frag.NWords(); ++word_i)
+      {
+        if(ctb_frag.Trigger(word_i)){
+          uint32_t wt = 0;
+          uint32_t word_type = ctb_frag.Word(word_i)->word_type;
+          wt = word_type;
+	  if (wt == 2 && ctb_frag.Trigger(word_i)->IsTrigger(2))
+	  {
+
+	    uint64_t RawprevPTBTimeStamp = ctb_frag.PTBWord(word_i)->prevTS * 20; 
+            uint64_t RawcurrPTBTimeStamp = ctb_frag.Trigger(word_i)->timestamp * 20; 
+            PTBInfo.prevPTBTimeStamp = std::bitset<64>(RawprevPTBTimeStamp / 20).to_ullong()/50e6; 
+            PTBInfo.currPTBTimeStamp = std::bitset<64>(RawcurrPTBTimeStamp/20).to_ullong()/50e6; 
+            PTBInfo.GateCounter = ctb_frag.Trigger(word_i)->gate_counter;
+            break;
+	  }
+        }
+      } //End of loop over the number of trigger words
+    } //End of loop over the number of fragments per container
+  } //End of loop over the number of containers
+
+  return PTBInfo; 
+}
+
+double sbn::SBNDBNBRetriever::extractTDCTimeStamp(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const {
+  int numcont = 0;
+
+  double TDCTimeStamp = 0;
+  for (auto const& cont : *cont_frags)
+  { 
+    artdaq::ContainerFragment cont_frag(cont);
+    numcont++;
+    int numfrag = 0;
+    for (size_t fragi = 0; fragi < cont_frag.block_count(); ++fragi)
+    {
+      numfrag++;
+      artdaq::Fragment frag = *cont_frag[fragi];
+      sbndaq::TDCTimestampFragment tdc_frag(frag); 
+      TDCTimeStamp = static_cast<double>(tdc_frag.getTDCTimestamp()->timestamp_ns())/1e9;
+    } //End of loop over the number of fragments per container
+  } //End of loop over the number of containers
+  return TDCTimeStamp;
+}
+
+sbn::SBNDBNBRetriever::TriggerInfo_t sbn::SBNDBNBRetriever::extractTriggerInfo(art::Event const& e) const {
+  // Using TDC for current event, but PTB for previous event. Exception for case where no TDC.
+  art::InputTag PTB_itag("daq", "ContainerPTB");
+  auto PTB_cont_frags = e.getHandle<artdaq::Fragments>(PTB_itag);
+
+  art::InputTag TDC_itag("daq", "ContainerTDCTIMESTAMP");
+  auto TDC_cont_frags = e.getHandle<artdaq::Fragments>(TDC_itag);
+
+  PTBInfo_t PTBInfo;
+  TriggerInfo_t triggerInfo;
+  PTBInfo = extractPTBInfo(PTB_cont_frags);
+
+  if (TDC_cont_frags) {
+    double TDCTimeStamp = extractTDCTimeStamp(TDC_cont_frags);
+    triggerInfo.t_current_event = TDCTimeStamp;
+  }
+  else{
+    mf::LogDebug("SBNDBNBRetriever") << " Missing TDC Container Fragments!!! " << std::endl;
+    triggerInfo.t_current_event = PTBInfo.currPTBTimeStamp;
+  }
+
+  triggerInfo.t_previous_event = PTBInfo.prevPTBTimeStamp;
+  triggerInfo.number_of_gates_since_previous_event = PTBInfo.GateCounter;
+
+  if(triggerInfo.t_current_event - PTBInfo.currPTBTimeStamp >= 1){
+    mf::LogDebug("SBNDBNBRetriever") << "Caught PTB bug, PTB late" << std::endl;
+    mf::LogDebug("SBNDBNBRetriever") << "Before: " << triggerInfo.t_previous_event << std::endl;
+    triggerInfo.t_previous_event+=1;
+    mf::LogDebug("SBNDBNBRetriever") << "After: " << triggerInfo.t_previous_event << std::endl;
+  }
+  else if(triggerInfo.t_current_event - PTBInfo.currPTBTimeStamp <= -1){
+    mf::LogDebug("SBNDBNBRetriever") << "Caught PTB bug, PTB early" << std::endl;
+    mf::LogDebug("SBNDBNBRetriever") << "Before: " << triggerInfo.t_previous_event << std::endl;
+    triggerInfo.t_previous_event-=1;
+    mf::LogDebug("SBNDBNBRetriever") << "After: " << triggerInfo.t_previous_event << std::endl;
+  }
+
+  return triggerInfo;
+}
+
+sbn::SBNDBNBRetriever::MWRdata_t sbn::SBNDBNBRetriever::extractSpillTimes(TriggerInfo_t const& triggerInfo) const {
+  
+  // These lines get everything primed within the IFBeamDB.
+  try{bfp->FillCache((triggerInfo.t_current_event)+fTimePad);} catch (WebAPIException &we) {};     
+  try{bfp->FillCache((triggerInfo.t_previous_event)-fTimePad);} catch (WebAPIException &we) {};      
+  try{bfp_mwr->FillCache((triggerInfo.t_current_event)+fTimePad);} catch (WebAPIException &we) {};
+  try{bfp_mwr->FillCache((triggerInfo.t_previous_event)-fTimePad);} catch (WebAPIException &we) {};
+
+  // The multiwire chambers provide their
+  // data in a vector format but we'll have 
+  // to sort through it in std::string format
+  // to correctly unpack it
+  std::vector< std::vector< std::vector< int > > >  unpacked_MWR;
+  std::vector< std::vector< double> > MWR_times;
+  unpacked_MWR.resize(3);
+  MWR_times.resize(3);
+  std::string packed_data_str; 
+  
+  // Create a list of all the MWR devices with their different
+  // memory buffer increments 
+  // generally in the format: "E:<Device>.{Memory Block}"
+  std::vector<std::string> vars = bfp_mwr->GetDeviceList();
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR Device Blocks Found : " << vars.size() << std::endl;
+  // Tracking the time from the IFBeamDB
+  double time_for_mwr;    
+  
+  // this is an iterator to track which of the 
+  // three devices we will be working with
+  int dev = 0;
+  
+  // The MWR devices are annoying and have confusing buffer
+  // what we'll do is sort through all of them first and then 
+  // match them to the closest spills in time
+  // 
+
+  //  int t_steps = int(((triggerInfo.t_previous_event - fTimePad) - (triggerInfo.t_current_event + fTimePad))/0.5)+25;
+  int t_steps = int(((triggerInfo.t_current_event + fTimePad) - (triggerInfo.t_previous_event - fTimePad - 20.))/0.5)+25;
+
+  for(int t = 0; t < t_steps; t++){//Iterate through time increments
+    for (std::string const& var : vars) {// Iterate through the devices
+      
+      //Make sure we have a device
+      if(var.empty()){ 
+	//mf::LogDebug("SBNDBNBRetriever") << " NO MWR DEVICES?!" << std::endl;
+	continue;
+      }
+      /// Check the device name and interate the double-vector index
+      if(var.find("M875BB") != std::string::npos ) dev = 0;
+      else if(var.find("M876BB") != std::string::npos ) dev = 1;
+      else if(var.find("MMBTBB") != std::string::npos ) dev = 2;
+      else{
+	//mf::LogDebug("SBNDBNBRetriever") << " NOT matched to a MWR DEVICES?!" << var << std::endl;
+	continue;}
+      
+      time_for_mwr = 0;
+      
+      try{
+
+	//Pull the MWR data for the device
+	// these data are "packed"
+	std::vector<double> packed_MWR = bfp_mwr->GetNamedVector((triggerInfo.t_previous_event)-20.-fTimePad+double(0.5*t),var,&time_for_mwr);
+
+	//We'll convert this into a format
+	// that we can unpack doubles >> strings
+	//
+	packed_data_str.clear();
+	packed_data_str += std::to_string(int(time_for_mwr));
+	packed_data_str.append(",");
+	packed_data_str.append(var);
+	packed_data_str.append(",,");
+	
+	/*	for(auto const value: packed_MWR){
+	  packed_data_str += ',';
+	  packed_data_str += std::to_string(int(value));
+	  }*/
+	for(int j = 0; j < int(packed_MWR.size()); j++){
+	  packed_data_str += std::to_string(int(packed_MWR[j]));
+	  if(j < int(packed_MWR.size())-1)
+	    packed_data_str.append(",");
+	}
+	
+	// Use Zarko's unpacking function to turn this into consumeable data
+	std::vector<double> MWR_times_temp;
+	
+	// There is a 35 ms offset between the toriod and the MWR times
+	//   we'll just remove that here to match to the spill times
+	std::vector< std::vector< int > > unpacked_MWR_temp = mwrdata.unpackMWR(packed_data_str,MWR_times_temp,MWRtoroidDelay);
+	
+	//There are four events that are packed into one MWR IFBeam entry
+	for(std::size_t s: util::counter(unpacked_MWR_temp.size())){
+	  	  
+	  // If this entry has a unique time them store it for later	  
+	  if(std::find(MWR_times[dev].begin(), MWR_times[dev].end(), MWR_times_temp[s]) == MWR_times[dev].end()){
+	    unpacked_MWR[dev].push_back(unpacked_MWR_temp[s]);
+	    MWR_times[dev].push_back(MWR_times_temp[s]);
+	  }//check for unique time 
+	}//Iterate through the unpacked events
+	}//try
+      catch (WebAPIException &we) {
+	//Ignore when we can't find the MWR devices
+	//   they don't always report and the timing of them can be annoying
+	}//catch
+    }// Iterate over all the multiwire devices
+  }// Iterate over all times
+
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[0] times : " << MWR_times[0].size() << std::endl;	
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[0]s : " << unpacked_MWR[0].size() << std::endl;	
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[1] times : " << MWR_times[1].size() << std::endl;	
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[1]s : " << unpacked_MWR[1].size() << std::endl;	
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[2] times : " << MWR_times[2].size() << std::endl;	
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[2]s : " << unpacked_MWR[2].size() << std::endl;	
+  
+  return { std::move(MWR_times), std::move(unpacked_MWR) };
+}
+
+int sbn::SBNDBNBRetriever::matchMultiWireData(
+  art::EventID const& eventID,
+  TriggerInfo_t const& triggerInfo,
+  MWRdata_t const& MWRdata, bool isFirstEventInRun,
+  std::vector< sbn::BNBSpillInfo >& beamInfos
+) const {
+  
+  auto const& [ MWR_times, unpacked_MWR ] = MWRdata; // alias
+  
+  //Here we will start collecting all the other beamline devices
+  // First we get the times that the beamline device fired
+  //  we have to pick a specific variable to use
+  std::vector<double> times_temps = bfp->GetTimeList(fDeviceUsedForTiming);
+
+  mf::LogDebug("SBNDBNBRetriever") << "matchMultiWireData:: Number of time spills : " << times_temps.size() << std::endl;
+
+  // We'll keep track of how many of these spills match to our 
+  // DAQ trigger times
+  int spill_count = 0;
+  int spills_removed = 0;
+  std::vector<int> matched_MWR;
+  matched_MWR.resize(3);
+  
+  // NOTE: for now, this is dead code because we don't
+  // do anything for the first event in a run. We may want to revisit 
+  // this later to understand if there is a way we can do the POT
+  // accounting in the first event.
+  //
+  // Need to handle the first event in a run differently
+  if(isFirstEventInRun){
+    //We'll remove the spills after our event
+    int spills_after_our_target = 0;
+    // iterate through all the spills to find the 
+    // spills that are after our triggered event
+    for (size_t i = 0; i < times_temps.size(); i++) {       
+      if(times_temps[i] > (triggerInfo.t_current_event+fTimePad)){
+	spills_after_our_target++;
+      }
+    }//end loop through spill times 	 
+    
+    // Remove the spills after our trigger
+    times_temps.erase(times_temps.end()-spills_after_our_target,times_temps.end());
+    
+    // Remove the spills before the start of our Run
+    times_temps.erase(times_temps.begin(), times_temps.end() - std::min(int(triggerInfo.number_of_gates_since_previous_event), int(times_temps.size())));
+        
+  }//end fix for "first event"
+  
+    ///reject time_stamps which have a trigger_type == 1 from data-base
+    //To-Do 
+
+  //  mf::LogDebug("SBNDBNBRetriever") << "Total number of Times we're going to test: " << times_temps.size() <<  std::endl;
+  // mf::LogDebug("SBNDBNBRetriever") << std::setprecision(19) << "Upper Limit : " << (triggerInfo.t_current_event)+fTimePad <<  std::endl;
+  // mf::LogDebug("SBNDBNBRetriever") << std::setprecision(19) << "Lower Limit : " << (triggerInfo.t_previous_event)+fTimePad <<  std::endl;
+  
+  // Iterating through each of the beamline times
+  for (size_t i = 0; i < times_temps.size(); i++) {
+    
+    // Only continue if these times are matched to our DAQ time
+    // mf::LogDebug("SBNDBNBRetriever") << std::setprecision(19) << "Time # : " <<  i << std::endl;
+
+    if(!isFirstEventInRun){//We already addressed the "first event" above
+      if(times_temps[i] > (triggerInfo.t_current_event)+fTimePad){
+	//mf::LogDebug("SBNDBNBRetriever") << std::setprecision(19) << "Removed!  : " << times_temps[i] << std::endl;
+	spills_removed++; 
+	continue;} 
+      if(times_temps[i] <= (triggerInfo.t_previous_event)+fTimePad){
+	spills_removed++; 
+	//mf::LogDebug("SBNDBNBRetriever") << std::setprecision(19) << "Removed!  : " << times_temps[i] << std::endl;
+	continue;}
+    }
+
+    //check if this spill is is minbias   
+    /*
+      40 ms was selected to be close to but outside the 66 ms 
+      time of the next spill (when the beam is running at 15 Hz) 
+      DocDB 33155 provides documentation of this
+    */
+
+    // mf::LogDebug("SBNDBNBRetriever") << std::setprecision(19) << "matchMultiWireData:: trigger type : " << get_trigger_type_matching_gate(db, callback_trigger_type, run_number, times_temps[i]*1.e9-triggerInfo.WR_to_Spill_conversion+3.6e7, 40.) << " times : spill " << times_temps[i]*1.e9 << " - " << triggerInfo.WR_to_Spill_conversion << " + " << 3.6e7 <<  std::endl;
+    
+    // if(get_trigger_type_matching_gate(db, callback_trigger_type, run_number, times_temps[i]*1.e9-triggerInfo.WR_to_Spill_conversion+3.6e7, 40.) == 1){
+    //      mf::LogDebug("SBNDBNBRetriever") << std::setprecision(19)  << "matchMultiWireData:: Skipped a MinBias gate at : " << times_temps[i]*1000. << std::endl;
+
+    //  continue;
+    //}
+      
+    //Great we found a matched spill! Let's count it
+    spill_count++;
+
+    //Loop through the multiwire devices:
+    
+    for(int dev = 0; dev < int(MWR_times.size()); dev++){
+      
+      //Loop through the multiwire times:
+      double Tdiff = 1000000000.;
+      matched_MWR[dev] = 0;
+
+      for(int mwrt = 0;  mwrt < int(MWR_times[dev].size()); mwrt++){
+
+	//found a candidate match! 
+	if(fabs((MWR_times[dev][mwrt] - times_temps[i])) >= Tdiff){continue;}
+	
+	bool best_match = true;
+	  
+	//Check for a better match...
+	for (size_t j = 0; j < times_temps.size(); j++) {
+	  if( j == i) continue;
+	  if(times_temps[j] > (triggerInfo.t_current_event+fTimePad)){continue;}
+	  if(times_temps[j] <= (triggerInfo.t_previous_event+fTimePad)){continue;}
+	  
+	  //is there a better match later in the spill sequence
+	  if(fabs((MWR_times[dev][mwrt] - times_temps[j])) < 
+	     fabs((MWR_times[dev][mwrt] - times_temps[i]))){
+	    //we can have patience...
+	    best_match = false;
+	    break;
+	  }	     
+	}//end better match check
+	
+	//Verified best match!
+	if(best_match == true){
+	  matched_MWR[dev] = mwrt;
+	  Tdiff = fabs((MWR_times[dev][mwrt] - times_temps[i]));
+	}
+	
+      }//end loop over MWR times 
+      
+    }//end loop over MWR devices
+    
+    sbn::BNBSpillInfo spillInfo = makeBNBSpillInfo(eventID, times_temps[i], MWRdata, matched_MWR);
+
+    beamInfos.push_back(std::move(spillInfo));
+
+    // We do not write these to the art::Events because 
+    // we can filter events but want to keep all the POT 
+    // information, so we'll write it to the SubRun
+    
+  }//end iteration over beam device times
+  
+  //  mf::LogDebug("SBNDBNBRetriever") << "matchMultiWireData:: Total spills counted:  " << spill_count << "   Total spills removed : " << spills_removed <<  std::endl;
+
+  return spill_count;
+}
+
+sbn::BNBSpillInfo sbn::SBNDBNBRetriever::makeBNBSpillInfo
+  (art::EventID const& eventID, double time, MWRdata_t const& MWRdata, std::vector<int> const& matched_MWR) const
+{
+  
+  auto const& [ MWR_times, unpacked_MWR ] = MWRdata; // alias
+ 
+  // initializing all of our device carriers
+  // device definitions can be found in BNBSpillInfo.h
+  
+  double TOR860 = 0; // units e12 protons
+  double TOR875 = 0; // units e12 protons
+  double LM875A = 0; // units R/s
+  double LM875B = 0; // units R/s
+  double LM875C = 0; // units R/s
+  double HP875 = 0; // units mm
+  double VP875 = 0; // units mm
+  double HPTG1 = 0; // units mm
+  double VPTG1 = 0; // units mm
+  double HPTG2 = 0; // units mm
+  double VPTG2 = 0; // units mm
+  double BTJT2 = 0; // units Deg C
+  double THCURR = 0; // units kiloAmps
+  
+  double TOR860_time = 0; // units s
+    
+  // Here we request all the devices
+  // since sometimes devices fail to report we'll
+  // allow each to throw an exception but still move forward
+  // interpreting these failures will be part of the beam quality analyses 
+
+  try{bfp->GetNamedData(time, "E:TOR860@",&TOR860,&TOR860_time);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:TOR875",&TOR875);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:LM875A",&LM875A);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:LM875B",&LM875B);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:LM875C",&LM875C);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:HP875",&HP875);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:VP875",&VP875);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:HPTG1",&HPTG1);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:VPTG1",&VPTG1);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:HPTG2",&HPTG2);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:VPTG2",&VPTG2);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:BTJT2",&BTJT2);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:THCURR",&THCURR);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+
+  //crunch the times 
+  unsigned long int time_closest_int = (int) TOR860_time;
+  double time_closest_ns = (TOR860_time - time_closest_int)*1e9;
+
+  //Store everything in our data-product
+  sbn::BNBSpillInfo beamInfo;
+  beamInfo.TOR860 = TOR860*1e12; //add in factor of 1e12 protons to get correct POT units
+  beamInfo.TOR875 = TOR875*1e12; //add in factor of 1e12 protons to get correct POT units
+  beamInfo.LM875A = LM875A;
+  beamInfo.LM875B = LM875B;
+  beamInfo.LM875C = LM875C;
+  beamInfo.HP875 = HP875;
+  beamInfo.VP875 = VP875;
+  beamInfo.HPTG1 = HPTG1;
+  beamInfo.VPTG1 = VPTG1;
+  beamInfo.HPTG2 = HPTG2;
+  beamInfo.VPTG2 = VPTG2;
+  beamInfo.BTJT2 = BTJT2;
+  beamInfo.THCURR = THCURR;
+  beamInfo.spill_time_s = time_closest_int;
+  beamInfo.spill_time_ns = time_closest_ns;    
+
+  for(auto const& MWRdata: unpacked_MWR){
+    std::ignore = MWRdata;
+    assert(!MWRdata.empty());
+  }
+
+  if(unpacked_MWR[0].empty()){
+    beamInfo.M875BB.clear();
+    beamInfo.M875BB_spill_time_diff = -999;//units in seconds
+  }
+  else{
+    beamInfo.M875BB = unpacked_MWR[0][matched_MWR[0]];
+    beamInfo.M875BB_spill_time_diff = (MWR_times[0][matched_MWR[0]] - time);
+  }
+
+ if(unpacked_MWR[1].empty()){
+    beamInfo.M876BB.clear();
+    beamInfo.M876BB_spill_time_diff = -999;//units in seconds
+ }
+ else{
+   beamInfo.M876BB = unpacked_MWR[1][matched_MWR[1]];
+   beamInfo.M876BB_spill_time_diff = (MWR_times[1][matched_MWR[1]] - time);
+ }
+
+ if(unpacked_MWR[2].empty()){
+    beamInfo.MMBTBB.clear();
+    beamInfo.MMBTBB_spill_time_diff = -999;//units in seconds
+  }
+ else{
+   beamInfo.MMBTBB = unpacked_MWR[2][matched_MWR[2]];
+   beamInfo.MMBTBB_spill_time_diff = (MWR_times[2][matched_MWR[2]] - time);
+ }
+  // We do not write these to the art::Events because 
+  // we can filter events but want to keep all the POT 
+  // information, so we'll write it to the SubRun
+  
+  beamInfo.event = eventID.event(); // the rest of ID is known by art::SubRun
+  
+  return beamInfo;
+}
+
+void sbn::SBNDBNBRetriever::beginSubRun(art::SubRun& sr)
+{
+  return;
+}
+
+void sbn::SBNDBNBRetriever::endSubRun(art::SubRun& sr)
+{
+  mf::LogDebug("SBNDBNBRetriever")<< "Total number of DAQ Spills : " << TotalBeamSpills << std::endl;
+  mf::LogDebug("SBNDBNBRetriever")<< "Total number of Selected Spills : " << fOutbeamInfos.size() << std::endl;
+
+  auto p =  std::make_unique< std::vector< sbn::BNBSpillInfo > >();
+  std::swap(*p, fOutbeamInfos);
+  
+  sr.put(std::move(p), art::subRunFragment());
+  
+  return;
+}
+
+DEFINE_ART_MODULE(sbn::SBNDBNBRetriever)

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBZEROBIASRetriever/CMakeLists.txt
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBZEROBIASRetriever/CMakeLists.txt
@@ -1,0 +1,34 @@
+find_package(ifbeam)
+find_package(ifdh_art)
+
+
+art_make_library(LIBRARIES Boost::system
+        LIBRARY_NAME sbn_SBNDBNBZEROBIASSpillInfoRetriever_MWRData
+        SOURCE MWRData.cpp
+)
+
+cet_build_plugin(SBNDBNBZEROBIASRetriever art::module
+    LIBRARIES
+        art::Persistency_Common
+        art::Utilities canvas::canvas
+        cetlib::cetlib cetlib_except::cetlib_except
+        ROOT::X3d
+        Boost::system
+        messagefacility::MF_MessageLogger
+        ifbeam::ifbeam
+        ifdh_art::IFBeam_service
+	SQLite::SQLite3
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_Common
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_ICARUS
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_SBND
+        artdaq_core::artdaq-core_Utilities
+        sbn_SBNDBNBZEROBIASSpillInfoRetriever_MWRData
+        sbnobj::Common_POTAccounting
+        larcorealg::CoreUtils
+)
+
+install_headers()
+install_fhicl()
+install_source()
+

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBZEROBIASRetriever/MWRData.cpp
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBZEROBIASRetriever/MWRData.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <boost/algorithm/string.hpp>
+#include "MWRData.h"
+
+using namespace std;
+
+namespace sbn{
+
+  std::vector< std::vector < int > > MWRData::unpackMWR(std::string packed_data, std::vector<double> &time_stamp, double timeoffset) const
+{
+
+  std::vector<std::vector<int> > unpacked_data;
+  unpacked_data.resize(4);
+  short data[444];
+
+  std::vector<std::string> row(0);
+  boost::split(row, packed_data, boost::is_any_of(","));
+  if (row.size()==447) {
+    for (int i=3;i<447;i++) {
+      data[i-3]=atoi(row[i].c_str());
+    }
+    string devname=row[1].substr(0,8);
+    for (int idev=0;idev<4;idev++) {
+      mwrpulse_t mwr=getMWRdata(data,idev);
+      time_stamp.push_back(mwr.sheader.timesec+mwr.sheader.timensec/1000000000.+timeoffset);
+      for (int ich=0;ich<48;ich++) {
+	unpacked_data[idev].push_back(mwr.hor[ich]);
+      }
+      for (int ich=0;ich<48;ich++) {
+	unpacked_data[idev].push_back(mwr.ver[ich]);
+      }
+    }
+  } else {
+    cout <<"BeamSpillInfoRetriever: MRWData: Bad data!"<<endl;
+    return unpacked_data;
+  }
+
+  return unpacked_data;
+}
+
+MWRData::mwrpulse_t MWRData::getMWRdata(short* data, int nblock) const
+{
+  mwrpulse_t mwrdata;
+
+  memcpy(&mwrdata.hor,                  data+nblock*111,    96);
+  memcpy(&mwrdata.ver,                  data+nblock*111+48, 96);
+  memcpy(&mwrdata.sheader.timesec,      data+nblock*111+96,  4);
+  memcpy(&mwrdata.sheader.timensec,     data+nblock*111+98,  4);
+  memcpy(&mwrdata.sheader.gpstime1,     data+nblock*111+100, 4);
+  memcpy(&mwrdata.sheader.gpstime2,     data+nblock*111+102, 4);
+  memcpy(&mwrdata.sheader.boosterevent, data+nblock*111+104, 2);
+  memcpy(&mwrdata.sheader.mievent,      data+nblock*111+105, 2);
+  memcpy(&mwrdata.sheader.hz15micnt,    data+nblock*111+106, 2);
+  memcpy(&mwrdata.sheader.delta1f,      data+nblock*111+107, 4);
+  memcpy(&mwrdata.sheader.pulsemi,      data+nblock*111+109, 2);
+  memcpy(&mwrdata.sheader.pulsesc,      data+nblock*111+110, 2);
+
+  mwrdata.sheader.timesec=flipByte(mwrdata.sheader.timesec);
+  mwrdata.sheader.timensec=flipByte(mwrdata.sheader.timensec);
+  mwrdata.sheader.gpstime1=flipByte(mwrdata.sheader.gpstime1);
+  mwrdata.sheader.gpstime2=flipByte(mwrdata.sheader.gpstime2);
+  mwrdata.sheader.delta1f=flipByte(mwrdata.sheader.delta1f);
+
+  return mwrdata;
+
+}
+}

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBZEROBIASRetriever/MWRData.h
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBZEROBIASRetriever/MWRData.h
@@ -1,0 +1,39 @@
+#ifndef _MWRDATA_H
+#define _MWRDATA_H
+
+#include <string.h>
+namespace sbn{
+class MWRData
+{
+  typedef struct swicheader_t {
+    long timesec;
+    long timensec;
+    long gpstime1;
+    long gpstime2;
+    short boosterevent;
+    short mievent;
+    short hz15micnt;
+    long delta1f;
+    short pulsemi;
+    short pulsesc;
+  } swicheader_t;
+  
+  typedef struct mwrpulse_t {
+    short hor[48];
+    short ver[48];
+    swicheader_t sheader;
+  } mwrpulse_t;  
+  
+  static long flipByte(long data)
+  {
+    return ((data>>16)&0x0000FFFF) | ((data<<16)&0xFFFF0000);
+  }
+  
+  mwrpulse_t getMWRdata(short* data, int nblock) const;
+  
+ public:
+  std::vector< std::vector < int > > unpackMWR(std::string packed_data, std::vector<double> &time_stamp, double timeoffset=0) const;
+};
+}
+
+#endif /* #ifndef _MWRDATA_H */

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBZEROBIASRetriever/SBNDBNBZEROBIASRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBZEROBIASRetriever/SBNDBNBZEROBIASRetriever_module.cc
@@ -1,0 +1,597 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       SBNDBNBRetriever
+// Plugin Type: producer 
+// File:        SBNDBNBRetriever_module.cc
+//
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include <memory>
+#include <bitset>
+#include <tuple>
+#include <algorithm>
+
+#include "sbndaq-artdaq-core/Overlays/SBND/PTBFragment.hh"
+#include "sbndaq-artdaq-core/Overlays/SBND/TDCTimestampFragment.hh"
+#include "artdaq-core/Data/ContainerFragment.hh"
+//#include "sbndcode/Decoders/PTB/sbndptb.h"
+#include "sbnobj/Common/POTAccounting/BNBSpillInfo.h"
+
+#include "ifdh_art/IFBeamService/IFBeam_service.h"
+#include "ifbeam_c.h"
+#include "MWRData.h"
+
+#include "larcorealg/CoreUtils/counter.h"
+
+namespace sbn {
+  class SBNDBNBRetriever;
+}
+
+class sbn::SBNDBNBRetriever : public art::EDProducer {
+public:
+  explicit SBNDBNBRetriever(fhicl::ParameterSet const & params);
+  // Required functions.
+  void produce(art::Event & e) override;
+  void beginSubRun(art::SubRun& sr) override;
+  void endSubRun(art::SubRun& sr) override;
+
+  // Plugins should not be copied or assigned.
+  SBNDBNBRetriever(SBNDBNBRetriever const &) = delete;
+  SBNDBNBRetriever(SBNDBNBRetriever &&) = delete;
+  SBNDBNBRetriever & operator = (SBNDBNBRetriever const &) = delete;
+  SBNDBNBRetriever & operator = (SBNDBNBRetriever &&) = delete;
+
+
+private:
+  // Declare member data here.
+  std::vector< sbn::BNBSpillInfo > fOutbeamInfos;
+  double fTimePad;
+  std::string fInputLabel;
+  std::string fInputNonContainerInstance;
+  std::string fDeviceUsedForTiming;
+  std::string fOutputInstance;
+  std::string raw_data_label;
+  int fDebugLevel;
+  sbn::MWRData mwrdata;
+  art::ServiceHandle<ifbeam_ns::IFBeam> ifbeam_handle;
+  std::unique_ptr<ifbeam_ns::BeamFolder> bfp;
+  std::unique_ptr<ifbeam_ns::BeamFolder> bfp_mwr;
+
+  struct PTBInfo_t {
+    double currPTBTimeStamp  = 0;
+    double prevPTBTimeStamp  = 0;
+    unsigned int GateCounter = 0; // FIXME needs to be integral type
+  };
+
+  struct TriggerInfo_t {
+    double t_current_event  = 0;
+    double t_previous_event = 0;
+    unsigned int number_of_gates_since_previous_event = 0; // FIXME needs to be integral type
+  };
+
+  struct MWRdata_t {
+    std::vector< std::vector<double> > MWR_times;
+    std::vector< std::vector< std::vector< int > > > unpacked_MWR;
+  };
+
+  static constexpr double MWRtoroidDelay = -0.035; ///< the same time point is measured _t_ by MWR and _t + MWRtoroidDelay`_ by the toroid [ms]
+
+  TriggerInfo_t extractTriggerInfo(art::Event const& e) const;
+  PTBInfo_t extractPTBInfo(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const;
+  double extractTDCTimeStamp(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const;
+  MWRdata_t extractSpillTimes(TriggerInfo_t const& triggerInfo) const; 
+  void matchMultiWireData(
+    art::EventID const& eventID, 
+    TriggerInfo_t const& triggerInfo,
+    MWRdata_t const& MWRdata, bool isFirstEventInRun,
+    std::vector< sbn::BNBSpillInfo >& beamInfos
+    ) const;
+  unsigned int TotalBeamSpills;
+  sbn::BNBSpillInfo makeBNBSpillInfo
+    (art::EventID const& eventID, double time, MWRdata_t const& MWRdata, std::vector<int> const& matched_MWR) const;
+};
+
+sbn::SBNDBNBRetriever::SBNDBNBRetriever(fhicl::ParameterSet const & params)
+  : EDProducer{params} {
+  raw_data_label = params.get<std::string>("raw_data_label", "daq");
+  fInputLabel = params.get<std::string>("InputLabel");
+  fDeviceUsedForTiming = params.get<std::string>("DeviceUsedForTiming");
+  fTimePad = params.get<double>("TimePadding");
+  fInputNonContainerInstance = params.get<std::string>("InputNonContainerInstance");
+  fOutputInstance = params.get<std::string>("OutputInstance");
+  fDebugLevel = params.get<int>("DebugLevel",0);
+  bfp = ifbeam_handle->getBeamFolder(params.get<std::string>("Bundle"), params.get<std::string>("URL"), std::stod(params.get<std::string>("TimeWindow")));
+  bfp->set_epsilon(0.02);
+  bfp_mwr = ifbeam_handle->getBeamFolder(params.get<std::string>("MultiWireBundle"), params.get<std::string>("URL"), std::stod(params.get<std::string>("MWR_TimeWindow")));
+  bfp_mwr->set_epsilon(0.5);
+  bfp_mwr->setValidWindow(3605);
+  TotalBeamSpills = 0;
+  produces< std::vector< sbn::BNBSpillInfo >, art::InEvent >();
+  // produces< std::vector<sbn::BNBSpillInfo> >();
+}
+
+int eventNum =0;
+int _run;
+int _subrun;
+int _event;
+
+void sbn::SBNDBNBRetriever::produce(art::Event & e)
+{
+
+  // If this is the first event in the run, then ignore it
+  // We do not currently have the ability to figure out the first
+  // spill that the DAQ was sensitive to, so don't try to save any
+  // spill information
+
+  if (e.event() == 1) {
+    auto p =  std::make_unique< std::vector< sbn::BNBSpillInfo > >();
+    std::swap(*p, fOutbeamInfos);
+    e.put(std::move(p));
+    return;
+  }
+
+
+  TriggerInfo_t const triggerInfo = extractTriggerInfo(e);
+
+
+  TotalBeamSpills += triggerInfo.number_of_gates_since_previous_event;
+  MWRdata_t const MWRdata = extractSpillTimes(triggerInfo);
+
+  matchMultiWireData(e.id(), triggerInfo, MWRdata, e.event() == 1, fOutbeamInfos);
+
+  auto p =  std::make_unique< std::vector< sbn::BNBSpillInfo > >();
+  std::swap(*p, fOutbeamInfos);
+  e.put(std::move(p));
+}
+
+sbn::SBNDBNBRetriever::PTBInfo_t sbn::SBNDBNBRetriever::extractPTBInfo(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const {
+
+  int numcont = 0;
+  PTBInfo_t PTBInfo;
+  for (auto const& cont : *cont_frags)
+  { 
+    artdaq::ContainerFragment cont_frag(cont);
+    numcont++;
+    int numfrag = 0;
+    for (size_t fragi = 0; fragi < cont_frag.block_count(); ++fragi)
+    {
+      numfrag++;
+      artdaq::Fragment frag = *cont_frag[fragi];
+      sbndaq::CTBFragment ctb_frag(frag);   // somehow the name CTBFragment stuck
+      for(size_t word_i = 0; word_i < ctb_frag.NWords(); ++word_i)
+      {
+        if(ctb_frag.Trigger(word_i)){
+          uint32_t wt = 0;
+          uint32_t word_type = ctb_frag.Word(word_i)->word_type;
+          wt = word_type;
+	  if (wt == 2 && ctb_frag.Trigger(word_i)->IsTrigger(1))
+	  {
+	    uint64_t RawprevPTBTimeStamp = ctb_frag.PTBWord(word_i)->prevTS * 20.0; 
+	    // uint64_t RawcurrPTBTimeStamp = ctb_frag.Trigger(word_i)->timestamp * 20;
+	    uint64_t RawcurrPTBTimeStamp = ctb_frag.TimeStamp(word_i) * 20.0;
+            PTBInfo.prevPTBTimeStamp = std::bitset<64>(RawprevPTBTimeStamp / 20.0).to_ullong()/50e6; 
+            PTBInfo.currPTBTimeStamp = std::bitset<64>(RawcurrPTBTimeStamp / 20.0).to_ullong()/50e6; 
+            PTBInfo.GateCounter = ctb_frag.Trigger(word_i)->gate_counter;
+
+            break;
+	  }
+        }
+      } //End of loop over the number of trigger words
+    } //End of loop over the number of fragments per container
+  } //End of loop over the number of containers
+
+  return PTBInfo; 
+}
+
+double sbn::SBNDBNBRetriever::extractTDCTimeStamp(art::Handle<std::vector<artdaq::Fragment> > cont_frags) const {
+  int numcont = 0;
+  double TDCTimeStamp = 0;
+  for (auto const& cont : *cont_frags)
+  { 
+    artdaq::ContainerFragment cont_frag(cont);
+    numcont++;
+    int numfrag = 0;
+    for (size_t fragi = 0; fragi < cont_frag.block_count(); ++fragi)
+    {
+      numfrag++;
+      artdaq::Fragment frag = *cont_frag[fragi];
+      sbndaq::TDCTimestampFragment tdc_frag(frag);
+      TDCTimeStamp = static_cast<double>(tdc_frag.getTDCTimestamp()->timestamp_ns()) / 1e9;
+    } //End of loop over the number of fragments per container
+  } //End of loop over the number of containers
+  return TDCTimeStamp;
+}
+
+sbn::SBNDBNBRetriever::TriggerInfo_t sbn::SBNDBNBRetriever::extractTriggerInfo(art::Event const& e) const {
+  // Using TDC for current event, but PTB for previous event
+  art::InputTag PTB_itag("daq", "ContainerPTB");
+  auto PTB_cont_frags = e.getHandle<artdaq::Fragments>(PTB_itag);
+
+  art::InputTag TDC_itag("daq", "ContainerTDCTIMESTAMP");
+  auto TDC_cont_frags = e.getHandle<artdaq::Fragments>(TDC_itag);
+
+  PTBInfo_t PTBInfo;
+  TriggerInfo_t triggerInfo;
+  PTBInfo = extractPTBInfo(PTB_cont_frags);
+
+  if (TDC_cont_frags) {
+    double TDCTimeStamp = extractTDCTimeStamp(TDC_cont_frags);
+    triggerInfo.t_current_event = TDCTimeStamp;
+  }
+  else{
+    mf::LogDebug("SBNDBNBZEROBIASRetriever") << " Missing TDC Container Fragments!!!" << std::endl;
+    triggerInfo.t_current_event = PTBInfo.currPTBTimeStamp;
+  }
+
+  triggerInfo.t_previous_event = PTBInfo.prevPTBTimeStamp;
+  triggerInfo.number_of_gates_since_previous_event = PTBInfo.GateCounter;
+
+
+  if(triggerInfo.t_current_event - PTBInfo.currPTBTimeStamp >= 1){
+    triggerInfo.t_previous_event+=1;
+  }
+  else if(triggerInfo.t_current_event - PTBInfo.currPTBTimeStamp <= -1){
+    triggerInfo.t_previous_event-=1;
+  }
+
+  return triggerInfo;
+}
+
+sbn::SBNDBNBRetriever::MWRdata_t sbn::SBNDBNBRetriever::extractSpillTimes(TriggerInfo_t const& triggerInfo) const {
+  
+  // These lines get everything primed within the IFBeamDB.
+  try{bfp->FillCache((triggerInfo.t_current_event)+fTimePad);} catch (WebAPIException &we) {}; 
+  try{bfp->FillCache((triggerInfo.t_current_event)+fTimePad);} catch (WebAPIException &we) {};     
+  try{bfp->FillCache((triggerInfo.t_previous_event)-fTimePad);} catch (WebAPIException &we) {};      
+  try{bfp_mwr->FillCache((triggerInfo.t_current_event)+fTimePad);} catch (WebAPIException &we) {};
+  try{bfp_mwr->FillCache((triggerInfo.t_previous_event)-fTimePad);} catch (WebAPIException &we) {};
+
+  // The multiwire chambers provide their
+  // data in a vector format but we'll have 
+  // to sort through it in std::string format
+  // to correctly unpack it
+  std::vector< std::vector< std::vector< int > > >  unpacked_MWR;
+  std::vector< std::vector< double> > MWR_times;
+  unpacked_MWR.resize(3);
+  MWR_times.resize(3);
+  std::string packed_data_str; 
+  
+  // Create a list of all the MWR devices with their different
+  // memory buffer increments 
+  // generally in the format: "E:<Device>.{Memory Block}"
+  std::vector<std::string> vars = bfp_mwr->GetDeviceList();
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR Device Blocks Found : " << vars.size() << std::endl;
+  // Tracking the time from the IFBeamDB
+  double time_for_mwr;    
+  
+  // this is an iterator to track which of the 
+  // three devices we will be working with
+  int dev = 0;
+  
+  // The MWR devices are annoying and have confusing buffer
+  // what we'll do is sort through all of them first and then 
+  // match them to the closest spills in time
+  // 
+
+  //  int t_steps = int(((triggerInfo.t_previous_event - fTimePad) - (triggerInfo.t_current_event + fTimePad))/0.5)+25;
+  int t_steps = int(((triggerInfo.t_current_event + fTimePad) - (triggerInfo.t_previous_event - fTimePad - 20.))/0.5)+25;
+
+  for(int t = 0; t < t_steps; t++){//Iterate through time increments
+    for (std::string const& var : vars) {// Iterate through the devices
+      
+      //Make sure we have a device
+      if(var.empty()){ 
+	//mf::LogDebug("SBNDBNBRetriever") << " NO MWR DEVICES?!" << std::endl;
+	continue;
+      }
+      /// Check the device name and interate the double-vector index
+      if(var.find("M875BB") != std::string::npos ) dev = 0;
+      else if(var.find("M876BB") != std::string::npos ) dev = 1;
+      else if(var.find("MMBTBB") != std::string::npos ) dev = 2;
+      else{
+	//mf::LogDebug("SBNDBNBRetriever") << " NOT matched to a MWR DEVICES?!" << var << std::endl;
+	continue;}
+      
+      time_for_mwr = 0;
+      
+      try{
+
+	//Pull the MWR data for the device
+	// these data are "packed"
+	std::vector<double> packed_MWR = bfp_mwr->GetNamedVector((triggerInfo.t_previous_event)-20.-fTimePad+double(0.5*t),var,&time_for_mwr);
+
+	//We'll convert this into a format
+	// that we can unpack doubles >> strings
+	//
+	packed_data_str.clear();
+	packed_data_str += std::to_string(int(time_for_mwr));
+	packed_data_str.append(",");
+	packed_data_str.append(var);
+	packed_data_str.append(",,");
+	
+	/*	for(auto const value: packed_MWR){
+	  packed_data_str += ',';
+	  packed_data_str += std::to_string(int(value));
+	  }*/
+	for(int j = 0; j < int(packed_MWR.size()); j++){
+	  packed_data_str += std::to_string(int(packed_MWR[j]));
+	  if(j < int(packed_MWR.size())-1)
+	    packed_data_str.append(",");
+	}
+	
+	// Use Zarko's unpacking function to turn this into consumeable data
+	std::vector<double> MWR_times_temp;
+	
+	// There is a 35 ms offset between the toriod and the MWR times
+	//   we'll just remove that here to match to the spill times
+	std::vector< std::vector< int > > unpacked_MWR_temp = mwrdata.unpackMWR(packed_data_str,MWR_times_temp,MWRtoroidDelay);
+	
+	//There are four events that are packed into one MWR IFBeam entry
+	for(std::size_t s: util::counter(unpacked_MWR_temp.size())){
+	  	  
+	  // If this entry has a unique time them store it for later	  
+	  if(std::find(MWR_times[dev].begin(), MWR_times[dev].end(), MWR_times_temp[s]) == MWR_times[dev].end()){
+	    unpacked_MWR[dev].push_back(unpacked_MWR_temp[s]);
+	    MWR_times[dev].push_back(MWR_times_temp[s]);
+	  }//check for unique time 
+	}//Iterate through the unpacked events
+	}//try
+      catch (WebAPIException &we) {
+	//Ignore when we can't find the MWR devices
+	//   they don't always report and the timing of them can be annoying
+	}//catch
+    }// Iterate over all the multiwire devices
+  }// Iterate over all times
+
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[0] times : " << MWR_times[0].size() << std::endl;	
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[0]s : " << unpacked_MWR[0].size() << std::endl;	
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[1] times : " << MWR_times[1].size() << std::endl;	
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[1]s : " << unpacked_MWR[1].size() << std::endl;	
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[2] times : " << MWR_times[2].size() << std::endl;	
+  mf::LogDebug("SBNDBNBRetriever") << " Number of MWR[2]s : " << unpacked_MWR[2].size() << std::endl;	
+  
+  return { std::move(MWR_times), std::move(unpacked_MWR) };
+}
+
+void sbn::SBNDBNBRetriever::matchMultiWireData(
+  art::EventID const& eventID,
+  TriggerInfo_t const& triggerInfo,
+  MWRdata_t const& MWRdata, bool isFirstEventInRun,
+  std::vector< sbn::BNBSpillInfo >& beamInfos
+) const {
+  
+  auto const& [ MWR_times, unpacked_MWR ] = MWRdata; // alias
+  
+  //Here we will start collecting all the other beamline devices
+  // First we get the times that the beamline device fired
+  //  we have to pick a specific variable to use
+  std::vector<double> times_temps = bfp->GetTimeList(fDeviceUsedForTiming);
+
+  mf::LogDebug("SBNDBNBRetriever") << "matchMultiWireData:: Number of time spills : " << times_temps.size() << std::endl;
+
+  // We'll keep track of how many of these spills match to our 
+  // DAQ trigger times
+  int spills_removed = 0;
+  std::vector<int> matched_MWR;
+  matched_MWR.resize(3);
+
+  //  mf::LogDebug("SBNDBNBRetriever") << "Total number of Times we're going to test: " << times_temps.size() <<  std::endl;
+  // mf::LogDebug("SBNDBNBRetriever") << std::setprecision(19) << "Upper Limit : " << (triggerInfo.t_current_event)+fTimePad <<  std::endl;
+  // mf::LogDebug("SBNDBNBRetriever") << std::setprecision(19) << "Lower Limit : " << (triggerInfo.t_previous_event)+fTimePad <<  std::endl;
+  
+  // Iterating through each of the beamline times
+ 
+  if(isFirstEventInRun){
+    //We'll remove the spills after our event
+    int spills_after_our_target = 0;
+    // iterate through all the spills to find the 
+    // spills that are after our triggered event
+    for (size_t i = 0; i < times_temps.size(); i++) {       
+      if(times_temps[i] > (triggerInfo.t_current_event+fTimePad)){
+	spills_after_our_target++;
+      }
+    }//end loop through spill times 	 
+    
+    // Remove the spills after our trigger
+    times_temps.erase(times_temps.end()-spills_after_our_target,times_temps.end());
+    
+    // Remove the spills before the start of our Run
+    times_temps.erase(times_temps.begin(), times_temps.end() - std::min(int(triggerInfo.number_of_gates_since_previous_event), int(times_temps.size())));
+        
+  }//end fix for "first event"
+
+  double best_diff = 10000000000.0; 
+  double diff; 
+  size_t i = 0;
+
+  for (size_t k = 0; k < times_temps.size(); k++){
+    diff = times_temps[k] - (triggerInfo.t_current_event + fTimePad);
+
+    if( diff < 0 and diff < best_diff){
+      if(!isFirstEventInRun){
+        if(times_temps[k] > (triggerInfo.t_current_event)+fTimePad){
+	  spills_removed++; 
+	  continue;} 
+        if(times_temps[k] <= (triggerInfo.t_previous_event)+fTimePad){
+	  spills_removed++; 
+	  continue;}
+      }
+      best_diff = diff; 
+      i = k;
+    }
+  }
+  for(int dev = 0; dev < int(MWR_times.size()); dev++){
+      
+    //Loop through the multiwire times:
+    double Tdiff = 1000000000.;
+    matched_MWR[dev] = 0;
+
+    for(int mwrt = 0;  mwrt < int(MWR_times[dev].size()); mwrt++){
+
+      //found a candidate match! 
+      if(fabs((MWR_times[dev][mwrt] - times_temps[i])) >= Tdiff){continue;}
+	
+      bool best_match = true;
+	  
+      //Check for a better match...
+      for (size_t j = 0; j < times_temps.size(); j++) {
+        if( j == i) continue;
+        if(times_temps[j] > (triggerInfo.t_current_event+fTimePad)){continue;}
+	if(times_temps[j] <= (triggerInfo.t_previous_event+fTimePad)){continue;}
+	  
+	//is there a better match later in the spill sequence
+	if(fabs((MWR_times[dev][mwrt] - times_temps[j])) < 
+	  fabs((MWR_times[dev][mwrt] - times_temps[i]))){
+	  //we can have patience...
+	  best_match = false;
+	  break;
+	}	     
+      }//end better match check
+	
+      //Verified best match! 
+      if(best_match == true){
+        matched_MWR[dev] = mwrt;
+	Tdiff = fabs((MWR_times[dev][mwrt] - times_temps[i]));
+      }	
+    }//end loop over MWR times 
+  }//end loop over MWR devices
+    
+    sbn::BNBSpillInfo spillInfo = makeBNBSpillInfo(eventID, times_temps[i], MWRdata, matched_MWR);
+
+    beamInfos.push_back(std::move(spillInfo));
+
+    // We do not write these to the art::Events because 
+    // we can filter events but want to keep all the POT 
+    // information, so we'll write it to the SubRun
+    
+  //}//end iteration over beam device times
+  
+  //  mf::LogDebug("SBNDBNBRetriever") << "matchMultiWireData:: Total spills counted:  " << spill_count << "   Total spills removed : " << spills_removed <<  std::endl;
+
+}
+
+sbn::BNBSpillInfo sbn::SBNDBNBRetriever::makeBNBSpillInfo
+  (art::EventID const& eventID, double time, MWRdata_t const& MWRdata, std::vector<int> const& matched_MWR) const
+{
+  auto const& [ MWR_times, unpacked_MWR ] = MWRdata; // alias
+ 
+  // initializing all of our device carriers
+  // device definitions can be found in BNBSpillInfo.h
+  
+  double TOR860 = 0; // units e12 protons
+  double TOR875 = 0; // units e12 protons
+  double LM875A = 0; // units R/s
+  double LM875B = 0; // units R/s
+  double LM875C = 0; // units R/s
+  double HP875 = 0; // units mm
+  double VP875 = 0; // units mm
+  double HPTG1 = 0; // units mm
+  double VPTG1 = 0; // units mm
+  double HPTG2 = 0; // units mm
+  double VPTG2 = 0; // units mm
+  double BTJT2 = 0; // units Deg C
+  double THCURR = 0; // units kiloAmps
+  
+  double TOR860_time = 0; // units s
+    
+  // Here we request all the devices
+  // since sometimes devices fail to report we'll
+  // allow each to throw an exception but still move forward
+  // interpreting these failures will be part of the beam quality analyses 
+ 
+  try{bfp->GetNamedData(time, "E:TOR860@",&TOR860,&TOR860_time);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:TOR875",&TOR875);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:LM875A",&LM875A);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:LM875B",&LM875B);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:LM875C",&LM875C);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:HP875",&HP875);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:VP875",&VP875);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:HPTG1",&HPTG1);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:VPTG1",&VPTG1);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:HPTG2",&HPTG2);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:VPTG2",&VPTG2);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:BTJT2",&BTJT2);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+  try{bfp->GetNamedData(time, "E:THCURR",&THCURR);}catch (WebAPIException &we) {mf::LogDebug("SBNDBNBRetriever")<< "At time : " << time << " " << "got exception: " << we.what() << "\n";}
+
+  //crunch the times 
+  unsigned long int time_closest_int = (int) TOR860_time;
+  double time_closest_ns = (TOR860_time - time_closest_int)*1e9;
+ 
+  //Store everything in our data-product
+  sbn::BNBSpillInfo beamInfo;
+  beamInfo.TOR860 = TOR860*1e12; //add in factor of 1e12 protons to get correct POT units
+  beamInfo.TOR875 = TOR875*1e12; //add in factor of 1e12 protons to get correct POT units
+  beamInfo.LM875A = LM875A;
+  beamInfo.LM875B = LM875B;
+  beamInfo.LM875C = LM875C;
+  beamInfo.HP875 = HP875;
+  beamInfo.VP875 = VP875;
+  beamInfo.HPTG1 = HPTG1;
+  beamInfo.VPTG1 = VPTG1;
+  beamInfo.HPTG2 = HPTG2;
+  beamInfo.VPTG2 = VPTG2;
+  beamInfo.BTJT2 = BTJT2;
+  beamInfo.THCURR = THCURR;
+  beamInfo.spill_time_s = time_closest_int;
+  beamInfo.spill_time_ns = time_closest_ns;    
+
+  for(auto const& MWRdata: unpacked_MWR){
+    std::ignore = MWRdata;
+    assert(!MWRdata.empty());
+  }
+
+  if(unpacked_MWR[0].empty()){
+    beamInfo.M875BB.clear();
+    beamInfo.M875BB_spill_time_diff = -999;//units in seconds
+  }
+  else{
+    beamInfo.M875BB = unpacked_MWR[0][matched_MWR[0]];
+    beamInfo.M875BB_spill_time_diff = (MWR_times[0][matched_MWR[0]] - time);
+  }
+
+ if(unpacked_MWR[1].empty()){
+    beamInfo.M876BB.clear();
+    beamInfo.M876BB_spill_time_diff = -999;//units in seconds
+ }
+ else{
+   beamInfo.M876BB = unpacked_MWR[1][matched_MWR[1]];
+   beamInfo.M876BB_spill_time_diff = (MWR_times[1][matched_MWR[1]] - time);
+ }
+
+ if(unpacked_MWR[2].empty()){
+    beamInfo.MMBTBB.clear();
+    beamInfo.MMBTBB_spill_time_diff = -999;//units in seconds
+  }
+ else{
+   beamInfo.MMBTBB = unpacked_MWR[2][matched_MWR[2]];
+   beamInfo.MMBTBB_spill_time_diff = (MWR_times[2][matched_MWR[2]] - time);
+ }
+  // We do not write these to the art::Events because 
+  // we can filter events but want to keep all the POT 
+  // information, so we'll write it to the SubRun
+  
+  beamInfo.event = eventID.event(); // the rest of ID is known by art::SubRun
+  
+  return beamInfo;
+}
+
+void sbn::SBNDBNBRetriever::beginSubRun(art::SubRun& sr)
+{
+  return;
+}
+
+void sbn::SBNDBNBRetriever::endSubRun(art::SubRun& sr)
+{
+  return;
+}
+
+DEFINE_ART_MODULE(sbn::SBNDBNBRetriever)

--- a/sbncode/BeamSpillInfoRetriever/job/run_sbndbnbextinfo_sbn.fcl
+++ b/sbncode/BeamSpillInfoRetriever/job/run_sbndbnbextinfo_sbn.fcl
@@ -1,0 +1,46 @@
+#include "sbndbnbextspillinfo.fcl"
+
+process_name: SBNDBNBEXTInfoGen
+
+services:{
+  
+  message: {
+      debugModules: [ "*" ]
+       destinations: {
+           LogDebugFile:{
+               type:       "file"
+               filename:   "debug.log"
+               append:     false
+               threshold:  "DEBUG"
+               categories: {
+                   default: {}
+               }
+           }
+       }
+  }
+  IFBeam:{}
+}
+
+
+source: {
+}
+
+physics: {
+ producers: {
+   sbndbnbextinfo: @local::sbndbnbextspillinfo
+ }
+
+ simulate: [sbndbnbextinfo ]
+ stream1: [ out1 ]
+}
+
+outputs: {
+ out1: {
+   module_type: RootOutput
+   fileName: "%ifb_%tc_sbndbnbextinfo.root"
+   dataTier: "raw"
+   compressionLevel: 1
+ }
+}
+
+physics.producers.sbndbnbextinfo.fileNames: @local::outputs.out1.fileName

--- a/sbncode/BeamSpillInfoRetriever/job/run_sbndbnbinfo_sbn.fcl
+++ b/sbncode/BeamSpillInfoRetriever/job/run_sbndbnbinfo_sbn.fcl
@@ -1,0 +1,47 @@
+#include "sbndbnbspillinfo.fcl"
+
+process_name: SBNDBNBInfoGen
+
+services:{
+  
+  message: {
+      debugModules: [ "*" ]
+       destinations: {
+           LogDebugFile:{
+               type:       "file"
+               filename:   "debug.log"
+               append:     false
+               threshold:  "DEBUG"
+               categories: {
+                   default: {}
+               }
+           }
+       }
+  }
+  IFBeam:{}
+}
+
+
+source: {
+
+}
+
+physics: {
+ producers: {
+   sbndbnbinfo: @local::sbndbnbspillinfo
+ }
+
+ simulate: [sbndbnbinfo ]
+ stream1: [ out1 ]
+}
+
+outputs: {
+ out1: {
+   module_type: RootOutput
+   fileName: "%ifb_%tc_sbndbnbinfo.root"
+   dataTier: "raw"
+   compressionLevel: 1
+ }
+}
+
+physics.producers.sbndbnbinfo.fileNames: @local::outputs.out1.fileName

--- a/sbncode/BeamSpillInfoRetriever/job/run_sbndbnbzerobiasinfo_sbn.fcl
+++ b/sbncode/BeamSpillInfoRetriever/job/run_sbndbnbzerobiasinfo_sbn.fcl
@@ -1,0 +1,46 @@
+#include "sbndbnbzerobiasspillinfo.fcl"
+
+process_name: SBNDBNBZEROBIASInfoGen
+
+services:{
+  
+  message: {
+      debugModules: [ "*" ]
+       destinations: {
+           LogDebugFile:{
+               type:       "file"
+               filename:   "debug.log"
+               append:     false
+               threshold:  "DEBUG"
+               categories: {
+                   default: {}
+               }
+           }
+       }
+  }
+  IFBeam:{}
+}
+
+
+source: {
+}
+
+physics: {
+ producers: {
+   sbndbnbzerobiasinfo: @local::sbndbnbzerobiasspillinfo
+ }
+
+ simulate: [sbndbnbzerobiasinfo ]
+ stream1: [ out1 ]
+}
+
+outputs: {
+ out1: {
+   module_type: RootOutput
+   fileName: "%ifb_%tc_sbndbnbzerobiasinfo.root"
+   dataTier: "raw"
+   compressionLevel: 1
+ }
+}
+
+physics.producers.sbndbnbzerobiasinfo.fileNames: @local::outputs.out1.fileName

--- a/sbncode/BeamSpillInfoRetriever/job/sbndbnbextspillinfo.fcl
+++ b/sbncode/BeamSpillInfoRetriever/job/sbndbnbextspillinfo.fcl
@@ -1,0 +1,21 @@
+BEGIN_PROLOG
+
+sbndbnbextspillinfo: {
+    module_type: SBNDBNBEXTRetriever
+    InputLabel: "bnbext"
+    InputContainerInstance: "ContainerBNB"
+    InputNonContainerInstance: "BNB"
+    OutputInstance: ""
+    DebugLevel: 0
+    TimePadding: 0.0333 #unit seconds, Booster Rep Rate is 15 Hz, so the closest spill could be 66ms away
+    URL: "https://dbdata3vm.fnal.gov:9443/ifbeam" 
+    Bundle: "BoosterNeutrinoBeam_read"
+    MultiWireBundle: "BNBMultiWire"
+    TimeWindow: "700" #seconds
+    MWR_TimeWindow: "3601" #seconds
+    raw_data_label: "daq"
+    DeviceUsedForTiming: "E:TOR860"
+}
+
+END_PROLOG
+

--- a/sbncode/BeamSpillInfoRetriever/job/sbndbnbspillinfo.fcl
+++ b/sbncode/BeamSpillInfoRetriever/job/sbndbnbspillinfo.fcl
@@ -1,0 +1,21 @@
+BEGIN_PROLOG
+
+sbndbnbspillinfo: {
+    module_type: SBNDBNBRetriever
+    InputLabel: "bnb"
+    InputContainerInstance: "ContainerBNB"
+    InputNonContainerInstance: "BNB"
+    OutputInstance: ""
+    DebugLevel: 0
+    TimePadding: 0.0333 #unit seconds, Booster Rep Rate is 15 Hz, so the closest spill could be 66ms away
+    URL: "" #Default URL having issues Nov 21 2024, used this instead https://dbdata3vm.fnal.gov:9443/ifbeam
+    Bundle: "BoosterNeutrinoBeam_read"
+    MultiWireBundle: "BNBMultiWire"
+    TimeWindow: "700" #seconds
+    MWR_TimeWindow: "3601" #seconds
+    raw_data_label: "daq"
+    DeviceUsedForTiming: "E:TOR860"
+}
+
+END_PROLOG
+

--- a/sbncode/BeamSpillInfoRetriever/job/sbndbnbzerobiasspillinfo.fcl
+++ b/sbncode/BeamSpillInfoRetriever/job/sbndbnbzerobiasspillinfo.fcl
@@ -1,0 +1,21 @@
+BEGIN_PROLOG
+
+sbndbnbzerobiasspillinfo: {
+    module_type: SBNDBNBZEROBIASRetriever
+    InputLabel: "bnbzerobias"
+    InputContainerInstance: "ContainerBNB"
+    InputNonContainerInstance: "BNB"
+    OutputInstance: ""
+    DebugLevel: 0
+    TimePadding: 0.0333 #unit seconds, Booster Rep Rate is 15 Hz, so the closest spill could be 66ms away
+    URL: "" 
+    Bundle: "BoosterNeutrinoBeam_read"
+    MultiWireBundle: "BNBMultiWire"
+    TimeWindow: "700" #seconds
+    MWR_TimeWindow: "3601" #seconds
+    raw_data_label: "daq"
+    DeviceUsedForTiming: "E:TOR860"
+}
+
+END_PROLOG
+


### PR DESCRIPTION
Splitting the PR for POT Accounting into two components. An additional PR will follow this which fixes a bug in  the ICARUS POT accounting and reorganizes the directory a bit.

Requires updated PTB information from [sbndaq_artdaq_core/v01_10_03](https://github.com/SBNSoftware/sbndaq-artdaq-core/tree/release/v1_10_03) as well as [sbndaq_artdaq/v01_10_03](https://github.com/SBNSoftware/sbndaq-artdaq/tree/release/v1_10_03).

This PR introduces three producer modules, summarized in presentation at [SBND Dec 2024 Collab Meeting](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=39161).

Remaining issues were determined to be beam related. Behavior is stable with new BNBZeroBias stream.
