### PR TITLE
Use Ts0 not Ts1

### DIFF
--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -122,8 +122,8 @@ namespace caf
     srspacepoint.position     = SRVector3D(spacepoint.X(), spacepoint.Y(), spacepoint.Z());
     srspacepoint.position_err = SRVector3D(spacepoint.XErr(), spacepoint.YErr(), spacepoint.ZErr());
     srspacepoint.pe           = spacepoint.PE();
-    srspacepoint.time         = spacepoint.Ts1();
-    srspacepoint.time_err     = spacepoint.Ts1Err();
+    srspacepoint.time         = spacepoint.Ts0();
+    srspacepoint.time_err     = spacepoint.Ts0Err();
     srspacepoint.complete     = spacepoint.Complete();
   }
 
@@ -134,8 +134,8 @@ namespace caf
     for(auto const& point : track.Points())
       srsbndcrttrack.points.emplace_back(point.X(), point.Y(), point.Z());
 
-    srsbndcrttrack.time     = track.Ts1();
-    srsbndcrttrack.time_err = track.Ts1Err();
+    srsbndcrttrack.time     = track.Ts0();
+    srsbndcrttrack.time_err = track.Ts0Err();
     srsbndcrttrack.pe       = track.PE();
     srsbndcrttrack.tof      = track.ToF();
   }


### PR DESCRIPTION
### Description 
No one in the CRT team has been using CAFs for data work so this hadn't been picked up yet. We should swap the CAFs to use the Ts0 timestamp in both MC & Data. This is because it is the field we reference to the event trigger and has the closest meaning between MC & Data (see especially SBNSoftware/sbndcode#672). This is a last minute patch that should be included in the upcoming production. Apologies for the late notice.

Note, SBND & ICARUS use separate objects & filling of the StandardRecord for our CRT information - this ONLY impacts SBND.

A more detailed study of the CRT in the CAFs would be worthwhile in time for the next production.

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [X] Is this PR related to an open issue / project?
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [ ] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [ ] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
