### PR TITLE
Update explicit references to 'EventWeightParameterSet::kMultisim'

### DIFF
--- a/sbncode/SBNEventWeight/Calculators/BNBFlux/FluxCalcPrep.cxx
+++ b/sbncode/SBNEventWeight/Calculators/BNBFlux/FluxCalcPrep.cxx
@@ -261,7 +261,7 @@ namespace sbn {
 
         //Let's make a weights based on the calculator you have requested 
 
-        if(fParameterSet.fRWType == EventWeightParameterSet::kMultisim){
+        if(fParameterSet.fRWType == EventWeightParameterSet::kMultiSim){
 
           for (size_t i=0;i<weights.size();i++) {
             double randomN = (fParameterSet.fParameterMap.begin())->second[i];
@@ -293,7 +293,7 @@ namespace sbn {
           return weights;//done, all 1
         }// Hadronic parent check
 
-        if(fParameterSet.fRWType == EventWeightParameterSet::kMultisim){
+        if(fParameterSet.fRWType == EventWeightParameterSet::kMultiSim){
 
           for (unsigned int i = 0; int(weights.size()) < NUni; i++) {//if all weights are 1, no need to calculate weights;
             std::pair<bool, double> test_weight;
@@ -338,7 +338,7 @@ namespace sbn {
             };
 
           }//Iterate through the number of universes      
-        }//Yes, Multisim
+        }//Yes, MultiSim
       }
 
       if(count_weights){


### PR DESCRIPTION
### Description

This is a companion PR to [sbnobj/#128](https://github.com/SBNSoftware/sbnobj/pull/128), which is itself a companion PR to [sbnanaobj/#110](https://github.com/SBNSoftware/sbnanaobj/pull/110) opened by @jedori0228 . 
This depends on [sbnobj/#128](https://github.com/SBNSoftware/sbnobj/pull/128), and should be merged in at the same time as the above two PRs.

The reason why these companion PRs are opened is because of a stipulated need to synchronise `sbnanaobj/StandardRecord/SREnums.h::enum ReweightType_t` with the member `fRWType` of class `EventWeightParameterSet` (see `sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h`), which duplicates that enum. 

This PR follows through on the synchronisation between `sbnanaobj -> ReweightType_t` --> `sbnobj -> fRWType`, as there were differences in capitalisation that had been introduced into sbnanaobj but not sbnobj.

Calling @jedori0228 (who authored the original sbnanaobj PR) and @PetrilloAtWork (who reviewed it) for review.

- [o] Have you added a label? (bug/enhancement/physics etc.)
- [o] Have you assigned at least 1 reviewer?
- [o] Is this PR related to an open issue / project?
- [x] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [o] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [x] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
