### PR TITLE
Feature/aantonak crtveto caf

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -338,6 +338,12 @@ namespace caf
       "crttracks" // sbnd
     };
 
+    Atom<string> SBNDCRTVetoLabel {
+      Name("SBNDCRTVetoLabel"),
+      Comment("Label of sbnd CRT Veto."),
+      "crtveto" // sbnd
+    };
+
     Atom<string> CRTPMTLabel {
       Name("CRTPMTLabel"),
       Comment("Label for the CRTPMT Matched variables from the crtpmt data product"),

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1602,6 +1602,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   std::vector<caf::SRCRTTrack> srcrttracks;
   std::vector<caf::SRCRTSpacePoint> srcrtspacepoints;
   std::vector<caf::SRSBNDCRTTrack> srsbndcrttracks;
+  caf::SRSBNDCRTVeto srsbndcrtveto;
 
   if(fDet == kICARUS)
     {
@@ -1650,6 +1651,44 @@ void CAFMaker::produce(art::Event& evt) noexcept {
           FillSBNDCRTTrack(sbndcrttracks[i], srsbndcrttracks.back());
         }
       }
+      // Fill CRT Veto 
+      std::cout << std::endl;	
+      std::cout << std::endl;	
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << std::endl;	
+      std::cout << std::endl;	
+      art::Handle<std::vector<sbnd::crt::CRTVeto>> sbndcrtveto_handle;
+      GetByLabelStrict(evt, fParams.SBNDCRTVetoLabel(), sbndcrtveto_handle);
+      // fill into event
+      if (sbndcrtveto_handle.isValid()) {
+	std::cout << "Found a valid CRT Veto Handle!!!" << std::endl;
+        const std::vector<sbnd::crt::CRTVeto> &sbndcrtvetos = *sbndcrtveto_handle;
+          //srsbndcrtveto.emplace_back();
+          FillSBNDCRTVeto(sbndcrtvetos[0], srsbndcrtveto);
+      }
+      else {
+        std::cout << "Invalid CRT Veto Handle!" << std::endl;
+	return;
+      }
+      std::cout << std::endl;	
+      std::cout << std::endl;	
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
+      std::cout << std::endl;	
+      std::cout << std::endl;	
     }
 
   // Get all of the CRTPMT Matches
@@ -2349,6 +2388,12 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 
   }  // end loop over slices
 
+  std::cout << std::endl;
+  std::cout << std::endl;
+  std::cout << "// -------------- DEBUG FILL REC TREE --------------------- //" <<std::endl;
+  std::cout << "V0 " << srsbndcrtveto.V0 << std::endl;
+  std::cout << std::endl;
+  std::cout << std::endl;
   //#######################################################
   //  Fill rec Tree
   //#######################################################
@@ -2365,6 +2410,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   rec.ncrt_spacepoints = srcrtspacepoints.size();
   rec.sbnd_crt_tracks  = srsbndcrttracks;
   rec.nsbnd_crt_tracks = srsbndcrttracks.size();
+  rec.sbnd_crt_veto  = srsbndcrtveto;
   rec.opflashes        = srflashes;
   rec.nopflashes       = srflashes.size();
   if (fParams.FillTrueParticles()) {
@@ -2374,6 +2420,12 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   rec.crtpmt_matches = srcrtpmtmatches;
   rec.ncrtpmt_matches = srcrtpmtmatches.size();
 
+  std::cout << std::endl;
+  std::cout << std::endl;
+  std::cout << "// -------------- DEBUG After FILL REC TREE --------------------- //" <<std::endl;
+  std::cout << "V0 " << rec.sbnd_crt_veto.V0 << std::endl;
+  std::cout << std::endl;
+  std::cout << std::endl;
   // Fix the Reference time
   //
   // We want MC and Data to have the same reference time.

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -118,6 +118,7 @@
 #include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
 #include "sbnobj/Common/Reco/CRUMBSResult.h"
 #include "sbnobj/Common/Reco/OpT0FinderResult.h"
+#include "sbnobj/SBND/CRT/CRTVeto.hh"
 
 // GENIE
 #include "Framework/EventGen/EventRecord.h"
@@ -1671,8 +1672,64 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       if (sbndcrtveto_handle.isValid()) {
 	std::cout << "Found a valid CRT Veto Handle!!!" << std::endl;
         const std::vector<sbnd::crt::CRTVeto> &sbndcrtvetos = *sbndcrtveto_handle;
-          //srsbndcrtveto.emplace_back();
-          FillSBNDCRTVeto(sbndcrtvetos[0], srsbndcrtveto);
+	  
+  	// And associated SpacePoint objects
+  	//
+  	//art::FindManyP<sbnd::crt::CRTSpacePoint> fveto_sp = FindManyPStrict<sbnd::crt::CRTSpacePoint>(sbndcrtvetos[0], evt, fParams.SBNDCRTVetoLabel());
+	//art::FindManyP<sbnd::crt::CRTSpacePoint> spAssoc(&sbndcrtvetos[0], evt, fParams.SBNDCRTVetoLabel());
+	art::FindManyP<sbnd::crt::CRTSpacePoint> spAssoc(sbndcrtveto_handle, evt, fParams.SBNDCRTVetoLabel());
+        if (spAssoc.isValid()) {
+	  std::cout << "Valid SpacePoint Association" << std::endl;
+	  std::cout << "Association Size: " << spAssoc.size() << std::endl;
+	}
+	else {
+	  std::cout << "Invalid Space Point Association" << std::endl;
+	}
+
+	// Assume there is only one Veto per event    
+	const std::vector<art::Ptr<sbnd::crt::CRTSpacePoint>> veto_sp_v(spAssoc.at(0)); 
+        //for (auto const& sp: veto_sp_v) {
+      
+        //}
+        //
+
+       // Fill the associated space points --> then add to the FillReco function
+       
+       std::vector<sbnd::crt::CRTSpacePoint> vetoSpacePoints;
+       if (veto_sp_v.size() == 0) {
+         std::cout << " No Veto SpacePoints" << std::endl; 
+         vetoSpacePoints.emplace_back(); // nullptr
+       }
+       else {
+       
+         for (auto const& sp: veto_sp_v) {
+	       
+           vetoSpacePoints.push_back(*sp);
+
+         }
+       }
+
+       /*
+       if (fveto_sp.isValid()) {
+         std::cout << "Veto SP Association is valid! Size = " << fveto_sp.size() << std::endl;
+         //for (unsigned i = 0; i < fveto_sp.size(); i++) {
+         // Should have just one vector of possible space points
+         const std::vector<art::Ptr<sbnd::crt::CRTSpacePoint>> &theseSpacePoints = fveto_sp.at(0);
+           if (theseSpacePoints.size() == 0) {
+	     std::cout << " No Veto SpacePoints" << std::endl; 
+             vetoSpacePoints.emplace_back(); // nullptr
+           }
+           else if (theseSpacePoints.size() > 0) {
+             //vetoSpacePoints.push_back(*fveto_sp.at(i).at(0));
+             for (auto const& sp: theseSpacePoints) {
+	       vetoSpacePoints.push_back(*sp);
+             }
+           }
+         }
+	 */
+	  //srsbndcrtveto.emplace_back();
+	
+          FillSBNDCRTVeto(sbndcrtvetos[0], vetoSpacePoints, srsbndcrtveto);
       }
       else {
         std::cout << "Invalid CRT Veto Handle!" << std::endl;
@@ -2419,12 +2476,6 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   rec.ntrue_particles = true_particles.size();
   rec.crtpmt_matches = srcrtpmtmatches;
   rec.ncrtpmt_matches = srcrtpmtmatches.size();
-
-  rec.sbnd_crtveto_v0 = srsbndcrtveto.V0;
-  rec.sbnd_crtveto_v1 = srsbndcrtveto.V1;
-  rec.sbnd_crtveto_v2 = srsbndcrtveto.V2;
-  rec.sbnd_crtveto_v3 = srsbndcrtveto.V3;
-  rec.sbnd_crtveto_v4 = srsbndcrtveto.V4;
 
   std::cout << std::endl;
   std::cout << std::endl;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -2420,6 +2420,12 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   rec.crtpmt_matches = srcrtpmtmatches;
   rec.ncrtpmt_matches = srcrtpmtmatches.size();
 
+  rec.sbnd_crtveto_v0 = srsbndcrtveto.V0;
+  rec.sbnd_crtveto_v1 = srsbndcrtveto.V1;
+  rec.sbnd_crtveto_v2 = srsbndcrtveto.V2;
+  rec.sbnd_crtveto_v3 = srsbndcrtveto.V3;
+  rec.sbnd_crtveto_v4 = srsbndcrtveto.V4;
+
   std::cout << std::endl;
   std::cout << std::endl;
   std::cout << "// -------------- DEBUG After FILL REC TREE --------------------- //" <<std::endl;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1653,99 +1653,39 @@ void CAFMaker::produce(art::Event& evt) noexcept {
         }
       }
       // Fill CRT Veto 
-      std::cout << std::endl;	
-      std::cout << std::endl;	
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << std::endl;	
-      std::cout << std::endl;	
       art::Handle<std::vector<sbnd::crt::CRTVeto>> sbndcrtveto_handle;
       GetByLabelStrict(evt, fParams.SBNDCRTVetoLabel(), sbndcrtveto_handle);
       // fill into event
       if (sbndcrtveto_handle.isValid()) {
-	std::cout << "Found a valid CRT Veto Handle!!!" << std::endl;
         const std::vector<sbnd::crt::CRTVeto> &sbndcrtvetos = *sbndcrtveto_handle;
-	  
   	// And associated SpacePoint objects
-  	//
-  	//art::FindManyP<sbnd::crt::CRTSpacePoint> fveto_sp = FindManyPStrict<sbnd::crt::CRTSpacePoint>(sbndcrtvetos[0], evt, fParams.SBNDCRTVetoLabel());
-	//art::FindManyP<sbnd::crt::CRTSpacePoint> spAssoc(&sbndcrtvetos[0], evt, fParams.SBNDCRTVetoLabel());
 	art::FindManyP<sbnd::crt::CRTSpacePoint> spAssoc(sbndcrtveto_handle, evt, fParams.SBNDCRTVetoLabel());
+        std::vector<sbnd::crt::CRTSpacePoint> vetoSpacePoints;
         if (spAssoc.isValid()) {
-	  std::cout << "Valid SpacePoint Association" << std::endl;
-	  std::cout << "Association Size: " << spAssoc.size() << std::endl;
-	}
-	else {
-	  std::cout << "Invalid Space Point Association" << std::endl;
-	}
 
-	// Assume there is only one Veto per event    
-	const std::vector<art::Ptr<sbnd::crt::CRTSpacePoint>> veto_sp_v(spAssoc.at(0)); 
-        //for (auto const& sp: veto_sp_v) {
-      
-        //}
-        //
+	  // Assume there is only one Veto per event    
+	  const std::vector<art::Ptr<sbnd::crt::CRTSpacePoint>> veto_sp_v(spAssoc.at(0)); 
 
-       // Fill the associated space points --> then add to the FillReco function
+          // Fill the associated space points --> then add to the FillReco function
        
-       std::vector<sbnd::crt::CRTSpacePoint> vetoSpacePoints;
-       if (veto_sp_v.size() == 0) {
-         std::cout << " No Veto SpacePoints" << std::endl; 
-         vetoSpacePoints.emplace_back(); // nullptr
-       }
-       else {
+          if (veto_sp_v.size() == 0) {
+            // TODO ? Need to decide how to handle this
+            // This version seems to work in skipping empty associations. It does break the rec.sbnd_crt_veto.sp_pe..length and 
+            // rec.sbnd_crt_veto.sp_time..length branches? However, the rec.sbnd_crt_veto.sp_position..length still works and can be used?
+            std::cout << "No Veto Space Points" << std::endl;
+            //vetoSpacePoints.emplace_back(); // nullptr 
+          }
+          else {
        
-         for (auto const& sp: veto_sp_v) {
+            for (auto const& sp: veto_sp_v) {
 	       
-           vetoSpacePoints.push_back(*sp);
+              vetoSpacePoints.push_back(*sp);
 
-         }
-       }
-
-       /*
-       if (fveto_sp.isValid()) {
-         std::cout << "Veto SP Association is valid! Size = " << fveto_sp.size() << std::endl;
-         //for (unsigned i = 0; i < fveto_sp.size(); i++) {
-         // Should have just one vector of possible space points
-         const std::vector<art::Ptr<sbnd::crt::CRTSpacePoint>> &theseSpacePoints = fveto_sp.at(0);
-           if (theseSpacePoints.size() == 0) {
-	     std::cout << " No Veto SpacePoints" << std::endl; 
-             vetoSpacePoints.emplace_back(); // nullptr
-           }
-           else if (theseSpacePoints.size() > 0) {
-             //vetoSpacePoints.push_back(*fveto_sp.at(i).at(0));
-             for (auto const& sp: theseSpacePoints) {
-	       vetoSpacePoints.push_back(*sp);
-             }
-           }
-         }
-	 */
-	  //srsbndcrtveto.emplace_back();
-	
-          FillSBNDCRTVeto(sbndcrtvetos[0], vetoSpacePoints, srsbndcrtveto);
+            }
+          }
+	}
+        FillSBNDCRTVeto(sbndcrtvetos[0], vetoSpacePoints, srsbndcrtveto);
       }
-      else {
-        std::cout << "Invalid CRT Veto Handle!" << std::endl;
-	return;
-      }
-      std::cout << std::endl;	
-      std::cout << std::endl;	
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << "/------------- DEBUG DEBUG DEBUG DEBUG ------------------------ //" << std::endl;
-      std::cout << std::endl;	
-      std::cout << std::endl;	
     }
 
   // Get all of the CRTPMT Matches
@@ -2445,12 +2385,6 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 
   }  // end loop over slices
 
-  std::cout << std::endl;
-  std::cout << std::endl;
-  std::cout << "// -------------- DEBUG FILL REC TREE --------------------- //" <<std::endl;
-  std::cout << "V0 " << srsbndcrtveto.V0 << std::endl;
-  std::cout << std::endl;
-  std::cout << std::endl;
   //#######################################################
   //  Fill rec Tree
   //#######################################################
@@ -2477,12 +2411,6 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   rec.crtpmt_matches = srcrtpmtmatches;
   rec.ncrtpmt_matches = srcrtpmtmatches.size();
 
-  std::cout << std::endl;
-  std::cout << std::endl;
-  std::cout << "// -------------- DEBUG After FILL REC TREE --------------------- //" <<std::endl;
-  std::cout << "V0 " << rec.sbnd_crt_veto.V0 << std::endl;
-  std::cout << std::endl;
-  std::cout << std::endl;
   // Fix the Reference time
   //
   // We want MC and Data to have the same reference time.

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -141,6 +141,18 @@ namespace caf
     srsbndcrttrack.tof      = track.ToF();
   }
 
+  void FillSBNDCRTVeto(const sbnd::crt::CRTVeto &veto,
+                        caf::SRSBNDCRTVeto &srsbndcrtveto,
+                        bool allowEmpty)
+  {
+    std::cout << "DEBUGGING!!!! veto.V0 " << veto.V0() << std::endl;
+    srsbndcrtveto.V0     = veto.V0();
+    srsbndcrtveto.V1     = veto.V1();
+    srsbndcrtveto.V2     = veto.V2();
+    srsbndcrtveto.V3     = veto.V3();
+    srsbndcrtveto.V4     = veto.V4();
+  }
+
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,
 		       caf::SRCRTPMTMatch &srmatch,
 		       bool allowEmpty){

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -153,23 +153,11 @@ namespace caf
     srsbndcrtveto.V4     = veto.V4();
 
     // add the CRTSpacePoint associations to the SR Veto
-    //std::vector<SRCRTSpacePoint> srvetopoints;
-    // TODO --> Figure out if we want all SpacePoint Info or a subset
-    // Going with subset for now
-
-    //for (long unsigned int i = 0; i < points.size(); ++i) {
-      //SRCRTSpacePoint this_srsp;
-      //FillCRTSpacePoint(points.at(i), this_srsp);
-      //srvetopoints.push_back(this_srsp)
-    int counter = 0;
     for(auto const& sp : points) {
       srsbndcrtveto.sp_position.emplace_back(sp.X(), sp.Y(), sp.Z());   
       srsbndcrtveto.sp_time.emplace_back(sp.Ts0());   
       srsbndcrtveto.sp_pe.emplace_back(sp.PE());   
-      std::cout << "Veto SP X " << srsbndcrtveto.sp_position[counter].x << std::endl;
-      counter += 1;
     }
-    //srsbndcrtveto.crtveto_points = srvetopoints;
   }
 
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -142,15 +142,34 @@ namespace caf
   }
 
   void FillSBNDCRTVeto(const sbnd::crt::CRTVeto &veto,
-                        caf::SRSBNDCRTVeto &srsbndcrtveto,
-                        bool allowEmpty)
+                       const std::vector<sbnd::crt::CRTSpacePoint> &points,
+                       caf::SRSBNDCRTVeto &srsbndcrtveto,
+                       bool allowEmpty)
   {
-    std::cout << "DEBUGGING!!!! veto.V0 " << veto.V0() << std::endl;
     srsbndcrtveto.V0     = veto.V0();
     srsbndcrtveto.V1     = veto.V1();
     srsbndcrtveto.V2     = veto.V2();
     srsbndcrtveto.V3     = veto.V3();
     srsbndcrtveto.V4     = veto.V4();
+
+    // add the CRTSpacePoint associations to the SR Veto
+    //std::vector<SRCRTSpacePoint> srvetopoints;
+    // TODO --> Figure out if we want all SpacePoint Info or a subset
+    // Going with subset for now
+
+    //for (long unsigned int i = 0; i < points.size(); ++i) {
+      //SRCRTSpacePoint this_srsp;
+      //FillCRTSpacePoint(points.at(i), this_srsp);
+      //srvetopoints.push_back(this_srsp)
+    int counter = 0;
+    for(auto const& sp : points) {
+      srsbndcrtveto.sp_position.emplace_back(sp.X(), sp.Y(), sp.Z());   
+      srsbndcrtveto.sp_time.emplace_back(sp.Ts0());   
+      srsbndcrtveto.sp_pe.emplace_back(sp.PE());   
+      std::cout << "Veto SP X " << srsbndcrtveto.sp_position[counter].x << std::endl;
+      counter += 1;
+    }
+    //srsbndcrtveto.crtveto_points = srvetopoints;
   }
 
   void FillCRTPMTMatch(const sbn::crt::CRTPMTMatching &match,

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -40,6 +40,7 @@
 #include "sbnobj/Common/CRT/CRTTrack.hh"
 #include "sbnobj/SBND/CRT/CRTSpacePoint.hh"
 #include "sbnobj/SBND/CRT/CRTTrack.hh"
+#include "sbnobj/SBND/CRT/CRTVeto.hh"
 #include "sbnobj/Common/CRT/CRTPMTMatching.hh"
 #include "sbnobj/Common/CRT/CRTHitT0TaggingInfo.hh"
 #include "sbnobj/Common/PMT/Data/PMTBeamSignal.hh"
@@ -252,6 +253,10 @@ namespace caf
 
   void FillSBNDCRTTrack(const sbnd::crt::CRTTrack &track,
                         caf::SRSBNDCRTTrack &srsbndcrttrack,
+                        bool allowEmpty = false);
+  
+  void FillSBNDCRTVeto(const sbnd::crt::CRTVeto &veto,
+                        caf::SRSBNDCRTVeto &srsbndcrtveto,
                         bool allowEmpty = false);
 
   void FillICARUSOpFlash(const recob::OpFlash &flash,

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -256,8 +256,9 @@ namespace caf
                         bool allowEmpty = false);
   
   void FillSBNDCRTVeto(const sbnd::crt::CRTVeto &veto,
-                        caf::SRSBNDCRTVeto &srsbndcrtveto,
-                        bool allowEmpty = false);
+		       const std::vector<sbnd::crt::CRTSpacePoint> &points,
+                       caf::SRSBNDCRTVeto &srsbndcrtveto,
+                       bool allowEmpty = false);
 
   void FillICARUSOpFlash(const recob::OpFlash &flash,
                   std::vector<recob::OpHit const*> const& hits,


### PR DESCRIPTION
### Description 
Please provide a detailed description of the changes this pull request introduces. If available, also link to a docdb link where the issue/change have been presented on/discussed.

This PR adds the SBND CRT Veto from reco2 to CAF. It needs a Standard Record CRT Veto class to propagate the Veto variables. This adds branches to the recTree that consist of boolean values at the Event level and limited information related to the CRT SpacePoints that were involved in triggering the analysis veto. Here is a link to the original PR for reco2:  https://github.com/SBNSoftware/sbndcode/pull/707

Additionally, here is a docdb entry: SBN Document 40318-v1

Checklist Items: 

- [yes] Have you added a label? (bug/enhancement/physics etc.)
- [yes] Have you assigned at least 1 reviewer?
- [maybe] Is this PR related to an open issue / project?
- May be part of the Spring Production ?
- [yes] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- May need to update reviewers?
- [yes] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
-  It requires sbnanobj: https://github.com/SBNSoftware/sbnanaobj/pull/159/
- [No] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
