### PR TITLE
Frame Shift Module to Correct Timing in Data - PR For Spring Production

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -341,13 +341,13 @@ namespace caf
     Atom<string> SBNDFrameShiftInfoLabel {
       Name("SBNDFrameShiftInfoLabel"),
       Comment("Label of sbnd frame shift."),
-      "reco1" // sbnd
+      "framshift" // sbnd
     };
 
     Atom<string> SBNDTimingInfoLabel {
       Name("SBNDTimingInfoLabel"),
       Comment("Label of sbnd timing shift."),
-      "reco1" // sbnd
+      "frameshift" // sbnd
     };
 
     Atom<string> CRTPMTLabel {

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -338,6 +338,18 @@ namespace caf
       "crttracks" // sbnd
     };
 
+    Atom<string> SBNDFrameShiftInfoLabel {
+      Name("SBNDFrameShiftInfoLabel"),
+      Comment("Label of sbnd frame shift."),
+      "reco1" // sbnd
+    };
+
+    Atom<string> SBNDTimingInfoLabel {
+      Name("SBNDTimingInfoLabel"),
+      Comment("Label of sbnd timing shift."),
+      "reco1" // sbnd
+    };
+
     Atom<string> CRTPMTLabel {
       Name("CRTPMTLabel"),
       Comment("Label for the CRTPMT Matched variables from the crtpmt data product"),

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -341,7 +341,7 @@ namespace caf
     Atom<string> SBNDFrameShiftInfoLabel {
       Name("SBNDFrameShiftInfoLabel"),
       Comment("Label of sbnd frame shift."),
-      "framshift" // sbnd
+      "frameshift" // sbnd
     };
 
     Atom<string> SBNDTimingInfoLabel {

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1603,6 +1603,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   std::vector<caf::SRCRTTrack> srcrttracks;
   std::vector<caf::SRCRTSpacePoint> srcrtspacepoints;
   std::vector<caf::SRSBNDCRTTrack> srsbndcrttracks;
+  std::vector<caf::SRSBNDFrameShiftInfo> srsbndframeshiftinfo;
+  std::vector<caf::SRSBNDTimingInfo> srsbndtiminginfo;
 
   if(fDet == kICARUS)
     {
@@ -1651,6 +1653,29 @@ void CAFMaker::produce(art::Event& evt) noexcept {
           FillSBNDCRTTrack(sbndcrttracks[i], srsbndcrttracks.back());
         }
       }
+
+      art::Handle<std::vector<raw::FrameShiftInfo>> sbndframeshiftinfo_handle;
+      GetByLabelStrict(evt, fParams.SBNDFrameShiftInfoLabel(), sbndframeshiftinfo_handle);
+      // fill into event
+      if (sbndframeshiftinfo_handle.isValid()) {
+        const std::vector<raw::FrameShiftInfo> &sbndframeshiftinfo = *sbndframeshiftinfo_handle;
+        for (unsigned i = 0; i < sbndframeshiftinfo.size(); i++) {
+          srsbndframeshiftinfo.emplace_back();
+          FillSBNDFrameShiftInfo(sbndframeshiftinfo[i], srsbndframeshiftinfo.back());
+        }
+      }
+
+      art::Handle<std::vector<raw::TimingInfo>> sbndtiminginfo_handle;
+      GetByLabelStrict(evt, fParams.SBNDTimingInfoLabel(), sbndtiminginfo_handle);
+      // fill into event
+      if (sbndtiminginfo_handle.isValid()) {
+        const std::vector<raw::TimingInfo> &sbndtiminginfo = *sbndtiminginfo_handle;
+        for (unsigned i = 0; i < sbndtiminginfo.size(); i++) {
+          srsbndtiminginfo.emplace_back();
+          FillSBNDTimingInfo(sbndtiminginfo[i], srsbndtiminginfo.back());
+        }
+      }
+
     }
 
   // Get all of the CRTPMT Matches

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -118,6 +118,8 @@
 #include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
 #include "sbnobj/Common/Reco/CRUMBSResult.h"
 #include "sbnobj/Common/Reco/OpT0FinderResult.h"
+#include "sbnobj/SBND/Timing/TimingInfo.hh"
+#include "sbnobj/SBND/Timing/FrameShiftInfo.hh"
 
 // GENIE
 #include "Framework/EventGen/EventRecord.h"
@@ -1692,19 +1694,19 @@ void CAFMaker::produce(art::Event& evt) noexcept {
         }
       }
     
-      art::Handle<raw::FrameShiftInfo> sbndframeshiftinfo_handle;
+      art::Handle<sbnd::timing::FrameShiftInfo> sbndframeshiftinfo_handle;
       GetByLabelStrict(evt, fParams.SBNDFrameShiftInfoLabel(), sbndframeshiftinfo_handle);
       // fill into event
       if (sbndframeshiftinfo_handle.isValid()) {
-        raw::FrameShiftInfo const& sbndframeshiftinfo(*sbndframeshiftinfo_handle);
+        sbnd::timing::FrameShiftInfo const& sbndframeshiftinfo(*sbndframeshiftinfo_handle);
         FillSBNDFrameShiftInfo(sbndframeshiftinfo, srsbndframeshiftinfo);
       }
 
-      art::Handle<raw::TimingInfo> sbndtiminginfo_handle;
+      art::Handle<sbnd::timing::TimingInfo> sbndtiminginfo_handle;
       GetByLabelStrict(evt, fParams.SBNDTimingInfoLabel(), sbndtiminginfo_handle);
       // fill into event
       if (sbndtiminginfo_handle.isValid()) {
-        raw::TimingInfo const& sbndtiminginfo(*sbndtiminginfo_handle);
+        sbnd::timing::TimingInfo const& sbndtiminginfo(*sbndtiminginfo_handle);
         FillSBNDTimingInfo(sbndtiminginfo, srsbndtiminginfo);
       }
     }

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -514,11 +514,11 @@ void CAFMaker::SBNDShiftCRTReference(StandardRecord &rec, double SBNDFrame){
     trk.time += SBNDFrame; //ns
   }
 
-  //CRT Space Point and Track Match
-  for (SRPFP &pfp: rec.reco.pfp) {
-    pfp.trk.crtspacepoint.spacepoint.time += SBNDFrame;
-    pfp.trk.crtsbndtrack.track.time += SBNDFrame;
-  }
+  //TODO: CRT Space Point and Track Match
+  //for (SRPFP &pfp: rec.reco.pfp) {
+  //  pfp.trk.crtspacepoint.spacepoint.time += SBNDFrame;
+  //  pfp.trk.crtsbndtrack.track.time += SBNDFrame;
+  //}
 }
 
 void CAFMaker::SBNDShiftPMTReference(StandardRecord &rec, double SBNDFrame){

--- a/sbncode/CAFMaker/CMakeLists.txt
+++ b/sbncode/CAFMaker/CMakeLists.txt
@@ -36,6 +36,7 @@ art_make_library( LIBRARY_NAME sbncode_CAFMaker
                   sbnobj::Common_Reco
                   sbnobj::Common_Analysis
                   sbnobj::SBND_CRT
+                  sbnobj::SBND_Timing
                   lardataalg::DetectorInfo
                   art::Framework_Services_System_TriggerNamesService_service
                   sbncode_Metadata_MetadataSBN_service

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -141,31 +141,31 @@ namespace caf
     srsbndcrttrack.tof      = track.ToF();
   }
 
-  void FillSBNDFrameShiftInfo(const raw::FrameShiftInfo &frame,
+  void FillSBNDFrameShiftInfo(const sbnd::timing::FrameShiftInfo &frame,
                         caf::SRSBNDFrameShiftInfo &srsbndframe,
                         bool allowEmpty)
   {
-    srsbndframe.timingType = frame.timingType;
-    srsbndframe.frameTdcCrtt1 = frame.frameTdcCrtt1;
-    srsbndframe.frameTdcBes = frame.frameTdcBes;
-    srsbndframe.frameTdcRwm = frame.frameTdcRwm;
-    srsbndframe.frameHltCrtt1 = frame.frameHltCrtt1;
-    srsbndframe.frameHltBeamGate = frame.frameHltBeamGate;
-    srsbndframe.frameApplyAtCaf = frame.frameApplyAtCaf;
+    srsbndframe.timingType = frame.TimingType();
+    srsbndframe.frameTdcCrtt1 = frame.FrameTdcCrtt1();
+    srsbndframe.frameTdcBes = frame.FrameTdcBes();
+    srsbndframe.frameTdcRwm = frame.FrameTdcRwm();
+    srsbndframe.frameHltCrtt1 = frame.FrameHltCrtt1();
+    srsbndframe.frameHltBeamGate = frame.FrameHltBeamGate();
+    srsbndframe.frameApplyAtCaf = frame.FrameApplyAtCaf();
   }
 
-  void FillSBNDTimingInfo(const raw::TimingInfo &timing,
+  void FillSBNDTimingInfo(const sbnd::timing::TimingInfo &timing,
                         caf::SRSBNDTimingInfo &srsbndtiming,
                         bool allowEmpty)
   {
-    srsbndtiming.rawDAQHeaderTimestamp = timing.rawDAQHeaderTimestamp;
-    srsbndtiming.tdcCrtt1 = timing.tdcCrtt1;
-    srsbndtiming.tdcBes = timing.tdcBes;
-    srsbndtiming.tdcRwm = timing.tdcRwm;
-    srsbndtiming.tdcEtrig = timing.tdcEtrig;
-    srsbndtiming.hltCrtt1 = timing.hltCrtt1;
-    srsbndtiming.hltEtrig = timing.hltEtrig;
-    srsbndtiming.hltBeamGate = timing.hltBeamGate;
+    srsbndtiming.rawDAQHeaderTimestamp = timing.RawDAQHeaderTimestamp();
+    srsbndtiming.tdcCrtt1 = timing.TdcCrtt1();
+    srsbndtiming.tdcBes = timing.TdcBes();
+    srsbndtiming.tdcRwm = timing.TdcRwm();
+    srsbndtiming.tdcEtrig = timing.TdcEtrig();
+    srsbndtiming.hltCrtt1 = timing.HltCrtt1();
+    srsbndtiming.hltEtrig = timing.HltEtrig();
+    srsbndtiming.hltBeamGate = timing.HltBeamGate();
   }
 
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -158,6 +158,7 @@ namespace caf
                         caf::SRSBNDTimingInfo &srsbndtiming,
                         bool allowEmpty)
   {
+    srsbndtiming.rawDAQHeaderTimestamp = timing.rawDAQHeaderTimestamp;
     srsbndtiming.tdcCrtt1 = timing.tdcCrtt1;
     srsbndtiming.tdcBes = timing.tdcBes;
     srsbndtiming.tdcRwm = timing.tdcRwm;

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -145,12 +145,13 @@ namespace caf
                         caf::SRSBNDFrameShiftInfo &srsbndframe,
                         bool allowEmpty)
   {
+    srsbndframe.timingType = frame.timingType;
     srsbndframe.frameTdcCrtt1 = frame.frameTdcCrtt1;
     srsbndframe.frameTdcBes = frame.frameTdcBes;
     srsbndframe.frameTdcRwm = frame.frameTdcRwm;
     srsbndframe.frameHltCrtt1 = frame.frameHltCrtt1;
     srsbndframe.frameHltBeamGate = frame.frameHltBeamGate;
-    srsbndframe.frameDataToMC = frame.frameDataToMC;
+    srsbndframe.frameApplyAtCaf = frame.frameApplyAtCaf;
   }
 
   void FillSBNDTimingInfo(const raw::TimingInfo &timing,

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -141,6 +141,31 @@ namespace caf
     srsbndcrttrack.tof      = track.ToF();
   }
 
+  void FillSBNDFrameShiftInfo(const raw::FrameShiftInfo &frame,
+                        caf::SRSBNDFrameShiftInfo &srsbndframe,
+                        bool allowEmpty)
+  {
+    srsbndframe.frameTdcCrtt1 = frame.frameTdcCrtt1;
+    srsbndframe.frameTdcBes = frame.frameTdcBes;
+    srsbndframe.frameTdcRwm = frame.frameTdcRwm;
+    srsbndframe.frameHltCrtt1 = frame.frameHltCrtt1;
+    srsbndframe.frameHltBeamGate = frame.frameHltBeamGate;
+    srsbndframe.frameDataToMC = frame.frameDataToMC;
+  }
+
+  void FillSBNDTimingInfo(const raw::TimingInfo &timing,
+                        caf::SRSBNDTimingInfo &srsbndtiming,
+                        bool allowEmpty)
+  {
+    srsbndtiming.tdcCrtt1 = timing.tdcCrtt1;
+    srsbndtiming.tdcBes = timing.tdcBes;
+    srsbndtiming.tdcRwm = timing.tdcRwm;
+    srsbndtiming.tdcEtrig = timing.tdcEtrig;
+    srsbndtiming.hltCrtt1 = timing.hltCrtt1;
+    srsbndtiming.hltEtrig = timing.hltEtrig;
+    srsbndtiming.hltBeamGate = timing.hltBeamGate;
+  }
+
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
 		       caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty){

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -42,9 +42,11 @@
 #include "sbnobj/SBND/CRT/CRTTrack.hh"
 #include "sbnobj/Common/CRT/CRTPMTMatching.hh"
 #include "sbnobj/Common/CRT/CRTHitT0TaggingInfo.hh"
+#include "sbnobj/SBND/Timing/TimingInfo.hh"
+#include "sbnobj/SBND/Timing/FrameShiftInfo.hh"
+
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
-#include "sbndcode/Timing/SBNDRawTimingObj.h"
 
 #include "sbnanaobj/StandardRecord/SRSlice.h"
 #include "sbnanaobj/StandardRecord/StandardRecord.h"
@@ -280,11 +282,11 @@ namespace caf
                       caf::SRPFP& srpfp,
                       bool allowEmpty = false);
 
-  void FillSBNDFrameShiftInfo(const raw::FrameShiftInfo &frame,
+  void FillSBNDFrameShiftInfo(const sbnd::timing::FrameShiftInfo &frame,
                         caf::SRSBNDFrameShiftInfo &srsbndframe,
                         bool allowEmpty = false);
 
-  void FillSBNDTimingInfo(const raw::TimingInfo &timing,
+  void FillSBNDTimingInfo(const sbnd::timing::TimingInfo &timing,
                         caf::SRSBNDTimingInfo &srsbndtiming,
                         bool allowEmpty = false);
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -44,6 +44,7 @@
 #include "sbnobj/Common/CRT/CRTHitT0TaggingInfo.hh"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
+#include "sbndcode/Timing/SBNDRawTimingObj.h"
 
 #include "sbnanaobj/StandardRecord/SRSlice.h"
 #include "sbnanaobj/StandardRecord/StandardRecord.h"
@@ -278,6 +279,14 @@ namespace caf
   void FillPFPRazzled(const art::Ptr<sbn::MVAPID> razzled,
                       caf::SRPFP& srpfp,
                       bool allowEmpty = false);
+
+  void FillSBNDFrameShiftInfo(const raw::FrameShiftInfo &frame,
+                        caf::SRSBNDFrameShiftInfo &srsbndframe,
+                        bool allowEmpty = false);
+
+  void FillSBNDTimingInfo(const raw::TimingInfo &timing,
+                        caf::SRSBNDTimingInfo &srsbndtiming,
+                        bool allowEmpty = false);
 
   template<class T, class U>
   void CopyPropertyIfSet( const std::map<std::string, T>& props, const std::string& search, U& value );


### PR DESCRIPTION
### Description 

New module for timing reconstruction in introduced at reco2 in sbndcode. 
Module make data products that are saved in CAF as new Standard Record products. 
Data Timing variables in CAF, i.e. crt space point time, sbnd crt track time, opflash and opt0, are shifted for beam spill reconstruction.
Full description can be found in docdb: https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=43090

- [x] Have you added a label? (bug/enhancement/physics etc.)
- [x] Have you assigned at least 1 reviewer?
- [ ] Is this PR related to an open issue / project?
- [x] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [x] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.


- [ ] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
