### PR TITLE
Ensure CRT T0 usage in calibration ntuples is direction aware

### DIFF
--- a/sbncode/Calibration/TrackCaloSkimmer_module.cc
+++ b/sbncode/Calibration/TrackCaloSkimmer_module.cc
@@ -1140,15 +1140,10 @@ void sbn::TrackCaloSkimmer::FillTrack(const recob::Track &track,
     fTrack->start.x = track.Start().X();
     fTrack->end.x = track.End().X();
   } else if (t0Info.hasT0CRTTrack) {
+    int driftDir = geo->TPC(hits[0]->WireID()).DriftDir().X();
     const double driftv(dprop.DriftVelocity(dprop.Efield(), dprop.Temperature()));
-    // Comment from Francesco: I am not sure of the below formula.
-    // SBND has two TPCs with a common cathode like ICARUS, the driftvelocity
-    // returns the absolute value, but the displacement (basically the + below)
-    // depends on the TPC, in one case is + and in the other is negative.
-    // In this way the displacement is always in the same direction, working for
-    // one TPC, but not for the other.
-    fTrack->start.x = track.Start().X() + driftv*t0Info.t0CRTTrack*1e-3;
-    fTrack->end.x = track.End().X() + driftv*t0Info.t0CRTTrack*1e-3;
+    fTrack->start.x = track.Start().X() + driftDir*driftv*t0Info.t0CRTTrack*1e-3;
+    fTrack->end.x = track.End().X() + driftDir*driftv*t0Info.t0CRTTrack*1e-3;
   } else if (t0Info.hasT0CRTHit){ 
     // If the track does not have a a Pandora T0, the tracks will always be either on the left or (ex Or) right of the cathode. 
     int driftDir = geo->TPC(hits[0]->WireID()).DriftDir().X();


### PR DESCRIPTION
### Description 
This PR fixes a bug in how the calib ntuples make use of the CRT track T0 tagging. There was no accounting for the fact that the drift direction is different in the two TPCs so the xshift has to be in different directions depending on which TPC is being considered.

Please see slides linked investigating the issue: https://docs.google.com/presentation/d/1CJ8yL7P7Dae1H3r_99cGIuQ4Dqgc2nATDqnGpyKvbaE/edit?usp=sharing

I haven't presented these slides because a hotfix was requested. I can present them at a future calibration meeting. The key plots are shown below. They show the TPC track start in x for tracks that have been shifted by the CRT T0 values.

**Before Fix**

<img width="1200" height="800" alt="tpc_start_x_crt_t0" src="https://github.com/user-attachments/assets/8c356a92-e408-42b3-a718-99eaeb7519a0" />

**After Fix**

<img width="1200" height="800" alt="tpc_start_x_crt_t0" src="https://github.com/user-attachments/assets/1320a20c-04de-41ac-9836-988f78f786e3" />


- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [ ] Is this PR related to an open issue / project?
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [ ] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [ ] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
