### PR TITLE
Modify `MergeSimChannels` signature with check to skip G4 tracks or not

### DIFF
--- a/sbncode/LArG4/MergeSimSourcesSBN_module.cc
+++ b/sbncode/LArG4/MergeSimSourcesSBN_module.cc
@@ -97,6 +97,12 @@ public:
       true // default
     };
 
+    fhicl::Atom<bool> SkipSimChannelTrackIDs{
+      fhicl::Name{"SkipSimChannelTrackIDs"},
+      fhicl::Comment{"Skip G4 track IDs in SimChannels"},
+      false // default
+    };
+
     fhicl::Atom<bool> FillAuxDetSimChannels{
       fhicl::Name{"FillAuxDetSimChannels"},
       fhicl::Comment{"whether to merge AuxDetSimChannels"},
@@ -156,6 +162,7 @@ private:
   bool const fFillMCParticlesAssociated;
   bool const fFillSimPhotons;
   bool const fFillSimChannels;
+  bool const fSkipSimChannelTrackIDs;
   bool const fFillAuxDetSimChannels;
   bool const fFillSimEnergyDeposits;
   std::vector<std::string> const fEnergyDepositionInstances;
@@ -198,6 +205,7 @@ sbn::MergeSimSourcesSBN::MergeSimSourcesSBN(Parameters const& params)
   , fFillMCParticlesAssociated(params().FillMCParticlesAssociated())
   , fFillSimPhotons(params().FillSimPhotons())
   , fFillSimChannels(params().FillSimChannels())
+  , fSkipSimChannelTrackIDs(params().SkipSimChannelTrackIDs())
   , fFillAuxDetSimChannels(params().FillAuxDetSimChannels())
   , fFillSimEnergyDeposits(
       getOptionalValue(params().FillSimEnergyDeposits)
@@ -349,7 +357,7 @@ void sbn::MergeSimSourcesSBN::produce(art::Event& e)
 
     if (fFillSimChannels) {
       auto const& input_scCol = e.getProduct<std::vector<sim::SimChannel>>(input_label);
-      MergeUtility.MergeSimChannels(*scCol, input_scCol, i_source);
+      MergeUtility.MergeSimChannels(*scCol, input_scCol, i_source, !fSkipSimChannelTrackIDs);
     }
 
     if (fFillAuxDetSimChannels) {
@@ -451,6 +459,7 @@ void sbn::MergeSimSourcesSBN::dumpConfiguration() const
   if (fFillMCParticlesAssociated) log << "\n - filling MCParticlesAssociated";
 
   if (fFillSimChannels) log << "\n - filling SimChannels";
+  if (fSkipSimChannelTrackIDs) log << "\n - skipping track IDs in filling SimChannels";
 
   if (fFillAuxDetSimChannels) log << "\n - filling AuxDetSimChannels";
 

--- a/sbncode/LArG4/MergeSimSourcesSBN_module.cc
+++ b/sbncode/LArG4/MergeSimSourcesSBN_module.cc
@@ -357,7 +357,7 @@ void sbn::MergeSimSourcesSBN::produce(art::Event& e)
 
     if (fFillSimChannels) {
       auto const& input_scCol = e.getProduct<std::vector<sim::SimChannel>>(input_label);
-      MergeUtility.MergeSimChannels(*scCol, input_scCol, i_source, !fSkipSimChannelTrackIDs);
+      MergeUtility.MergeSimChannels(*scCol, input_scCol, i_source, fSkipSimChannelTrackIDs);
     }
 
     if (fFillAuxDetSimChannels) {

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -254,12 +254,12 @@ libdir	fq_dir		lib
 product			version		qual	flags		<table_format=2>
 genie_xsec		v3_04_00	-
 larcv2			v2_2_6		-
-larsoft			v10_04_08	-
+larsoft			v10_05_00	-
 sbnalg		        v10_04_08	-
 sbndaq_artdaq_core	v1_10_06	-
 sbndata			v01_07		-
 systematicstools	v01_04_04	-
-nusystematics		v1_05_06	-
+nusystematics		v1_05_07	-
 cetmodules		v3_24_01	-	only_for_build
 end_product_list
 ####################################


### PR DESCRIPTION
### Description 
This is a required PR following larsim v10_03_00, in larsoft v10_05_00 and later. 
[larsim/#151](https://github.com/LArSoft/larsim/pull/151) introduced a required bool to skip G4 tracks when merging SimChannel objects or not. This PR adds this object + the concomitant "SkipSimChannelTrackIDs" fcl switch (default false).

Calling on @gputnam to review this change.

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [X] Is this PR related to an open issue / project?
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [ ] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [ ] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
