### PR TITLE
TrackCaloSmikker object: include changed

### DIFF
--- a/sbncode/Calibration/TrackCaloSkimmer.h
+++ b/sbncode/Calibration/TrackCaloSkimmer.h
@@ -61,8 +61,8 @@
 #include "larsim/MCCheater/ParticleInventoryService.h"
 
 #include "sbnobj/Common/Calibration/TrackCaloSkimmerObj.h"
-#include "sbnobj/Common/CRT/CRTHitT0TaggingInfo.cc"
-#include "sbnobj/Common/CRT/CRTHitT0TaggingTruthInfo.cc"
+#include "sbnobj/Common/CRT/CRTHitT0TaggingInfo.h"
+#include "sbnobj/Common/CRT/CRTHitT0TaggingTruthInfo.h"
 
 #include "ITCSSelectionTool.h"
 

--- a/sbncode/Calibration/TrackCaloSkimmer.h
+++ b/sbncode/Calibration/TrackCaloSkimmer.h
@@ -61,8 +61,8 @@
 #include "larsim/MCCheater/ParticleInventoryService.h"
 
 #include "sbnobj/Common/Calibration/TrackCaloSkimmerObj.h"
-#include "sbnobj/Common/CRT/CRTHitT0TaggingInfo.h"
-#include "sbnobj/Common/CRT/CRTHitT0TaggingTruthInfo.h"
+#include "sbnobj/Common/CRT/CRTHitT0TaggingInfo.hh"
+#include "sbnobj/Common/CRT/CRTHitT0TaggingTruthInfo.hh"
 
 #include "ITCSSelectionTool.h"
 


### PR DESCRIPTION
In develop by mistake the include for CRTT0TaggingInfo and CRTT0TaggingTruthInfo were point to the wrong file: .cc instead of .hh
This PR fixes that.
