### PR TITLE
Add PMT Beam Signal timing to ICARUS CAFs 

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -374,6 +374,12 @@ namespace caf
       "OpFlash"
     };
 
+    Atom<string> PMTBeamSignalLabel {
+      Name("PMTBeamSignalLabel"),
+      Comment("Label for special PMT beam timing signals used to build the beam bunch structure"),
+      "beamTiming:RWM"
+    };
+
     Atom<long long> CRTSimT0Offset {
       Name("CRTSimT0Offset"),
       Comment("start of beam gate/simulation time in the simulated CRT clock"),

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1669,6 +1669,10 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   std::vector<caf::SROpFlash> srflashes;
   if(fDet == kICARUS)
   {
+    //Get all of the special PMT Beam Signals (to use as an opFlash reference time below)
+    art::Handle<std::vector<sbn::timing::PMTBeamSignal>> PMTBeamSignal_handle;
+    GetByLabelStrict(evt, fParams.PMTBeamSignalLabel(), PMTBeamSignal_handle);
+  
     for (const std::string& pandora_tag_suffix : pandora_tag_suffixes) {
       art::Handle<std::vector<recob::OpFlash>> flashes_handle;
       GetByLabelStrict(evt, fParams.OpFlashLabel() + pandora_tag_suffix, flashes_handle);
@@ -1676,7 +1680,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       if (flashes_handle.isValid()) {
         const std::vector<recob::OpFlash> &opflashes = *flashes_handle;
         int cryostat = ( pandora_tag_suffix.find("W") != std::string::npos ) ? 1 : 0;
-
+        
         // get associated OpHits for each OpFlash
         art::FindMany<recob::OpHit> findManyHits(flashes_handle, evt, fParams.OpFlashLabel() + pandora_tag_suffix);
 
@@ -1686,7 +1690,14 @@ void CAFMaker::produce(art::Event& evt) noexcept {
           std::vector<recob::OpHit const*> const& ophits = findManyHits.at(iflash);
 
           srflashes.emplace_back();
-          FillICARUSOpFlash(flash, ophits, cryostat, srflashes.back());
+          if(PMTBeamSignal_handle.isValid() && isRealData){
+            const std::vector<sbn::timing::PMTBeamSignal> &pmtbeamsignals = *PMTBeamSignal_handle;
+            FillICARUSOpFlash(flash, ophits, cryostat, pmtbeamsignals, srflashes.back());
+          }
+          else{
+            const std::vector<sbn::timing::PMTBeamSignal> pmtbeamsignals;
+            FillICARUSOpFlash(flash, ophits, cryostat, pmtbeamsignals, srflashes.back());
+          }
           iflash++;
         }
       }

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1671,7 +1671,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   {
     //Get all of the special PMT Beam Signals (to use as an opFlash reference time below)
     art::Handle<std::vector<sbn::timing::PMTBeamSignal>> PMTBeamSignal_handle;
-    GetByLabelStrict(evt, fParams.PMTBeamSignalLabel(), PMTBeamSignal_handle);
+    GetByLabelIfExists(evt, fParams.PMTBeamSignalLabel(), PMTBeamSignal_handle);
   
     for (const std::string& pandora_tag_suffix : pandora_tag_suffixes) {
       art::Handle<std::vector<recob::OpFlash>> flashes_handle;

--- a/sbncode/CAFMaker/CMakeLists.txt
+++ b/sbncode/CAFMaker/CMakeLists.txt
@@ -35,6 +35,7 @@ art_make_library( LIBRARY_NAME sbncode_CAFMaker
                   sbnobj::Common_CRT
                   sbnobj::Common_Reco
                   sbnobj::Common_Analysis
+                  sbnobj::Common_PMT_Data
                   sbnobj::SBND_CRT
                   lardataalg::DetectorInfo
                   art::Framework_Services_System_TriggerNamesService_service

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -202,7 +202,6 @@ namespace caf
         sbn::timing::SelectFirstOpHitByTime(hit,startmap,risemap); 
     }
     srflash.rwmtime = getFlashBunchTime(risemap, RWMTimes);
-    std::cout << "Flash at Time " << flash.Time() << " has " << startmap.size() << " opHit channels, flashTime_rwm = " <<  srflash.rwmtime << " \n";
     srflash.firsttime = firstTime;
 
     srflash.cryo = cryo; // 0 in SBND, 0/1 for E/W in ICARUS

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -183,6 +183,7 @@ namespace caf
   void FillICARUSOpFlash(const recob::OpFlash &flash,
                   std::vector<recob::OpHit const*> const& hits,
                   int cryo, 
+                  std::vector<sbn::timing::PMTBeamSignal> RWMTimes,
                   caf::SROpFlash &srflash,
                   bool allowEmpty) {
 
@@ -192,11 +193,16 @@ namespace caf
     srflash.timewidth = flash.TimeWidth();
 
     double firstTime = std::numeric_limits<double>::max();
+    std::map<int, double> startmap, risemap;
     for(const auto& hit: hits){
       double const hitTime = hit->HasStartTime()? hit->StartTime(): hit->PeakTime();
       if (firstTime > hitTime)
         firstTime = hitTime;
+      if (!RWMTimes.empty())
+        sbn::timing::SelectFirstOpHitByTime(hit,startmap,risemap); 
     }
+    srflash.rwmtime = getFlashBunchTime(risemap, RWMTimes);
+    std::cout << "Flash at Time " << flash.Time() << " has " << startmap.size() << " opHit channels, flashTime_rwm = " <<  srflash.rwmtime << " \n";
     srflash.firsttime = firstTime;
 
     srflash.cryo = cryo; // 0 in SBND, 0/1 for E/W in ICARUS

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -193,13 +193,13 @@ namespace caf
     srflash.timewidth = flash.TimeWidth();
 
     double firstTime = std::numeric_limits<double>::max();
-    std::map<int, double> startmap, risemap;
+    std::map<int, double> risemap;
     for(const auto& hit: hits){
       double const hitTime = hit->HasStartTime()? hit->StartTime(): hit->PeakTime();
       if (firstTime > hitTime)
         firstTime = hitTime;
       if (!RWMTimes.empty())
-        sbn::timing::SelectFirstOpHitByTime(hit,startmap,risemap); 
+        sbn::timing::SelectFirstOpHitByTime(hit,risemap); 
     }
     srflash.rwmtime = getFlashBunchTime(risemap, RWMTimes);
     srflash.firsttime = firstTime;

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -42,6 +42,7 @@
 #include "sbnobj/SBND/CRT/CRTTrack.hh"
 #include "sbnobj/Common/CRT/CRTPMTMatching.hh"
 #include "sbnobj/Common/CRT/CRTHitT0TaggingInfo.hh"
+#include "sbnobj/Common/PMT/Data/PMTBeamSignal.hh"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
 
@@ -256,6 +257,7 @@ namespace caf
   void FillICARUSOpFlash(const recob::OpFlash &flash,
                   std::vector<recob::OpHit const*> const& hits,
                   int cryo,
+                  std::vector<sbn::timing::PMTBeamSignal> RWMTimes,
                   caf::SROpFlash &srflash,
                   bool allowEmpty = false);
 


### PR DESCRIPTION
### Description 
This pull request reads the special PMT Beam timing signal (RWM) into the CAFMaker which enables us to reconstruct the Beam Bunch structure seen by ICARUS PMTs. 

The PMT Beam signals were originally stored in an icaruscode data product `icarus::timing::PMTBeamSignal`, but [icaruscode PR #832](https://github.com/SBNSoftware/icaruscode/pull/832) and  [sbnobj PR #130 ](https://github.com/SBNSoftware/sbnobj/pull/130) together move the data product to a SBN common area, `sbnobj/Common`. 

A `std::vector<sbn::timing::PMTBeamSignal>` is read into the CAFMaker and then passed to `FillICARUSOpFlash` if the `PMTBeamSignal` is valid. If running on MC, offbeam data or stage1 files without the `sbn::timing::PMTBeamSignal` data product, the `srflash.rwmtime` variable will be left to it's default value `kSignalingNaN` in [SROpFlash.h](https://github.com/SBNSoftware/sbnanaobj/blob/69d7ab43f2e153463c73ef8081a46d9077b207f2/sbnanaobj/StandardRecord/SROpFlash.cxx#L28). 

Within `FillICARUSOpFlash`, two new helper functions defined in [sbnobj/Common/PMT/Data/PMTBeamSignal.cxx](https://github.com/SBNSoftware/sbnobj/blob/519bea6995d58bff59d07b7a171c842665bb3a51/sbnobj/Common/PMT/Data/PMTBeamSignal.cxx) are called. 
* `SelectFirstOpHitByTime` reads in a single OpHit and returns a startmap and risemap (holding the start and rise time of each OpHit channel).
* `getFlashBunchTime` reads in the risemap and `std::vector<sbn::timing::PMTBeamSignal> RWMTimes`, finds the mean between the first OpHit RiseTimes on opposite walls to get the Flash Interaction time wrt the RWM time. 

This PR is a companion to [sbnanaobj PR #141](https://github.com/SBNSoftware/sbnanaobj/pull/141). This PR requires [icaruscode PR #832](https://github.com/SBNSoftware/icaruscode/pull/832) and  [sbnobj PR #130 ](https://github.com/SBNSoftware/sbnobj/pull/130) also being merged. 



- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [ ] Is this PR related to an open issue / project?
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [ ] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
