### PR TITLE
Save OpFlash information in CAF files in SBND. 

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1681,11 +1681,9 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   }
   else if(fDet == kSBND)
   {
-    std::cout << " Adding flash for SBND" << std::endl;
     std::vector<std::string> tpc_suffixes_sbnd = {"tpc0", "tpc1"};
 
     for (size_t tpc=0; tpc<tpc_suffixes_sbnd.size(); tpc++) {
-      std::cout << " Filling flash information for TPC " << tpc << std::endl;
       art::Handle<std::vector<recob::OpFlash>> flashes_handle;
       GetByLabelStrict(evt, fParams.OpFlashLabel() + tpc_suffixes_sbnd[tpc], flashes_handle);
       // fill into event

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -179,7 +179,7 @@ namespace caf
   }
 
 
-  void FillOpFlash(const recob::OpFlash &flash,
+  void FillICARUSOpFlash(const recob::OpFlash &flash,
                   std::vector<recob::OpHit const*> const& hits,
                   int cryo, 
                   caf::SROpFlash &srflash,
@@ -224,6 +224,41 @@ namespace caf
     if ( flash.hasXCenter() ) {
       srflash.center.SetX( flash.XCenter() );
       srflash.width.SetX( flash.XWidth() );
+    }
+  }
+
+  void FillSBNDOpFlash(const recob::OpFlash &flash,
+    std::vector<recob::OpHit const*> const& hits,
+    int tpc, 
+    caf::SROpFlash &srflash,
+    bool allowEmpty) {
+
+    srflash.setDefault();
+
+    srflash.time = flash.Time();
+    srflash.timewidth = flash.TimeWidth();
+
+    double firstTime = std::numeric_limits<double>::max();
+    for(const auto& hit: hits){
+    double const hitTime = hit->HasStartTime()? hit->StartTime(): hit->PeakTime();
+    if (firstTime > hitTime)
+    firstTime = hitTime;
+    }
+    srflash.firsttime = firstTime;
+    srflash.tpc = tpc;
+
+    srflash.totalpe = flash.TotalPE();
+    srflash.fasttototal = flash.FastToTotal();
+    srflash.onbeamtime = flash.OnBeamTime();
+
+    srflash.center.SetXYZ( -9999.f, flash.YCenter(), flash.ZCenter() );
+    srflash.width.SetXYZ( -9999.f, flash.YWidth(), flash.ZWidth() );
+
+    // Checks if ( recob::OpFlash.XCenter() != std::numeric_limits<double>::max() )
+    // See LArSoft OpFlash.h at https://nusoft.fnal.gov/larsoft/doxsvn/html/OpFlash_8h_source.html
+    if ( flash.hasXCenter() ) {
+    srflash.center.SetX( flash.XCenter() );
+    srflash.width.SetX( flash.XWidth() );
     }
   }
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -217,11 +217,18 @@ namespace caf
                         caf::SRSBNDCRTTrack &srsbndcrttrack,
                         bool allowEmpty = false);
 
-  void FillOpFlash(const recob::OpFlash &flash,
+  void FillICARUSOpFlash(const recob::OpFlash &flash,
                   std::vector<recob::OpHit const*> const& hits,
                   int cryo,
                   caf::SROpFlash &srflash,
                   bool allowEmpty = false);
+
+  void FillSBNDOpFlash(const recob::OpFlash &flash,
+                  std::vector<recob::OpHit const*> const& hits,
+                  int tpc,
+                  caf::SROpFlash &srflash,
+                  bool allowEmpty = false);
+                  
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
 		       caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty = false);


### PR DESCRIPTION
### Description 
OpFlash information is currently not being saved in CAF files in SBND. This PR splits the `FillOpFlash` function into two detector-specific functions so the OpFlash information can be filled also for SBND. 

Eventually, both functions could be modified to converge into a common function that does the job.

This PR depends on https://github.com/SBNSoftware/sbnanaobj/pull/138 

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [X] Is this PR related to an open issue / project?
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [X] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
