### PR TITLE
Update CAFMaker to fill new trigger variables

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -417,6 +417,30 @@ namespace caf
       "emuTriggerUnshifted"
     };
 
+    Atom<art::InputTag> MonPulsesTriggerLabel {
+      Name("MonPulsesTriggerLabel"),
+      Comment("Label of trigger emulation product MonPulses (number of PMT pairs above threshold for all channels) for all flashes."),
+      art::InputTag("opdaq", "MonPulses", "DetSim")
+    };
+
+    Atom<art::InputTag> MonPulseSizesTriggerLabel {
+      Name("MonPulseSizesTriggerLabel"),
+      Comment("Label of trigger emulation product MonPulses Sizes, which gives the length of each trigger response in MonPulses."),
+      art::InputTag("opdaq", "MonPulseSizes", "DetSim")
+    };
+
+    Atom<art::InputTag> PairsTriggerLabel {
+      Name("PairsTriggerLabel"),
+      Comment("Label of number of PMT pairs over threshold."),
+      art::InputTag("opdaq", "pairsOverThreshold", "DetSim")
+    };
+
+    Atom<art::InputTag> EmulatedTriggerLabel {
+      Name("EmulatedTriggerLabel"),
+      Comment("Label of bool of passing the trigger."),
+      art::InputTag("opdaq", "triggerEmulation", "DetSim")
+    };
+
     Atom<string> FlashTrigLabel {
       Name("FlashTrigLabel"),
       Comment("Label of bool of passing flash trigger."),

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1606,6 +1606,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   GetByLabelStrict(evt, fParams.TriggerLabel().encode(), extratrig_handle);
 
   art::Handle<std::vector<raw::Trigger>> trig_handle;
+  std::cout<<"Trigger label: "<<fParams.TriggerLabel()<<std::endl;
   GetByLabelStrict(evt, fParams.TriggerLabel().encode(), trig_handle);
 
   art::Handle<std::vector<raw::Trigger>> unshifted_trig_handle;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1600,29 +1600,52 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   //#######################################################
   // Fill detector & reco
   //#######################################################
-
+  
   //Beam gate and Trigger info
   art::Handle<sbn::ExtraTriggerInfo> extratrig_handle;
   GetByLabelStrict(evt, fParams.TriggerLabel().encode(), extratrig_handle);
 
   art::Handle<std::vector<raw::Trigger>> trig_handle;
-  std::cout<<"Trigger label: "<<fParams.TriggerLabel()<<std::endl;
   GetByLabelStrict(evt, fParams.TriggerLabel().encode(), trig_handle);
 
   art::Handle<std::vector<raw::Trigger>> unshifted_trig_handle;
   if (!isRealData)
     GetByLabelStrict(evt, fParams.UnshiftedTriggerLabel().encode(), unshifted_trig_handle);
 
+  //Trigger emulation handles
+  art::Handle<std::vector<int>> monpulses_handle;
+  GetByLabelStrict(evt, fParams.MonPulsesTriggerLabel().encode(), monpulses_handle);
+
+  art::Handle<std::vector<int>> monpulse_sizes_handle;
+  GetByLabelStrict(evt, fParams.MonPulseSizesTriggerLabel().encode(), monpulse_sizes_handle);
+
+  art::Handle<int> pairs_handle;
+  GetByLabelStrict(evt, fParams.PairsTriggerLabel().encode(), pairs_handle);
+
+  art::Handle<bool> trigemu_handle;
+  GetByLabelStrict(evt, fParams.EmulatedTriggerLabel().encode(), trigemu_handle);
+
+  // Check trigger handles
   const bool isValidTrigger = extratrig_handle.isValid() && trig_handle.isValid() && trig_handle->size() == 1;
   const bool isValidUnshiftedTrigger = unshifted_trig_handle.isValid() && unshifted_trig_handle->size() == 1;
+  const bool isValidEmulationTrigger = monpulses_handle.isValid() && monpulse_sizes_handle.isValid() && pairs_handle.isValid() && trigemu_handle.isValid();
 
   const double triggerShift = (isValidUnshiftedTrigger && isValidTrigger)?
     unshifted_trig_handle->at(0).TriggerTime() - trig_handle->at(0).TriggerTime() : 0.;
+
+  // Fill local ExtraTriggerInfo struct
+  sbn::ExtraTriggerInfo extratrig;
+  if (extratrig_handle.isValid()) extratrig = *extratrig_handle;
 
   caf::SRTrigger srtrigger;
   if (isValidTrigger) {
       FillTrigger(*extratrig_handle, trig_handle->at(0), srtrigger, triggerShift);
   }
+  // Fill trigger emulation information
+  if (isValidEmulationTrigger) { 
+      FillTriggerEmulation(monpulses_handle, monpulse_sizes_handle, pairs_handle, trigemu_handle, srtrigger);
+  }
+
   // If not real data, fill in enough of the SRTrigger to make (e.g.) the CRT
   // time referencing work. TODO: add more stuff to a "MC"-Trigger?
   // No longer needed with incorporation of trigger emulation in the MC.

--- a/sbncode/CAFMaker/CMakeLists.txt
+++ b/sbncode/CAFMaker/CMakeLists.txt
@@ -36,6 +36,7 @@ art_make_library( LIBRARY_NAME sbncode_CAFMaker
                   sbnobj::Common_Reco
                   sbnobj::Common_Analysis
                   sbnobj::Common_PMT_Data
+                  sbnobj::Common_Trigger
                   sbnobj::SBND_CRT
                   sbnobj::SBND_Timing
                   lardataalg::DetectorInfo

--- a/sbncode/CAFMaker/FillTrigger.cxx
+++ b/sbncode/CAFMaker/FillTrigger.cxx
@@ -24,11 +24,6 @@ namespace caf
     triggerInfo.gate_count = addltrig_info.gateCount;
     triggerInfo.gate_delta = addltrig_info.gateCountFromPreviousTrigger;
 
-    triggerInfo.passed_trigger = addltrig_info.triggerEmulation;
-    triggerInfo.num_pairs_over_threshold = addltrig_info.pairsOverThreshold;
-    triggerInfo.monpulses_flat = addltrig_info.MonPulses;
-    triggerInfo.monpulse_sizes = addltrig_info.MonPulseSizes;
-
   }
 
   void FillTriggerMC(double absolute_time, caf::SRTrigger& triggerInfo) {
@@ -47,6 +42,19 @@ namespace caf
     
     double diff_ts = triggerInfo.global_trigger_det_time - triggerInfo.beam_gate_det_time;
     triggerInfo.trigger_within_gate = diff_ts;
+  }
+
+  void FillTriggerEmulation(art::Handle<std::vector<int>> const& monpulsesFlat,
+                             art::Handle<std::vector<int>> const& monpulseSizes,
+                             art::Handle<int> const& numPairs,
+                             art::Handle<bool> const& passedTrig,
+                             caf::SRTrigger& triggerInfo) {
+
+    triggerInfo.monpulses_flat = *monpulsesFlat;
+    triggerInfo.monpulse_sizes = *monpulseSizes;
+    triggerInfo.num_pairs_over_threshold = *numPairs;
+    triggerInfo.passed_trigger = *passedTrig;
+
   }
 
 }

--- a/sbncode/CAFMaker/FillTrigger.cxx
+++ b/sbncode/CAFMaker/FillTrigger.cxx
@@ -23,6 +23,12 @@ namespace caf
     triggerInfo.trigger_count = addltrig_info.triggerCount;
     triggerInfo.gate_count = addltrig_info.gateCount;
     triggerInfo.gate_delta = addltrig_info.gateCountFromPreviousTrigger;
+
+    triggerInfo.passed_trigger = addltrig_info.triggerEmulation;
+    triggerInfo.num_pairs_over_threshold = addltrig_info.pairsOverThreshold;
+    triggerInfo.monpulses_flat = addltrig_info.MonPulses;
+    triggerInfo.monpulse_sizes = addltrig_info.MonPulseSizes;
+
   }
 
   void FillTriggerMC(double absolute_time, caf::SRTrigger& triggerInfo) {
@@ -32,7 +38,6 @@ namespace caf
     // Set this to 0 since the "MC" trigger is (for now) always at the spill time
     triggerInfo.trigger_within_gate = 0.;
 
-    // TODO: fill others?
   }
 
   void FillTriggerSBND(caf::SRSBNDTimingInfo& timingInfo, caf::SRTrigger& triggerInfo){

--- a/sbncode/CAFMaker/FillTrigger.h
+++ b/sbncode/CAFMaker/FillTrigger.h
@@ -6,6 +6,7 @@
 #include "sbnanaobj/StandardRecord/SRTrigger.h"
 #include "sbnanaobj/StandardRecord/SRSBNDTimingInfo.h"
 #include "lardataobj/RawData/TriggerData.h"
+#include "art/Framework/Principal/Handle.h"
 
 #include <vector>
 
@@ -20,6 +21,12 @@ namespace caf
   void FillTriggerMC(double absolute_time, caf::SRTrigger& triggerInfo);
 
   void FillTriggerSBND(caf::SRSBNDTimingInfo& timingInfo, caf::SRTrigger& triggerInfo);
+
+  void FillTriggerEmulation(art::Handle<std::vector<int>> const& monpulsesFlat,
+                             art::Handle<std::vector<int>> const& monpulseSizes,
+                             art::Handle<int> const& numPairs,
+                             art::Handle<bool> const& passedTrig,
+                             caf::SRTrigger& triggerInfo);
 }
 
 #endif


### PR DESCRIPTION
### Description 
This includes updates to FillTrigger.cxx to take trigger data products from detsim to be able to put them in the cafs: the variables include a bool of passed/failed trigger, number of PMT pairs over threshold, and two variables for the purpose of validation giving us the trigger response in a flattened vector and the size of the pulses (so the vector can be un-flattened).

This pull request must be merged after the [detsim updates](https://github.com/SBNSoftware/sbndcode/pull/830) and with the other updates for the CAF files: [sbnanaobj](https://github.com/SBNSoftware/sbnanaobj/pull/161) and [sbnobj](https://github.com/SBNSoftware/sbnobj/pull/146).

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [X] Is this PR related to an open issue / project?
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [X] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
