### PR TITLE
Add hit goodness to sbn::HitInfo

### DIFF
--- a/sbncode/Calibration/TrackCaloSkimmer_module.cc
+++ b/sbncode/Calibration/TrackCaloSkimmer_module.cc
@@ -953,6 +953,7 @@ void sbn::TrackCaloSkimmer::FillTrackEndHits(const geo::GeometryCore *geometry,
       hinfo.integral = hit->Integral();
       hinfo.sumadc = hit->ROISummedADC();
       hinfo.width = hit->RMS();
+      hinfo.goodness = hit->GoodnessOfFit();
       hinfo.time = hit->PeakTime();
       hinfo.mult = hit->Multiplicity();
       hinfo.wire = hit->WireID().Wire;
@@ -1282,6 +1283,7 @@ sbn::TrackHitInfo sbn::TrackCaloSkimmer::MakeHit(const recob::Hit &hit,
   hinfo.h.integral = hit.Integral();
   hinfo.h.sumadc = hit.ROISummedADC();
   hinfo.h.width = hit.RMS();
+  hinfo.h.goodness = hit.GoodnessOfFit();
   hinfo.h.time = hit.PeakTime();
   hinfo.h.mult = hit.Multiplicity();
   hinfo.h.wire = hit.WireID().Wire;


### PR DESCRIPTION
### Description 
It is sometimes useful to exclude hits with poor fits when doing analysis with the calibration ntuples. This PR fills a new field in the `sbn::HitInfo` object with `recob::Hit::GoodnessOfFit` score so that it is available in the calibration ntuples.

Required sbnobj PR: https://github.com/SBNSoftware/sbnobj/pull/122


- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [ ] Is this PR related to an open issue / project?
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [ ] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
