### PR TITLE
Feature/cerati ng2caf

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -340,6 +340,24 @@ namespace caf
       "" //Empty by default, configured in icaruscode cafmaker_defs
     };
 
+    Atom<art::InputTag> NuGraphSliceHitLabel {
+      Name("NuGraphSliceHitLabel"),
+      Comment("Label of NuGraph slice hit map."),
+	art::InputTag("nuslhits")
+    };
+
+    Atom<art::InputTag> NuGraphFilterLabel {
+      Name("NuGraphFilterLabel"),
+      Comment("Label of NuGraph filter."),
+	art::InputTag("NuGraph","filter")
+    };
+
+    Atom<art::InputTag> NuGraphSemanticLabel {
+      Name("NuGraphSemanticLabel"),
+      Comment("Label of NuGraph semantic."),
+	art::InputTag("NuGraph","semantic")
+    };
+
     Atom<string> OpFlashLabel {
       Name("OpFlashLabel"),
       Comment("Label of PMT flash."),

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -343,19 +343,19 @@ namespace caf
     Atom<art::InputTag> NuGraphSliceHitLabel {
       Name("NuGraphSliceHitLabel"),
       Comment("Label of NuGraph slice hit map."),
-	art::InputTag("nuslhits")
+      "" //Empty by default, please set to e.g. art::InputTag("nuslhits")
     };
 
     Atom<art::InputTag> NuGraphFilterLabel {
       Name("NuGraphFilterLabel"),
       Comment("Label of NuGraph filter."),
-	art::InputTag("NuGraph","filter")
+      "" //Empty by default, please set to e.g. art::InputTag("NuGraph","filter")
     };
 
     Atom<art::InputTag> NuGraphSemanticLabel {
       Name("NuGraphSemanticLabel"),
       Comment("Label of NuGraph semantic."),
-	art::InputTag("NuGraph","semantic")
+      "" //Empty by default, please set to e.g. art::InputTag("NuGraph","semantic")
     };
 
     Atom<string> OpFlashLabel {

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1766,9 +1766,15 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 
     std::vector<art::Ptr<anab::FeatureVector<1>>> ng2_filter_vec;
     std::vector<art::Ptr<anab::FeatureVector<5>>> ng2_semantic_vec;
-    art::fill_ptr_vector(ng2_filter_vec,ng2_filter_handle[producer]);
-    art::fill_ptr_vector(ng2_semantic_vec,ng2_semantic_handle[producer]);
-    FillSliceNuGraph(slcHits,*ng2_slice_hit_map_handle[producer],ng2_filter_vec,ng2_semantic_vec,recslc);
+    if (ng2_filter_handle[producer].isValid()) {
+      art::fill_ptr_vector(ng2_filter_vec,ng2_filter_handle[producer]);
+    }
+    if (ng2_semantic_handle[producer].isValid()) {
+      art::fill_ptr_vector(ng2_semantic_vec,ng2_semantic_handle[producer]);
+    }
+    if (ng2_slice_hit_map_handle[producer].isValid()) {
+      FillSliceNuGraph(slcHits,*ng2_slice_hit_map_handle[producer],ng2_filter_vec,ng2_semantic_vec,recslc);
+    }
 
     art::FindManyP<sbn::OpT0Finder> fmOpT0 =
       FindManyPStrict<sbn::OpT0Finder>(sliceList, evt, fParams.OpT0Label() + slice_tag_suff);
@@ -2142,7 +2148,9 @@ void CAFMaker::produce(art::Event& evt) noexcept {
         FillCNNScores(thisParticle, cnnScores, pfp);
       }
 
-      FillPPFNuGraph(*ng2_slice_hit_map_handle[producer], ng2_filter_vec, ng2_semantic_vec, fmPFPartHits.at(iPart), pfp);
+      if (ng2_slice_hit_map_handle[producer].isValid()) {
+	FillPPFNuGraph(*ng2_slice_hit_map_handle[producer], ng2_filter_vec, ng2_semantic_vec, fmPFPartHits.at(iPart), pfp);
+      }
 
       if (!thisTrack.empty())  { // it has a track!
         assert(thisTrack.size() == 1);

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -96,6 +96,7 @@
 #include "lardataobj/RecoBase/Shower.h"
 #include "lardataobj/RecoBase/MCSFitResult.h"
 #include "lardataobj/RecoBase/Cluster.h"
+#include "lardataobj/AnalysisBase/MVAOutput.h"
 
 #include "nusimdata/SimulationBase/MCFlux.h"
 #include "nusimdata/SimulationBase/MCTruth.h"

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -2150,7 +2150,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       }
 
       if (ng2_slice_hit_map_handle[producer].isValid()) {
-	FillPPFNuGraph(*ng2_slice_hit_map_handle[producer], ng2_filter_vec, ng2_semantic_vec, fmPFPartHits.at(iPart), pfp);
+	FillPFPNuGraph(*ng2_slice_hit_map_handle[producer], ng2_filter_vec, ng2_semantic_vec, fmPFPartHits.at(iPart), pfp);
       }
 
       if (!thisTrack.empty())  { // it has a track!

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -553,7 +553,7 @@ namespace caf
   {
 
     //need to double check that the slice processed by NuGraph is the same under consideration
-    std::cout << "sizes=" << inputHits.size() << " " << sliceHitsMap.size() << " " << ngFilterResult.size() << " " << ngSemanticResult.size() << std::endl;
+    //std::cout << "sizes=" << inputHits.size() << " " << sliceHitsMap.size() << " " << ngFilterResult.size() << " " << ngSemanticResult.size() << std::endl;
     unsigned int nHits = inputHits.size();
     if (nHits==0 || nHits!=sliceHitsMap.size() || inputHits[0].key()!=sliceHitsMap[0]) return;//not the same slice!
 

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -1058,11 +1058,12 @@ namespace caf
 	}
       }
       srpfp.ngscore.sem_cat = SRNuGraphScore::NuGraphCategory(std::distance(ng2sempfpcounts.begin(), std::max_element(ng2sempfpcounts.begin(), ng2sempfpcounts.end())));//arg_max(ng2sempfpcounts);
-      srpfp.ngscore.mip_frac = (pfpHits.size()>ng2bkgpfpcount ? float(ng2sempfpcounts[0])/(pfpHits.size()-ng2bkgpfpcount) : -1.);
-      srpfp.ngscore.hip_frac = (pfpHits.size()>ng2bkgpfpcount ? float(ng2sempfpcounts[1])/(pfpHits.size()-ng2bkgpfpcount) : -1.);
-      srpfp.ngscore.shr_frac = (pfpHits.size()>ng2bkgpfpcount ? float(ng2sempfpcounts[2])/(pfpHits.size()-ng2bkgpfpcount) : -1.);
-      srpfp.ngscore.mhl_frac = (pfpHits.size()>ng2bkgpfpcount ? float(ng2sempfpcounts[3])/(pfpHits.size()-ng2bkgpfpcount) : -1.);
-      srpfp.ngscore.dif_frac = (pfpHits.size()>ng2bkgpfpcount ? float(ng2sempfpcounts[4])/(pfpHits.size()-ng2bkgpfpcount) : -1.);
+      size_t nonBkgHits = (pfpHits.size() > ng2bkgpfpcount ? pfpHits.size()-ng2bkgpfpcount : 0);
+      srpfp.ngscore.mip_frac = (nonBkgHits>0 ? float(ng2sempfpcounts[0])/nonBkgHits : -1.);
+      srpfp.ngscore.hip_frac = (nonBkgHits>0 ? float(ng2sempfpcounts[1])/nonBkgHits : -1.);
+      srpfp.ngscore.shr_frac = (nonBkgHits>0 ? float(ng2sempfpcounts[2])/nonBkgHits : -1.);
+      srpfp.ngscore.mhl_frac = (nonBkgHits>0 ? float(ng2sempfpcounts[3])/nonBkgHits : -1.);
+      srpfp.ngscore.dif_frac = (nonBkgHits>0 ? float(ng2sempfpcounts[4])/nonBkgHits : -1.);
       srpfp.ngscore.bkg_frac = float(ng2bkgpfpcount)/pfpHits.size();
     } else {
       srpfp.ngscore.sem_cat = SRNuGraphScore::NuGraphCategory::Unset;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -970,7 +970,7 @@ namespace caf
     srpfp.cnnscore.nclusters = cnnscore->nClusters;
   }
 
-  void FillPPFNuGraph(const std::vector<unsigned int> &sliceHitsMap,
+  void FillPFPNuGraph(const std::vector<unsigned int> &sliceHitsMap,
 		      const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
 		      const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
 		      const std::vector<art::Ptr<recob::Hit>> &pfpHits,

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -20,6 +20,7 @@
 #include "lardataobj/RecoBase/OpFlash.h"
 #include "lardataobj/RecoBase/OpHit.h"
 #include "lardataobj/AnalysisBase/Calorimetry.h"
+#include "lardataobj/AnalysisBase/MVAOutput.h"
 #include "lardataobj/AnalysisBase/ParticleID.h"
 #include "lardataobj/AnalysisBase/T0.h"
 #include "lardataobj/RecoBase/PFParticleMetadata.h"
@@ -104,6 +105,12 @@ namespace caf
                            const std::vector<art::Ptr<recob::SpacePoint>> &inputPoints,
                            caf::SRSlice &slice);
 
+  void FillSliceNuGraph(const std::vector<art::Ptr<recob::Hit>> &inputHits,
+			const std::vector<unsigned int> &sliceHitsMap,
+			const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
+			const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
+			caf::SRSlice &slice);
+
   bool SelectSlice(const caf::SRSlice &slice, bool cut_clear_cosmic);
 
   void FillTrackVars(const recob::Track& track,
@@ -129,6 +136,13 @@ namespace caf
                      const sbn::PFPCNNScore *cnnscore,
                      caf::SRPFP& srpfp,
                      bool allowEmpty = false);
+
+  void FillPPFNuGraph(const std::vector<unsigned int> &sliceHitsMap,
+		      const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
+		      const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
+		      const std::vector<art::Ptr<recob::Hit>> &pfpHits,
+		      caf::SRPFP& srpfp,
+		      bool allowEmpty= false);
 
   void FillTrackCRTHit(const std::vector<art::Ptr<anab::T0>> &t0match,
                        const std::vector<art::Ptr<sbn::crt::CRTHit>> &hitmatch,

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -105,6 +105,16 @@ namespace caf
                            const std::vector<art::Ptr<recob::SpacePoint>> &inputPoints,
                            caf::SRSlice &slice);
 
+  /**
+   * @brief Fills the results from NuGraph at slice level
+   * @param inputHits (pointers to) the hits associated to the slice
+   * @param sliceHitsMap maps position of hits in collection input to NuGraph (slice only) to the one input to Pandora (all gaus hits)
+   * @param ngFilterResult NuGraph filter result, for each hit
+   * @param ngSemanticResult NuGraph semnatic result, for each hit (MIP track, HIP, shower, Michel electron, diffuse activity)
+   * @param[out] slice the destination slice object
+   *
+   * Hits with filter value (`ngFilterResult`) lower than `ng_filter_cut` are counted as background.
+   */
   void FillSliceNuGraph(const std::vector<art::Ptr<recob::Hit>> &inputHits,
 			const std::vector<unsigned int> &sliceHitsMap,
 			const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
@@ -137,6 +147,16 @@ namespace caf
                      caf::SRPFP& srpfp,
                      bool allowEmpty = false);
 
+  /**
+   * @brief Fills the results from NuGraph at slice level
+   * @param sliceHitsMap maps position of hits in collection input to NuGraph (slice only) to the one input to Pandora (all gaus hits)
+   * @param ngFilterResult NuGraph filter result, for each hit
+   * @param ngSemanticResult NuGraph semnatic result, for each hit (MIP track, HIP, shower, Michel electron, diffuse activity)
+   * @param pfpHits Vector of hits associated to the PFParticle
+   * @param[out] srpfp the destination PFParticle object
+   *
+   * Hits with filter value (`ngFilterResult`) lower than `ng_filter_cut` are counted as background.
+   */
   void FillPFPNuGraph(const std::vector<unsigned int> &sliceHitsMap,
 		      const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
 		      const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -137,7 +137,7 @@ namespace caf
                      caf::SRPFP& srpfp,
                      bool allowEmpty = false);
 
-  void FillPPFNuGraph(const std::vector<unsigned int> &sliceHitsMap,
+  void FillPFPNuGraph(const std::vector<unsigned int> &sliceHitsMap,
 		      const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
 		      const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
 		      const std::vector<art::Ptr<recob::Hit>> &pfpHits,


### PR DESCRIPTION
### Description 
This PR adds a few NuGraph-related variables to CAFs, along the lines of what presented on [docdb 40585](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40585). Once icaruscode [PR815](https://github.com/SBNSoftware/icaruscode/pull/815) is merged the needed data products can be produced, but it won't break CAF making if they are not there. Requires `sbnanaobj` [PR137](https://github.com/SBNSoftware/sbnanaobj/pull/137).

