### PR TITLE
Updates to Enable ICARUS Spring Production

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -46,7 +46,7 @@ namespace caf
     };
     
     Atom<bool> OverrideRealData { Name("OverrideRealData"),
-	      Comment("Whether to ignore things aimed at real data -- e.g. if instead the event in an overlay"), false
+	      Comment("when true, some algorithms (e.g. PoT count) treat events as MC rather than real data -- e.g. set it if the event is an overlay"), false
     };
 
     Atom<float> PrescaleFactor { Name("PrescaleFactor"),

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1469,7 +1469,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 
 	  int iparticle=0;
 	  genie::GHepParticle * p = 0;
-	  while( genie_rec->Particle(iparticle) != 0 ) {
+	  while( (genie_rec->Particle(iparticle) != 0) && (iparticle < 250) ) {
 	    p = genie_rec->Particle(iparticle);
 	    fGenieEvtRec_brStdHepPdg[iparticle] = p->Pdg();
 	    fGenieEvtRec_brStdHepStatus[iparticle] = (int) p->Status(); 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1274,7 +1274,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   bool const firstInFile = (fIndexInFile++ == 0);
 
   // is this event real data? -- BH: if fOverrideRealData, treat it as MC. Otherwise, get the info from the art event.
-  bool isRealData = ( fOverrideRealData ? false : evt.isRealData() );
+  bool isRealData = !fOverrideRealData && evt.isRealData();
 
   std::unique_ptr<std::vector<caf::StandardRecord>> srcol(
       new std::vector<caf::StandardRecord>);

--- a/sbncode/Calibration/TrackCaloSkimmer_module.cc
+++ b/sbncode/Calibration/TrackCaloSkimmer_module.cc
@@ -234,7 +234,7 @@ void sbn::TrackCaloSkimmer::analyze(art::Event const& e)
 
   // Hits (ICARUS style)
   art::FindManyP<anab::T0> fmT0CRTHit(tracks, e, fCRTHitT0producer);
-  art::FindManyP<sbn::crt::CRTHitT0TaggingInfo> fmCRTHitT0TaggingInfo(PFParticleList, e, fCRTHitT0producer);
+  art::FindManyP<sbn::crt::CRTHitT0TaggingInfo> fmCRTHitT0TaggingInfo(tracks, e, fCRTHitT0producer);
 
   // Track - associated data
   art::FindManyP<recob::Track> fmTracks(PFParticleList, e, fTRKproducer);

--- a/sbncode/DetSim/fcl/icarus_simedepfilter.fcl
+++ b/sbncode/DetSim/fcl/icarus_simedepfilter.fcl
@@ -3,6 +3,7 @@ BEGIN_PROLOG
 simedepfilter_ind1gap: {
   module_type: "FilterSimEnergyDeposits"
   InitSimEnergyDepositLabel: "ionization"
+  InitSimEnergyDepositLiteLabel: "sedlite"
   P1_X: -400 #cm, create a box that spans the full x,y range. Not super-precise.
   P1_Y: -200 #cm, create a box that spans the full x,y range. Not super-precise.
   P1_Z: -2 #cm, one edge of the filtered gap based on the 37 mm total size of the wire gap

--- a/sbncode/LArG4/MergeSimSourcesSBN_module.cc
+++ b/sbncode/LArG4/MergeSimSourcesSBN_module.cc
@@ -119,6 +119,12 @@ public:
       false // default
     };
 
+    fhicl::Atom<bool> SkipTrackIDOffsets {
+      fhicl::Name{"SkipTrackIDOffsets"},
+      fhicl::Comment{"whether to skip track ID offsets in merge"},
+      false // default
+    };
+
     fhicl::Sequence<std::string> AuxDetHitsInstanceLabels{
       fhicl::Name{"AuxDetHitsInstanceLabels"},
       fhicl::Comment{"labels of AuxDetHits collections to merge"},
@@ -158,6 +164,7 @@ private:
   bool const fFillSimChannels;
   bool const fFillAuxDetSimChannels;
   bool const fFillSimEnergyDeposits;
+  bool const fSkipTrackIDOffsets;
   std::vector<std::string> const fEnergyDepositionInstances;
   bool const fFillAuxDetHits;
   std::vector<std::string> const fAuxDetHitsInstanceLabels;
@@ -202,6 +209,7 @@ sbn::MergeSimSourcesSBN::MergeSimSourcesSBN(Parameters const& params)
   , fFillSimEnergyDeposits(
       getOptionalValue(params().FillSimEnergyDeposits)
         .value_or(art::ServiceHandle<sim::LArG4Parameters const>()->FillSimEnergyDeposits()))
+  , fSkipTrackIDOffsets(params().SkipTrackIDOffsets())
   , fEnergyDepositionInstances(params().EnergyDepositInstanceLabels())
   , fFillAuxDetHits(params().FillAuxDetHits())
   , fAuxDetHitsInstanceLabels(params().AuxDetHitsInstanceLabels())
@@ -349,7 +357,7 @@ void sbn::MergeSimSourcesSBN::produce(art::Event& e)
 
     if (fFillSimChannels) {
       auto const& input_scCol = e.getProduct<std::vector<sim::SimChannel>>(input_label);
-      MergeUtility.MergeSimChannels(*scCol, input_scCol, i_source);
+      MergeUtility.MergeSimChannels(*scCol, input_scCol, i_source, fSkipTrackIDOffsets);
     }
 
     if (fFillAuxDetSimChannels) {


### PR DESCRIPTION
This PR makes updates to sbncode necessary to enable the Spring production in ICARUS. It depends on:
https://github.com/SBNSoftware/sbnobj/pull/124
https://github.com/LArSoft/larsim/pull/151
https://github.com/WireCell/wire-cell-toolkit/pull/400 (will need a new cut of WireCell+LArSoft with this in)
https://github.com/SBNSoftware/sbnobj/pull/129

It incorporates (https://github.com/SBNSoftware/sbncode/pull/525), and can be merged in after that one.

In addition to updating the calbiration NTupler, it includes updates to CAFMaker to support overlays (from @icaromx) and updates to the new MergeSimSources module interface in LArSim (from @jzennamo).

It incorporates https://github.com/SBNSoftware/sbncode/pull/535, and can be merged either instead of or after that PR.