### PR TITLE
Prevent over-extension of vector length

### DIFF
--- a/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.cxx
+++ b/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.cxx
@@ -33,7 +33,7 @@ recob::MCSFitResult TrajectoryMCSFitter::fitMcs(const recob::TrackTrajectory& tr
       if (segradlengths[p]<-100. || segradlengths[p-1]<-100.) {
         dtheta.push_back(-999.);
       } 
-      if (!breakpointsgood[p] || !breakpointsgood[p-1]) {
+      else if (!breakpointsgood[p] || !breakpointsgood[p-1]) {
         dtheta.push_back(-999.);
       }
       else { 


### PR DESCRIPTION
### Description 
@RachelCoackley discovered this problem using the SBND CI. We were seeing non-reproducibility in the CAFs. @jzennamo traced this down to this tool using valgrind to find an invalid read. I have then investigated why it was happening.

Description copied from slack:
- The if statements here on [lines 33 & 36](https://github.com/SBNSoftware/sbncode/blob/develop/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.cxx#L33-L36) are not mutually exclusive and yet they both add a default value to the vector `dtheta`. 
- If both evaluate to true then the vector grows by 2 entries during this iteration of the loop. This makes it longer than other vectors such as `cumLenFwd` and `cumLenBwd` which are meant to be of the same length.
- It is the `dtheta` vector's size (after passing to other functions) that determines the domain of the loop on [line 224](https://github.com/SBNSoftware/sbncode/blob/develop/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.cxx#L224) (by setting `beg` & `end` at [lines 211 & 212](https://github.com/SBNSoftware/sbncode/blob/develop/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.cxx#L211-L212).
- This allows invalid reads of cumLen on lines [232](https://github.com/SBNSoftware/sbncode/blob/develop/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.cxx#L232) or [236](https://github.com/SBNSoftware/sbncode/blob/develop/sbncode/LArRecoProducer/LArReco/TrajectoryMCSFitter.cxx#L236).
- The simplest fix is very simple, just an `else if` not an `if` and I'm not willing to do anything more than the most simple!
- I've run my little bash script that does 20 iterations of the command run by the CI and they all come back the same - whereas before at least 5 or 6 were showing the random differences.

For the sake of the SBND CI there is a branch based on `v09_93_01_p02` [bugfix/hlay_mcs_invalid_read](https://github.com/SBNSoftware/sbncode/tree/bugfix/hlay_mcs_invalid_read) but this PR branch is rebased against `develop`.

I've added review requests from @gputnam and @wjdanswjddl as I see you have previous commits on this tool so may want to see this. The okay from Rachel or Joseph should be fine from the bugfix side of things though.

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [X] Is this PR related to an open issue / project?
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [X] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
