### PR TITLE
Handle CAF making when Pandora runs after the NuGraph2 filter

### DIFF
--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -350,10 +350,10 @@ namespace caf
       "" //Empty by default, configured in icaruscode cafmaker_defs
     };
 
-    Atom<art::InputTag> NuGraphSliceHitLabel {
-      Name("NuGraphSliceHitLabel"),
-      Comment("Label of NuGraph slice hit map."),
-      "" //Empty by default, please set to e.g. art::InputTag("nuslhits")
+    Atom<art::InputTag> NCCSlicesLabel {
+      Name("NCCSlicesLabel"),
+      Comment("Label of NotClearCosmic slices."),
+      "" //Empty by default, please set to e.g. art::InputTag("NCCSlices")
     };
 
     Atom<art::InputTag> NuGraphFilterLabel {

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -374,6 +374,12 @@ namespace caf
       false
     };
     
+    Atom<float> NuGraphFilterCut {
+      Name("NuGraphFilterCut"),
+      Comment("Cut on the NuGraph2 filter score to define hit as signal or noise."),
+      0.5
+    };
+
     Atom<float> NuGraphHIPTagWireDist {
       Name("NuGraphHIPTagWireDist"),
       Comment("TPC wire distance from the vertex used to count NuGraph2–tagged HIP hits."),

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -368,6 +368,12 @@ namespace caf
       "" //Empty by default, please set to e.g. art::InputTag("NuGraph","semantic")
     };
 
+    Atom<bool> UsePandoraAfterNuGraph {
+      Name("UsePandoraAfterNuGraph"),
+      Comment("Whether to use the second pass Pandora outputs for NuGraph reco."),
+      false
+    };
+
     Atom<string> OpFlashLabel {
       Name("OpFlashLabel"),
       Comment("Label of PMT flash."),

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -373,6 +373,18 @@ namespace caf
       Comment("Whether to use the second pass Pandora outputs for NuGraph reco."),
       false
     };
+    
+    Atom<float> NuGraphHIPTagWireDist {
+      Name("NuGraphHIPTagWireDist"),
+      Comment("TPC wire distance from the vertex used to count NuGraph2–tagged HIP hits."),
+      10
+    };
+
+    Atom<float> NuGraphHIPTagTickDist {
+      Name("NuGraphHIPTagTickDist"),
+      Comment("TPC tick distance from the vertex used to count NuGraph-2–tagged HIP hits."),
+      50
+    };
 
     Atom<string> OpFlashLabel {
       Name("OpFlashLabel"),

--- a/sbncode/CAFMaker/CAFMakerParams.h
+++ b/sbncode/CAFMaker/CAFMakerParams.h
@@ -350,9 +350,9 @@ namespace caf
       "" //Empty by default, configured in icaruscode cafmaker_defs
     };
 
-    Atom<art::InputTag> NCCSlicesLabel {
-      Name("NCCSlicesLabel"),
-      Comment("Label of NotClearCosmic slices."),
+    Atom<art::InputTag> NuGraphSlicesLabel {
+      Name("NuGraphSlicesLabel"),
+      Comment("Label of slices that have NuGraph inference."),
       "" //Empty by default, please set to e.g. art::InputTag("NCCSlices")
     };
 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1797,39 +1797,6 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       }
     }
     
-    // if (std::find(nuGraphSlices.begin(), nuGraphSlices.end(), slice) != nuGraphSlices.end()) {
-    //   std::vector<art::Ptr<anab::FeatureVector<1>>> ng2_filter_vec;
-    //   std::vector<art::Ptr<anab::FeatureVector<5>>> ng2_semantic_vec;
-    //   art::FindOneP<anab::FeatureVector<1>> findOneFilter(slcHits, evt, fParams.NuGraphFilterLabel().label() + slice_tag_suff + ":" + fParams.NuGraphFilterLabel().instance());
-    //   art::FindOneP<anab::FeatureVector<5>> findOneSemantic(slcHits, evt, fParams.NuGraphSemanticLabel().label() + slice_tag_suff + ":" + fParams.NuGraphSemanticLabel().instance());
-
-    //   if (findOneFilter.isValid()) {
-    //     for (size_t hitIdx = 0; hitIdx < slcHits.size(); ++hitIdx) {
-    //       if (findOneFilter.at(hitIdx).isNull()) {
-    //         slcHits.erase(slcHits.begin()+hitIdx);
-    //         hitIdx--;
-    //         continue; 
-    //       }
-    //       ng2_filter_vec.emplace_back(findOneFilter.at(hitIdx));
-    //     }
-    //   }
-
-    //   if (findOneSemantic.isValid()) {
-    //     for (size_t hitIdx = 0; hitIdx < slcHits.size(); ++hitIdx) {
-    //       if (findOneSemantic.at(hitIdx).isNull()) {
-    //         slcHits.erase(slcHits.begin()+hitIdx);
-    //         hitIdx--;
-    //         continue;
-    //       }
-    //       ng2_semantic_vec.emplace_back(findOneSemantic.at(hitIdx));
-    //     }
-    //   }
-
-    //   if (ng2_filter_vec.size() > 0 || ng2_semantic_vec.size() > 0) {
-    //     FillSliceNuGraph(slcHits, ng2_filter_vec, ng2_semantic_vec, recslc);
-    //   }
-    // }
-
     art::FindManyP<sbn::OpT0Finder> fmOpT0 =
       FindManyPStrict<sbn::OpT0Finder>(sliceList, evt, fParams.OpT0Label() + slice_tag_suff);
     std::vector<art::Ptr<sbn::OpT0Finder>> slcOpT0;

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1727,8 +1727,10 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     GetByLabelStrict(evt, fParams.PFParticleLabel() + pandora_tag_suffix, thisSlices);
     if (thisSlices.isValid()) {
       art::fill_ptr_vector(slices, thisSlices);
-      const std::vector<art::Ptr<recob::Slice>>& tempNuGraphSlices = evt.getProduct<std::vector<art::Ptr<recob::Slice>>>(fParams.NuGraphSlicesLabel().label() + pandora_tag_suffix);
-      nuGraphSlices.insert(nuGraphSlices.end(), tempNuGraphSlices.begin(), tempNuGraphSlices.end());
+      nuGraphSlices = evt.getProduct<std::vector<art::Ptr<recob::Slice>>>(fParams.NuGraphSlicesLabel().label() + pandora_tag_suffix);
+      if (fParams.UsePandoraAfterNuGraph()) {
+        nuGraphSlices = slices;
+      }
       for (unsigned i = 0; i < thisSlices->size(); i++) {
         slice_tag_suffixes.push_back(pandora_tag_suffix);
         slice_tag_indices.push_back(i_tag);

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -2127,7 +2127,9 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       }
 
       if (ng2_filter_vec.size() > 0 || ng2_semantic_vec.size() > 0) {
-        FillSliceNuGraph(slcHits, ng2_filter_vec, ng2_semantic_vec, fmPFPartHits, vtx_wire, vtx_tick, recslc);
+        FillSliceNuGraph(slcHits, ng2_filter_vec, ng2_semantic_vec, fmPFPartHits, 
+                         vtx_wire, vtx_tick, fParams.NuGraphHIPTagWireDist(), fParams.NuGraphHIPTagTickDist(), 
+                         recslc);
       }
     }
 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -2127,7 +2127,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       }
 
       if (ng2_filter_vec.size() > 0 || ng2_semantic_vec.size() > 0) {
-        FillSliceNuGraph(slcHits, ng2_filter_vec, ng2_semantic_vec, vtx_wire, vtx_tick, recslc);
+        FillSliceNuGraph(slcHits, ng2_filter_vec, ng2_semantic_vec, fmPFPartHits, vtx_wire, vtx_tick, recslc);
       }
     }
 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -1794,38 +1794,38 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       }
     }
     
-    if (std::find(nuGraphSlices.begin(), nuGraphSlices.end(), slice) != nuGraphSlices.end()) {
-      std::vector<art::Ptr<anab::FeatureVector<1>>> ng2_filter_vec;
-      std::vector<art::Ptr<anab::FeatureVector<5>>> ng2_semantic_vec;
-      art::FindOneP<anab::FeatureVector<1>> findOneFilter(slcHits, evt, fParams.NuGraphFilterLabel().label() + slice_tag_suff + ":" + fParams.NuGraphFilterLabel().instance());
-      art::FindOneP<anab::FeatureVector<5>> findOneSemantic(slcHits, evt, fParams.NuGraphSemanticLabel().label() + slice_tag_suff + ":" + fParams.NuGraphSemanticLabel().instance());
-      // iteration is the only way to get something out of a FindOne or FindMany...
-      if (findOneFilter.isValid()) {
-        for (size_t hitIdx = 0; hitIdx < slcHits.size(); ++hitIdx) {
-          if (findOneFilter.at(hitIdx).isNull()) {
-            slcHits.erase(slcHits.begin()+hitIdx);
-            hitIdx--;
-            continue; 
-          }
-          ng2_filter_vec.emplace_back(findOneFilter.at(hitIdx));
-        }
-      }
+    // if (std::find(nuGraphSlices.begin(), nuGraphSlices.end(), slice) != nuGraphSlices.end()) {
+    //   std::vector<art::Ptr<anab::FeatureVector<1>>> ng2_filter_vec;
+    //   std::vector<art::Ptr<anab::FeatureVector<5>>> ng2_semantic_vec;
+    //   art::FindOneP<anab::FeatureVector<1>> findOneFilter(slcHits, evt, fParams.NuGraphFilterLabel().label() + slice_tag_suff + ":" + fParams.NuGraphFilterLabel().instance());
+    //   art::FindOneP<anab::FeatureVector<5>> findOneSemantic(slcHits, evt, fParams.NuGraphSemanticLabel().label() + slice_tag_suff + ":" + fParams.NuGraphSemanticLabel().instance());
 
-      if (findOneSemantic.isValid()) {
-        for (size_t hitIdx = 0; hitIdx < slcHits.size(); ++hitIdx) {
-          if (findOneSemantic.at(hitIdx).isNull()) {
-            slcHits.erase(slcHits.begin()+hitIdx);
-            hitIdx--;
-            continue;
-          }
-          ng2_semantic_vec.emplace_back(findOneSemantic.at(hitIdx));
-        }
-      }
+    //   if (findOneFilter.isValid()) {
+    //     for (size_t hitIdx = 0; hitIdx < slcHits.size(); ++hitIdx) {
+    //       if (findOneFilter.at(hitIdx).isNull()) {
+    //         slcHits.erase(slcHits.begin()+hitIdx);
+    //         hitIdx--;
+    //         continue; 
+    //       }
+    //       ng2_filter_vec.emplace_back(findOneFilter.at(hitIdx));
+    //     }
+    //   }
 
-      if (ng2_filter_vec.size() > 0 || ng2_semantic_vec.size() > 0) {
-        FillSliceNuGraph(slcHits, ng2_filter_vec, ng2_semantic_vec, recslc);
-      }
-    }
+    //   if (findOneSemantic.isValid()) {
+    //     for (size_t hitIdx = 0; hitIdx < slcHits.size(); ++hitIdx) {
+    //       if (findOneSemantic.at(hitIdx).isNull()) {
+    //         slcHits.erase(slcHits.begin()+hitIdx);
+    //         hitIdx--;
+    //         continue;
+    //       }
+    //       ng2_semantic_vec.emplace_back(findOneSemantic.at(hitIdx));
+    //     }
+    //   }
+
+    //   if (ng2_filter_vec.size() > 0 || ng2_semantic_vec.size() > 0) {
+    //     FillSliceNuGraph(slcHits, ng2_filter_vec, ng2_semantic_vec, recslc);
+    //   }
+    // }
 
     art::FindManyP<sbn::OpT0Finder> fmOpT0 =
       FindManyPStrict<sbn::OpT0Finder>(sliceList, evt, fParams.OpT0Label() + slice_tag_suff);
@@ -1880,15 +1880,15 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     // make Ptr's to clusters for cluster -> other object associations
     if (fmPFPClusters.isValid()) {
       for (size_t ipf=0; ipf<fmPFPart.size();++ipf) {
-	std::vector<art::Ptr<recob::Hit>> pfphits;
-	std::vector<art::Ptr<recob::Cluster>> pfclusters = fmPFPClusters.at(ipf);
-	art::FindManyP<recob::Hit> fmCluHits = FindManyPStrict<recob::Hit>(pfclusters, evt, fParams.PFParticleLabel() + slice_tag_suff);
-	for (size_t icl=0; icl<fmCluHits.size();icl++) {
-	  for (auto hit : fmCluHits.at(icl)) {
-	    pfphits.push_back(hit);
-	  }
-	}
-	fmPFPartHits.push_back(pfphits);
+        std::vector<art::Ptr<recob::Hit>> pfphits;
+        std::vector<art::Ptr<recob::Cluster>> pfclusters = fmPFPClusters.at(ipf);
+        art::FindManyP<recob::Hit> fmCluHits = FindManyPStrict<recob::Hit>(pfclusters, evt, fParams.PFParticleLabel() + slice_tag_suff);
+        for (size_t icl=0; icl<fmCluHits.size();icl++) {
+          for (auto hit : fmCluHits.at(icl)) {
+            pfphits.push_back(hit);
+          }
+        }
+        fmPFPartHits.push_back(pfphits);
       }
     }
 
@@ -2058,8 +2058,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     // primary particle and meta-data
     const recob::PFParticle *primary = (iPart == fmPFPart.size()) ? NULL : fmPFPart[iPart].get();
     const larpandoraobj::PFParticleMetadata *primary_meta = (iPart == fmPFPart.size()) ? NULL : fmPFPMeta.at(iPart).at(0).get();
-    // get the flash match
 
+    // get the flash match
     std::map<std::string, const sbn::SimpleFlashMatch*> fmatch_map;
     std::map<std::string, art::FindManyP<sbn::SimpleFlashMatch>>::iterator fmatch_it;
     for(fmatch_it = fmatch_assn_map.begin();fmatch_it != fmatch_assn_map.end();fmatch_it++) {
@@ -2075,12 +2075,62 @@ void CAFMaker::produce(art::Event& evt) noexcept {
         }
       }
     }
+
     // get the primary vertex
     const recob::Vertex *vertex = (iPart == fmPFPart.size() || !fmVertex.at(iPart).size()) ? NULL : fmVertex.at(iPart).at(0).get();
 
     //#######################################################
     // Add slice info.
     //#######################################################
+    if (std::find(nuGraphSlices.begin(), nuGraphSlices.end(), slice) != nuGraphSlices.end()) {
+      std::vector<art::Ptr<anab::FeatureVector<1>>> ng2_filter_vec;
+      std::vector<art::Ptr<anab::FeatureVector<5>>> ng2_semantic_vec;
+      art::FindOneP<anab::FeatureVector<1>> findOneFilter(slcHits, evt, fParams.NuGraphFilterLabel().label() + slice_tag_suff + ":" + fParams.NuGraphFilterLabel().instance());
+      art::FindOneP<anab::FeatureVector<5>> findOneSemantic(slcHits, evt, fParams.NuGraphSemanticLabel().label() + slice_tag_suff + ":" + fParams.NuGraphSemanticLabel().instance());
+
+      // filter
+      if (findOneFilter.isValid()) {
+        for (size_t hitIdx = 0; hitIdx < slcHits.size(); ++hitIdx) {
+          if (findOneFilter.at(hitIdx).isNull()) {
+            slcHits.erase(slcHits.begin()+hitIdx);
+            hitIdx--;
+            continue; 
+          }
+          ng2_filter_vec.emplace_back(findOneFilter.at(hitIdx));
+        }
+      }
+
+      // semantic tagging
+      if (findOneSemantic.isValid()) {
+        for (size_t hitIdx = 0; hitIdx < slcHits.size(); ++hitIdx) {
+          if (findOneSemantic.at(hitIdx).isNull()) {
+            slcHits.erase(slcHits.begin()+hitIdx);
+            hitIdx--;
+            continue;
+          }
+          ng2_semantic_vec.emplace_back(findOneSemantic.at(hitIdx));
+        }
+      }
+
+      // vertex projection onto the three wire planes
+      float vtx_wire[3];
+      float vtx_tick[3];
+
+      if (vertex != NULL) {
+        auto const& tpcID = geom->FindTPCAtPosition(vertex->position());
+        for (geo::PlaneID const& p : wireReadout.Iterate<geo::PlaneID>()) {
+          auto const& planeID = geo::PlaneID{tpcID, p.Plane};
+          const geo::PlaneGeo& planeGeo = wireReadout.Plane(planeID);
+          vtx_wire[p.Plane] = planeGeo.WireCoordinate(vertex->position()); ///< wire projection
+          vtx_tick[p.Plane] = dprop.ConvertXToTicks(vertex->position().X(), planeID); ///< drift projection
+        }
+      }
+
+      if (ng2_filter_vec.size() > 0 || ng2_semantic_vec.size() > 0) {
+        FillSliceNuGraph(slcHits, ng2_filter_vec, ng2_semantic_vec, vtx_wire, vtx_tick, recslc);
+      }
+    }
+
     FillSliceVars(*slice, primary, producer, recslc);
     FillSliceMetadata(primary_meta, recslc);
     FillSliceFlashMatch(fmatch_map["fmatch"], recslc.fmatch);

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -2080,11 +2080,13 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 
       if (vertex != NULL) {
         auto const& tpcID = geom->FindTPCAtPosition(vertex->position());
-        for (geo::PlaneID const& p : wireReadout.Iterate<geo::PlaneID>()) {
-          auto const& planeID = geo::PlaneID{tpcID, p.Plane};
-          const geo::PlaneGeo& planeGeo = wireReadout.Plane(planeID);
-          vtx_wire[p.Plane] = planeGeo.WireCoordinate(vertex->position()); ///< wire projection
-          vtx_tick[p.Plane] = dprop.ConvertXToTicks(vertex->position().X(), planeID); ///< drift projection
+        if (tpcID.isValid) {
+          for (geo::PlaneID const& p : wireReadout.Iterate<geo::PlaneID>()) {
+            auto const& planeID = geo::PlaneID{tpcID, p.Plane};
+            const geo::PlaneGeo& planeGeo = wireReadout.Plane(planeID);
+            vtx_wire[p.Plane] = planeGeo.WireCoordinate(vertex->position()); ///< wire projection
+            vtx_tick[p.Plane] = dprop.ConvertXToTicks(vertex->position().X(), planeID); ///< drift projection
+          }
         }
       }
 

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -2095,6 +2095,21 @@ void CAFMaker::produce(art::Event& evt) noexcept {
                          vtx_wire, vtx_tick, fParams.NuGraphHIPTagWireDist(), fParams.NuGraphHIPTagTickDist(), 
                          fParams.NuGraphFilterCut(), recslc);
       }
+
+      // overwrite the `ng_filt_pass_frac` variable with post-NuGraph2-filtering 
+      if (fParams.UsePandoraAfterNuGraph()) {
+        art::Handle<std::vector<anab::FeatureVector<1>>> ngFilterVecHandle;
+        evt.getByLabel(art::InputTag("NGMultiSlice" + slice_tag_suff, "filter"), ngFilterVecHandle);
+        art::Handle<std::vector<recob::Hit>> ngFilteredHitsHandle;
+        GetByLabelStrict(evt, "ngfilteredhits" + slice_tag_suff, ngFilteredHitsHandle);
+        if (
+          ngFilterVecHandle.isValid() && 
+          ngFilteredHitsHandle.isValid() &&
+          ngFilterVecHandle->size() > 0) {
+          recslc.ng_filt_pass_frac = float(ngFilteredHitsHandle->size()) / float(ngFilterVecHandle->size());
+        }
+      }
+
     }
 
     FillSliceVars(*slice, primary, producer, recslc);

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -2102,10 +2102,9 @@ void CAFMaker::produce(art::Event& evt) noexcept {
         evt.getByLabel(art::InputTag("NGMultiSlice" + slice_tag_suff, "filter"), ngFilterVecHandle);
         art::Handle<std::vector<recob::Hit>> ngFilteredHitsHandle;
         GetByLabelStrict(evt, "ngfilteredhits" + slice_tag_suff, ngFilteredHitsHandle);
-        if (
-          ngFilterVecHandle.isValid() && 
-          ngFilteredHitsHandle.isValid() &&
-          ngFilterVecHandle->size() > 0) {
+        if (ngFilterVecHandle.isValid() && 
+            ngFilteredHitsHandle.isValid() &&
+            ngFilterVecHandle->size() > 0) {
           recslc.ng_filt_pass_frac = float(ngFilteredHitsHandle->size()) / float(ngFilterVecHandle->size());
         }
       }

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -592,8 +592,6 @@ namespace caf
     unsigned int nHits = inputHits.size();
     unsigned int npass = 0;
 
-    std::cout << "number of hits: " << nHits << std::endl;
-
     for ( unsigned int i = 0; i < nHits; i++ ) {
       if (ngFilterResult.at(i)->at(0)>=ng_filter_cut) npass++;
     }
@@ -602,7 +600,7 @@ namespace caf
     // nugraph HIP vertex tagging
     for (unsigned int plane = 0; plane < 3; ++plane) {
 
-      unsigned int nHIPHits = 0;
+      int nHIPHits = 0;
 
       for ( unsigned int i = 0; i < nHits; i++ ) {
         const recob::Hit& hit = *inputHits.at(i);

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -611,9 +611,13 @@ namespace caf
     // NuGraph2 plane-by-plane slice variables
     for (unsigned int plane = 0; plane < 3; ++plane) {
 
-      int nHIPHits = 0;             ///< HIP tagging at interaction vertex
-      int nShrHits = 0;             ///< shower hits in the slice
-      int nUnclusteredShrHits = 0;  ///< shower hits in the slice not belonging to a PFP
+      int nMIPHits = 0;             ///< `MIP` hits in the slice
+      int nHIPHits = 0;             ///< `HIP` hits in the slice
+      int nShrHits = 0;             ///< `Shower` hits in the slice
+      int nMhlHits = 0;             ///< `Michel` hits in the slice
+      int nDifHits = 0;             ///< `Diffuse` hits in the slice
+      int nVtxHIPHits = 0;          ///< `HIP` hits in the slice around the vertex
+      int nUnclusteredShrHits = 0;  ///< `Shower` hits in the slice not belonging to a PFP
 
       for ( unsigned int i = 0; i < nHits; i++ ) {
         const recob::Hit& hit = *inputHits.at(i);
@@ -629,28 +633,51 @@ namespace caf
           std::max_element(semVec.begin(), semVec.end())
         );
 
-        // HIP tagging
-        float dwire = std::abs(float(hit.WireID().Wire) - vtx_wire[plane]);
-        float dtick = std::abs(hit.PeakTime() - vtx_tick[plane]);
-        if ((highestScoreIdx == 1) && (dwire <= vtx_wire_dist) && (dtick <= vtx_tick_dist))
+        // `MIP` hits
+        if (highestScoreIdx == SRNuGraphScore::NuGraphCategory::MIP) {
+          nMIPHits += 1;
+        }
+
+        // `HIP` hits
+        if (highestScoreIdx == SRNuGraphScore::NuGraphCategory::HIP) {
           nHIPHits += 1;
 
-        // shower hits
-        if (highestScoreIdx == 2) {
+          // `HIP` hits at vertex
+          float dwire = std::abs(float(hit.WireID().Wire) - vtx_wire[plane]);
+          float dtick = std::abs(hit.PeakTime() - vtx_tick[plane]);    
+          if ((dwire <= vtx_wire_dist) && (dtick <= vtx_tick_dist)) {
+            nVtxHIPHits += 1;
+          }
+        }
 
-          // all shower hits
+        // `Shower` hits
+        if (highestScoreIdx == SRNuGraphScore::NuGraphCategory::Shower) {
           nShrHits += 1;
 
-          // unclustered shower hits
+          // `Shower` hits not clustered by Pandora
           art::Ptr<recob::Hit> hitPtr = inputHits.at(i);
           if (pfpHitSet.find(hitPtr) == pfpHitSet.end()) {
             nUnclusteredShrHits += 1;
           }
         }
+
+        // `Michel` hits
+        if (highestScoreIdx == SRNuGraphScore::NuGraphCategory::Michel) {
+          nMhlHits += 1;
+        }
+
+        // `Diffuse` hits
+        if (highestScoreIdx == SRNuGraphScore::NuGraphCategory::Diffuse) {
+          nDifHits += 1;
+        }
       }
 
-      slice.ng_plane[plane].ng_vtx_hip_hits = nHIPHits;
+      slice.ng_plane[plane].mip_hits = nMIPHits;
+      slice.ng_plane[plane].hip_hits = nHIPHits;
       slice.ng_plane[plane].shr_hits = nShrHits;
+      slice.ng_plane[plane].mhl_hits = nMhlHits;
+      slice.ng_plane[plane].dif_hits = nDifHits;
+      slice.ng_plane[plane].ng_vtx_hip_hits = nVtxHIPHits;
       slice.ng_plane[plane].unclustered_shr_hits = nUnclusteredShrHits;
     }
   }

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -586,6 +586,8 @@ namespace caf
       const std::vector<std::vector<art::Ptr<recob::Hit>>> &fmPFPartHits,
       const float vtx_wire[3], 
       const float vtx_tick[3],
+      const float vtx_wire_dist, 
+      const float vtx_tick_dist,
 			caf::SRSlice &slice)
   {
 
@@ -628,7 +630,7 @@ namespace caf
         // HIP tagging
         float dwire = std::abs(float(hit.WireID().Wire) - vtx_wire[plane]);
         float dtick = std::abs(hit.PeakTime() - vtx_tick[plane]);
-        if ((highestScoreIdx == 1) && (dwire <= 10) && (dtick <= 50))
+        if ((highestScoreIdx == 1) && (dwire <= vtx_wire_dist) && (dtick <= vtx_tick_dist))
           nHIPHits += 1;
 
         // shower hits

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -116,6 +116,7 @@ namespace caf
    * @param vtx_tick vertex coordinates projected onto ticks, per plane
    * @param vtx_wire_dist TPC wire distance from the vertex used to count NuGraph2–tagged HIP hits
    * @param vtx_tick_dist TPC tick distance from the vertex used to count NuGraph2–tagged HIP hits
+   * @param filter_cut cut on the NuGraph2 filter score to define hit as signal or noise
    * @param[out] slice the destination slice object
    *
    * Hits with filter value (`ngFilterResult`) lower than `ng_filter_cut` are counted as background.
@@ -128,6 +129,7 @@ namespace caf
                         const float vtx_tick[3],
                         const float vtx_wire_dist, 
                         const float vtx_tick_dist,
+                        const float filter_cut,
                         caf::SRSlice &slice);
 
   bool SelectSlice(const caf::SRSlice &slice, bool cut_clear_cosmic);
@@ -161,6 +163,7 @@ namespace caf
    * @param sliceHitsMap maps position of hits in collection input to NuGraph (slice only) to the one input to Pandora (all gaus hits)
    * @param ngFilterResult NuGraph filter result, for each hit
    * @param ngSemanticResult NuGraph semnatic result, for each hit (MIP track, HIP, shower, Michel electron, diffuse activity)
+   * @param filter_cut cut on the NuGraph2 filter score to define hit as signal or noise
    * @param pfpHits Vector of hits associated to the PFParticle
    * @param[out] srpfp the destination PFParticle object
    *
@@ -169,6 +172,7 @@ namespace caf
   void FillPFPNuGraph(const std::vector<art::Ptr<recob::Hit>> &pfpHits,
 		      const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
 		      const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
+          const float filter_cut,
 		      caf::SRPFP& srpfp,
 		      bool allowEmpty= false);
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -114,17 +114,21 @@ namespace caf
    * @param fmPFPartHits vector of pointers-to-hits lists, for each PFP
    * @param vtx_wire vertex coordinates projected onto wires, per plane
    * @param vtx_tick vertex coordinates projected onto ticks, per plane
+   * @param vtx_wire_dist TPC wire distance from the vertex used to count NuGraph2–tagged HIP hits
+   * @param vtx_tick_dist TPC tick distance from the vertex used to count NuGraph2–tagged HIP hits
    * @param[out] slice the destination slice object
    *
    * Hits with filter value (`ngFilterResult`) lower than `ng_filter_cut` are counted as background.
    */
   void FillSliceNuGraph(const std::vector<art::Ptr<recob::Hit>> &inputHits,
-			const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
-			const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
-      const std::vector<std::vector<art::Ptr<recob::Hit>>> &fmPFPartHits,
-      const float vtx_wire[3], 
-      const float vtx_tick[3],
-			caf::SRSlice &slice);
+                        const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
+                        const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
+                        const std::vector<std::vector<art::Ptr<recob::Hit>>> &fmPFPartHits,
+                        const float vtx_wire[3], 
+                        const float vtx_tick[3],
+                        const float vtx_wire_dist, 
+                        const float vtx_tick_dist,
+                        caf::SRSlice &slice);
 
   bool SelectSlice(const caf::SRSlice &slice, bool cut_clear_cosmic);
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -110,7 +110,8 @@ namespace caf
    * @brief Fills the results from NuGraph at slice level
    * @param inputHits (pointers to) the hits associated to the slice
    * @param ngFilterResult NuGraph filter result, for each hit
-   * @param ngSemanticResult NuGraph semnatic result, for each hit (MIP track, HIP, shower, Michel electron, diffuse activity)
+   * @param ngSemanticResult NuGraph semantic result, for each hit (MIP track, HIP, shower, Michel electron, diffuse activity)
+   * @param fmPFPartHits vector of pointers-to-hits lists, for each PFP
    * @param vtx_wire vertex coordinates projected onto wires, per plane
    * @param vtx_tick vertex coordinates projected onto ticks, per plane
    * @param[out] slice the destination slice object
@@ -120,6 +121,7 @@ namespace caf
   void FillSliceNuGraph(const std::vector<art::Ptr<recob::Hit>> &inputHits,
 			const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
 			const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
+      const std::vector<std::vector<art::Ptr<recob::Hit>>> &fmPFPartHits,
       const float vtx_wire[3], 
       const float vtx_tick[3],
 			caf::SRSlice &slice);

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -109,9 +109,10 @@ namespace caf
   /**
    * @brief Fills the results from NuGraph at slice level
    * @param inputHits (pointers to) the hits associated to the slice
-   * @param sliceHitsMap maps position of hits in collection input to NuGraph (slice only) to the one input to Pandora (all gaus hits)
    * @param ngFilterResult NuGraph filter result, for each hit
    * @param ngSemanticResult NuGraph semnatic result, for each hit (MIP track, HIP, shower, Michel electron, diffuse activity)
+   * @param vtx_wire vertex coordinates projected onto wires, per plane
+   * @param vtx_tick vertex coordinates projected onto ticks, per plane
    * @param[out] slice the destination slice object
    *
    * Hits with filter value (`ngFilterResult`) lower than `ng_filter_cut` are counted as background.
@@ -119,6 +120,8 @@ namespace caf
   void FillSliceNuGraph(const std::vector<art::Ptr<recob::Hit>> &inputHits,
 			const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
 			const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
+      const float vtx_wire[3], 
+      const float vtx_tick[3],
 			caf::SRSlice &slice);
 
   bool SelectSlice(const caf::SRSlice &slice, bool cut_clear_cosmic);

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -117,7 +117,6 @@ namespace caf
    * Hits with filter value (`ngFilterResult`) lower than `ng_filter_cut` are counted as background.
    */
   void FillSliceNuGraph(const std::vector<art::Ptr<recob::Hit>> &inputHits,
-			const std::vector<unsigned int> &sliceHitsMap,
 			const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
 			const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
 			caf::SRSlice &slice);
@@ -158,10 +157,9 @@ namespace caf
    *
    * Hits with filter value (`ngFilterResult`) lower than `ng_filter_cut` are counted as background.
    */
-  void FillPFPNuGraph(const std::vector<unsigned int> &sliceHitsMap,
+  void FillPFPNuGraph(const std::vector<art::Ptr<recob::Hit>> &pfpHits,
 		      const std::vector<art::Ptr<anab::FeatureVector<1>>> &ngFilterResult,
 		      const std::vector<art::Ptr<anab::FeatureVector<5>>> &ngSemanticResult,
-		      const std::vector<art::Ptr<recob::Hit>> &pfpHits,
 		      caf::SRPFP& srpfp,
 		      bool allowEmpty= false);
 


### PR DESCRIPTION
This PR adds a mode governed by the `UsePandoraAfterNuGraph` FHiCL flag to handle NuGraph2 variables in the CAF maker, when using a second-pass Pandora after filtering noise with NuGraph2, based on work by summer intern Leonardo Lena. 

This PR also provides code to fill new NuGraph2 slice-level variables in CAF files.

Relevant information about the NuGraph2 chain is provided in [icaruscode PR #868](https://github.com/SBNSoftware/icaruscode/pull/868). 
___
### Associated PRs
- https://github.com/SBNSoftware/sbnanaobj/pull/183
- https://github.com/SBNSoftware/icaruscode/pull/868

___
### Review
Tagging for review @acampani and @PetrilloAtWork as reconstruction and infrastructure experts. Thanks a lot!
___
### Description 
Please provide a detailed description of the changes this pull request introduces. If available, also link to a docdb link where the issue/change have been presented on/discussed.

- [x] Have you added a label? (bug/enhancement/physics etc.)
- [x] Have you assigned at least 1 reviewer?
- [] Is this PR related to an open issue / project?
- [x] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [x] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [x] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
