### PR TITLE
Add PTB HLT and LLT information to CAF files for real SBND data

### DIFF
--- a/sbncode/BeamSpillInfoRetriever/POTTools.cpp
+++ b/sbncode/BeamSpillInfoRetriever/POTTools.cpp
@@ -20,11 +20,11 @@ namespace sbn::pot{
             if (ctb_frag.Trigger(word_i)->IsHLT() && ctb_frag.Trigger(word_i)->IsTrigger(HLT))
             {
               foundHLT = true;
-              uint64_t RawprevPTBTimeStamp = ctb_frag.PTBWord(word_i)->prevTS * 20;
-              uint64_t RawcurrPTBTimeStamp = ctb_frag.Trigger(word_i)->timestamp * 20;
-              double currTS_candidate = std::bitset<64>(RawcurrPTBTimeStamp/20).to_ullong()/50e6;
+              uint64_t RawprevPTBTimeStamp = ctb_frag.PTBWord(word_i)->prevTS;
+              uint64_t RawcurrPTBTimeStamp = ctb_frag.Trigger(word_i)->timestamp;
+              std::uint64_t currTS_candidate = std::bitset<64>(RawcurrPTBTimeStamp).to_ullong() * 20;
               if(currTS_candidate < PTBInfo.currPTBTimeStamp){
-                PTBInfo.prevPTBTimeStamp = std::bitset<64>(RawprevPTBTimeStamp / 20).to_ullong()/50e6;
+                PTBInfo.prevPTBTimeStamp = std::bitset<64>(RawprevPTBTimeStamp).to_ullong() * 20;
                 PTBInfo.currPTBTimeStamp = currTS_candidate;
                 PTBInfo.GateCounter = ctb_frag.Trigger(word_i)->gate_counter;
               }
@@ -43,9 +43,9 @@ namespace sbn::pot{
     }
   }
 
-  std::vector<PTBInfo_t> extractAllPTBInfo(art::Handle<std::vector<artdaq::Fragment> > cont_frags) {
+  std::vector<PTBInfo_t> extractAllPTBInfo(std::vector<artdaq::Fragment> const& cont_frags) {
     std::vector<PTBInfo_t> PTBInfoVec;
-    for (auto const& cont : *cont_frags)
+    for (auto const& cont : cont_frags)
     {
       artdaq::ContainerFragment cont_frag(cont);
       for (size_t fragi = 0; fragi < cont_frag.block_count(); ++fragi)
@@ -58,9 +58,8 @@ namespace sbn::pot{
             PTBInfo_t PTBInfo;
             uint64_t RawprevPTBTimeStamp = ctb_frag.PTBWord(word_i)->prevTS;
             uint64_t RawcurrPTBTimeStamp = ctb_frag.Trigger(word_i)->timestamp;
-            double currTS_candidate = std::bitset<64>(RawcurrPTBTimeStamp).to_ullong()/50e6;
-            PTBInfo.prevPTBTimeStamp = std::bitset<64>(RawprevPTBTimeStamp).to_ullong()/50e6;
-            PTBInfo.currPTBTimeStamp = currTS_candidate;
+            PTBInfo.prevPTBTimeStamp = std::bitset<64>(RawprevPTBTimeStamp).to_ullong() * 20;
+            PTBInfo.currPTBTimeStamp = std::bitset<64>(RawcurrPTBTimeStamp).to_ullong() * 20;
             PTBInfo.GateCounter = ctb_frag.Trigger(word_i)->gate_counter;
             PTBInfo.isHLT = ctb_frag.Trigger(word_i)->IsHLT();
             PTBInfo.triggerWord = ctb_frag.Trigger(word_i)->trigger_word;

--- a/sbncode/BeamSpillInfoRetriever/POTTools.h
+++ b/sbncode/BeamSpillInfoRetriever/POTTools.h
@@ -18,16 +18,16 @@
 namespace sbn::pot{
 
   typedef struct PTBInfo_t {
-    double currPTBTimeStamp  = 1e20;
-    double prevPTBTimeStamp  = 0;
+    std::uint64_t currPTBTimeStamp  = UINT64_MAX;  ///< Timestamp in UTC nanoseconds since Unix epoch (converted from 20ns clock ticks)
+    std::uint64_t prevPTBTimeStamp  = 0; 
     unsigned int GateCounter = 0;
     bool isHLT = false;            
-    uint64_t triggerWord = 0;        
+    uint64_t triggerWord = 0;  ///< Timestamp in s since beam extraction signal
   } PTBInfo_t;
 
   typedef struct TriggerInfo_t {
     int gate_type = 0; ///< Source of the spill: `1`: BNB, `2`: NuMI
-    double t_current_event  = 0;
+    double t_current_event  = 0;  ///< Timestamp in UTC seconds since Unix epoch (converted from 20ns clock ticks)
     double t_previous_event = 0;
     unsigned int number_of_gates_since_previous_event = 0;
     std::int64_t WR_to_Spill_conversion = 0;
@@ -52,7 +52,7 @@ namespace sbn::pot{
    * @param cont_frags The PTB fragments to examine.
    * @return Vector of PTBInfo_t containing all triggers found.
    */
-  std::vector<PTBInfo_t> extractAllPTBInfo(art::Handle<std::vector<artdaq::Fragment> > cont_frags);
+  std::vector<PTBInfo_t> extractAllPTBInfo(std::vector<artdaq::Fragment> const& cont_frags);
 
   /**
    * @brief Extracts information from TDC for use in SBND POT accounting.

--- a/sbncode/BeamSpillInfoRetriever/POTTools.h
+++ b/sbncode/BeamSpillInfoRetriever/POTTools.h
@@ -13,6 +13,7 @@
 
 #include "sbncode/BeamSpillInfoRetriever/MWRData.h"
 #include "larcorealg/CoreUtils/counter.h"
+#include <vector>
 
 namespace sbn::pot{
 
@@ -20,6 +21,8 @@ namespace sbn::pot{
     double currPTBTimeStamp  = 1e20;
     double prevPTBTimeStamp  = 0;
     unsigned int GateCounter = 0;
+    bool isHLT = false;            
+    uint64_t triggerWord = 0;        
   } PTBInfo_t;
 
   typedef struct TriggerInfo_t {
@@ -36,12 +39,20 @@ namespace sbn::pot{
   } MWRdata_t;
 
   /**
-   * @brief Extracts information from PTB for use in SBND POT accounting.
+   * @brief Extracts information from PTB for a single HLT for use in SBND POT accounting.
    * 
    * @param cont_frags The PTB fragments to examine.
    * @param HLT The high level trigger we are searching for.
    */
   PTBInfo_t extractPTBInfo(art::Handle<std::vector<artdaq::Fragment> > cont_frags, int HLT);
+
+  /**
+   * @brief Extracts ALL PTB information for using in SBND CAF files.
+   * 
+   * @param cont_frags The PTB fragments to examine.
+   * @return Vector of PTBInfo_t containing all triggers found.
+   */
+  std::vector<PTBInfo_t> extractAllPTBInfo(art::Handle<std::vector<artdaq::Fragment> > cont_frags);
 
   /**
    * @brief Extracts information from TDC for use in SBND POT accounting.

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBRetriever/SBNDBNBRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBRetriever/SBNDBNBRetriever_module.cc
@@ -123,13 +123,13 @@ sbn::pot::TriggerInfo_t sbn::SBNDBNBRetriever::extractTriggerInfo(art::Event con
   else{
     // If missing TDC, use PTB instead
     mf::LogDebug("SBNDBNBRetriever") << " Missing TDC Container Fragments!!! " << std::endl;
-    triggerInfo.t_current_event = PTBInfo.currPTBTimeStamp - fBESOffset;
+    triggerInfo.t_current_event = PTBInfo.currPTBTimeStamp / 1e9 - fBESOffset;
   }
 
-  triggerInfo.t_previous_event = PTBInfo.prevPTBTimeStamp - fBESOffset;
+  triggerInfo.t_previous_event = PTBInfo.prevPTBTimeStamp / 1e9 - fBESOffset;
   triggerInfo.number_of_gates_since_previous_event = PTBInfo.GateCounter;
 
-  double PTBandCurrOffset = PTBInfo.currPTBTimeStamp - triggerInfo.t_current_event - fBESOffset;
+  double PTBandCurrOffset = PTBInfo.currPTBTimeStamp / 1e9 - triggerInfo.t_current_event - fBESOffset;
 
   // Catch for an issue seen a few times where PTB off by a second.
   // Only need to correct prevTS because either currTS is from TDC

--- a/sbncode/BeamSpillInfoRetriever/SBNDBNBZEROBIASRetriever/SBNDBNBZEROBIASRetriever_module.cc
+++ b/sbncode/BeamSpillInfoRetriever/SBNDBNBZEROBIASRetriever/SBNDBNBZEROBIASRetriever_module.cc
@@ -126,13 +126,13 @@ sbn::pot::TriggerInfo_t sbn::SBNDBNBZEROBIASRetriever::extractTriggerInfo(art::E
   else{
     // If missing TDC, use PTB instead
     mf::LogDebug("SBNDBNBZEROBIASRetriever") << " Missing TDC Container Fragments!!!" << std::endl;
-    triggerInfo.t_current_event = PTBInfo.currPTBTimeStamp - fBESOffset;
+    triggerInfo.t_current_event = PTBInfo.currPTBTimeStamp / 1e9 - fBESOffset;
   }
 
-  triggerInfo.t_previous_event = PTBInfo.prevPTBTimeStamp - fBESOffset;
+  triggerInfo.t_previous_event = PTBInfo.prevPTBTimeStamp / 1e9 - fBESOffset;
   triggerInfo.number_of_gates_since_previous_event = PTBInfo.GateCounter;
 
-  double PTBandCurrOffset = PTBInfo.currPTBTimeStamp - triggerInfo.t_current_event - fBESOffset;
+  double PTBandCurrOffset = PTBInfo.currPTBTimeStamp / 1e9 - triggerInfo.t_current_event - fBESOffset;
 
   // Catch for an issue seen a few times where PTB off by a second.
   // Only need to correct prevTS because either currTS is from TDC

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1380,6 +1380,7 @@ bool CAFMaker::GetPsetParameter(const fhicl::ParameterSet& pset,
 
 //......................................................................
 void CAFMaker::produce(art::Event& evt) noexcept {
+  mf::LogInfo("CAFMaker") << "CAFMaker::produce called for event: " << evt.id();
 
   bool const firstInFile = (fIndexInFile++ == 0);
 
@@ -1720,13 +1721,14 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     art::Handle<artdaq::Fragments> ptb_frags_handle;
     evt.getByLabel(PTB_itag, ptb_frags_handle);
     if (ptb_frags_handle.isValid()) {
-      try {
-        std::vector<sbn::pot::PTBInfo_t> ptb_triggers = sbn::pot::extractAllPTBInfo(ptb_frags_handle);
-        FillPTBTriggersSBND(ptb_triggers, srtrigger);
-      }
-      catch (...) {
-        std::cout << "CAFMaker: Failed to extract PTB triggers" << std::endl;
-      }
+      mf::LogDebug("CAFMaker") << "Found ContainerPTB, extracting PTB triggers...";
+      std::vector<sbn::pot::PTBInfo_t> ptb_triggers = sbn::pot::extractAllPTBInfo(*ptb_frags_handle);
+      mf::LogDebug("CAFMaker") << "Extracted " << ptb_triggers.size() << " PTB triggers";
+      FillPTBTriggersSBND(ptb_triggers, srtrigger);
+      mf::LogDebug("CAFMaker") << "PTB HLT triggers: " << srtrigger.ptb_hlt_timestamp.size() 
+                                << ", LLT triggers: " << srtrigger.ptb_llt_timestamp.size();
+    } else {
+      mf::LogDebug("CAFMaker") << "ContainerPTB not found for event " << evt.id();
     }
   }
 

--- a/sbncode/CAFMaker/CMakeLists.txt
+++ b/sbncode/CAFMaker/CMakeLists.txt
@@ -50,6 +50,7 @@ art_make_library( LIBRARY_NAME sbncode_CAFMaker
                   ${GENIE_LIB_LIST}
                   nugen::EventGeneratorBase_GENIE
                   sbndaq_artdaq_core::sbndaq-artdaq-core_Obj_SBND
+                  sbn_POTTools
                   )
 
 cet_build_plugin ( CAFMaker art::module

--- a/sbncode/CAFMaker/FillTrigger.cxx
+++ b/sbncode/CAFMaker/FillTrigger.cxx
@@ -73,4 +73,28 @@ namespace caf
     caf_softInfo.flash_peakpe = softInfo.peakPE;
     caf_softInfo.flash_peaktime = softInfo.peaktime + softInfo.trig_ts*1e-3; 
   }
+
+  void FillPTBTriggersSBND(const std::vector<sbn::pot::PTBInfo_t>& ptb_triggers, caf::SRTrigger& triggerInfo) {
+    triggerInfo.ptb_hlt_timestamp.clear();
+    triggerInfo.ptb_hlt_bit.clear();
+    triggerInfo.ptb_llt_timestamp.clear();
+    triggerInfo.ptb_llt_bit.clear();
+    
+    // Decode trigger words: each set bit becomes a separate entry with the same timestamp
+    for(const auto& trig : ptb_triggers) {
+      std::uint64_t triggerWord = trig.triggerWord;
+      for(int bit = 0; bit < 64; ++bit) {
+        std::uint64_t bitMask = 1ULL << bit;
+        if(triggerWord & bitMask) {
+          if(trig.isHLT) {
+            triggerInfo.ptb_hlt_timestamp.push_back(trig.currPTBTimeStamp);
+            triggerInfo.ptb_hlt_bit.push_back(bit);
+          } else {
+            triggerInfo.ptb_llt_timestamp.push_back(trig.currPTBTimeStamp);
+            triggerInfo.ptb_llt_bit.push_back(bit);
+          }
+        }
+      }
+    }
+  }
 }

--- a/sbncode/CAFMaker/FillTrigger.h
+++ b/sbncode/CAFMaker/FillTrigger.h
@@ -9,6 +9,7 @@
 #include "lardataobj/RawData/TriggerData.h"
 #include "art/Framework/Principal/Handle.h"
 #include "sbndaq-artdaq-core/Obj/SBND/pmtSoftwareTrigger.hh"
+#include "sbncode/BeamSpillInfoRetriever/POTTools.h"
 
 namespace caf
 {
@@ -30,6 +31,8 @@ namespace caf
                              art::Handle<bool> const& passedTrig,
                              caf::SRTrigger& triggerInfo);
   void FillSoftwareTriggerSBND(const sbnd::trigger::pmtSoftwareTrigger& softInfo, caf::SRSoftwareTrigger& caf_softInfo);
+  
+  void FillPTBTriggersSBND(const std::vector<sbn::pot::PTBInfo_t>& ptb_triggers, caf::SRTrigger& triggerInfo);
 }
 
 #endif


### PR DESCRIPTION
### Description
This PR adds PTB information to CAF files for real SBND data, which is required for trigger efficiency studies using zero bias data. The implementation extracts all HLT (High Level Trigger) and LLT (Low Level Trigger) information from PTB fragments, decodes trigger words into individual bits, and stores them separately in the CAF structure. This PR requires merging https://github.com/SBNSoftware/sbnanaobj/pull/180

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [X] Is this PR related to an open issue / project?
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [X] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
