### PR TITLE
Add RadioactiveDecayBase to CAFMaker

### DIFF
--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -1363,6 +1363,7 @@ caf::g4_process_ caf::GetG4ProcessID(const std::string &process_name) {
   MATCH_PROCESS(Transportation)
   MATCH_PROCESS(msc)
   MATCH_PROCESS(StepLimiter)
+  MATCH_PROCESS(RadioactiveDecayBase)
   std::cerr << "Error: Process name with no match (" << process_name << ")\n";
   assert(false);
   return caf::kG4UNKNOWN; // unreachable in debug mode


### PR DESCRIPTION
Depends on https://github.com/SBNSoftware/sbnanaobj/pull/135.