### PR TITLE
SBND Timing Reconstruction Refactor

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -327,8 +327,8 @@ class CAFMaker : public art::EDProducer {
   void FixPMTReferenceTimes(StandardRecord &rec, double PMT_reference_time);
   void FixCRTReferenceTimes(StandardRecord &rec, double CRTT0_reference_time, double CRTT1_reference_time);
 
-  void SBNDShiftCRTReference(StandardRecord &rec, double SBNDFrame) const;
-  void SBNDShiftPMTReference(StandardRecord &rec, double SBNDFrame) const;
+  //void SBNDShiftCRTReference(StandardRecord &rec, double SBNDFrame) const;
+  //void SBNDShiftPMTReference(StandardRecord &rec, double SBNDFrame) const;
 
   /// Equivalent of FindManyP except a return that is !isValid() prints a
   /// messsage and aborts if StrictMode is true.
@@ -516,43 +516,43 @@ void CAFMaker::BlindEnergyParameters(StandardRecord* brec) {
   }
 }
 
-void CAFMaker::SBNDShiftCRTReference(StandardRecord &rec, double SBNDFrame) const {
-
-  //CRT Space Point
-  for (SRCRTSpacePoint &sp: rec.crt_spacepoints){
-    sp.time += SBNDFrame; //ns
-  }
-  
-  //CRT Track
-  for (SRSBNDCRTTrack &trk: rec.sbnd_crt_tracks){
-    trk.time += SBNDFrame; //ns
-  }
-
-  //TODO: CRT Space Point and Track Match
-  for (SRSlice &slc: rec.slc){
-    for (SRPFP &pfp: slc.reco.pfp){
-      if(!std::isnan(pfp.trk.crtspacepoint.score)) pfp.trk.crtspacepoint.spacepoint.time += SBNDFrame;
-
-      if(!std::isnan(pfp.trk.crtsbndtrack.score)) pfp.trk.crtsbndtrack.track.time += SBNDFrame;
-    }
-  }
-}
-
-void CAFMaker::SBNDShiftPMTReference(StandardRecord &rec, double SBNDFrame) const {
-
-  double SBNDFrame_us = SBNDFrame / 1000.0; //convert ns to us
-
-  //Op Flash
-  for (SROpFlash &opf: rec.opflashes) {
-    opf.time += SBNDFrame_us;
-    opf.firsttime += SBNDFrame_us;
-  }
-  
-  //OpT0 match to slice
-  for (SRSlice &s: rec.slc) {
-    s.opt0.time += SBNDFrame_us;
-  }
-}
+//void CAFMaker::SBNDShiftCRTReference(StandardRecord &rec, double SBNDFrame) const {
+//
+//  //CRT Space Point
+//  for (SRCRTSpacePoint &sp: rec.crt_spacepoints){
+//    sp.time += SBNDFrame; //ns
+//  }
+//  
+//  //CRT Track
+//  for (SRSBNDCRTTrack &trk: rec.sbnd_crt_tracks){
+//    trk.time += SBNDFrame; //ns
+//  }
+//
+//  //TODO: CRT Space Point and Track Match
+//  for (SRSlice &slc: rec.slc){
+//    for (SRPFP &pfp: slc.reco.pfp){
+//      if(!std::isnan(pfp.trk.crtspacepoint.score)) pfp.trk.crtspacepoint.spacepoint.time += SBNDFrame;
+//
+//      if(!std::isnan(pfp.trk.crtsbndtrack.score)) pfp.trk.crtsbndtrack.track.time += SBNDFrame;
+//    }
+//  }
+//}
+//
+//void CAFMaker::SBNDShiftPMTReference(StandardRecord &rec, double SBNDFrame) const {
+//
+//  double SBNDFrame_us = SBNDFrame / 1000.0; //convert ns to us
+//
+//  //Op Flash
+//  for (SROpFlash &opf: rec.opflashes) {
+//    opf.time += SBNDFrame_us;
+//    opf.firsttime += SBNDFrame_us;
+//  }
+//  
+//  //OpT0 match to slice
+//  for (SRSlice &s: rec.slc) {
+//    s.opt0.time += SBNDFrame_us;
+//  }
+//}
 
 void CAFMaker::FixPMTReferenceTimes(StandardRecord &rec, double PMT_reference_time) {
   // Fix the flashes
@@ -2587,27 +2587,27 @@ void CAFMaker::produce(art::Event& evt) noexcept {
 
   // TODO: TPC?
   
-  // SBND: Fix the Reference time in data depending on the stream
-  // For more information, see: 
-  // https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=43090
+  //// SBND: Fix the Reference time in data depending on the stream
+  //// For more information, see: 
+  //// https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=43090
 
-  if (isRealData && (fDet == kSBND) && fSubRunPOT > 0)
-  {
-    // Fill trigger info
-    FillTriggerSBND(srsbndtiminginfo, srtrigger);
+  //if (isRealData && (fDet == kSBND) && fSubRunPOT > 0)
+  //{
+  //  // Fill trigger info
+  //  FillTriggerSBND(srsbndtiminginfo, srtrigger);
 
-    // Shift timing reference frame
-    if (!std::isnan(rec.sbnd_frames.frameApplyAtCaf) && (rec.sbnd_frames.frameApplyAtCaf != 0.0)){
-      mf::LogInfo("CAFMaker") << "Setting Reference Timing for timing object in SBND \n"
-                              << "    Shift Apply At Caf Level = " << rec.sbnd_frames.frameApplyAtCaf << " ns\n";
-      
-      //shift reference frame for CRT objects: crt trk, crt sp, crt sp match, crt trk match
-      SBNDShiftCRTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
+  //  // Shift timing reference frame
+  //  if (!std::isnan(rec.sbnd_frames.frameApplyAtCaf) && (rec.sbnd_frames.frameApplyAtCaf != 0.0)){
+  //    mf::LogInfo("CAFMaker") << "Setting Reference Timing for timing object in SBND \n"
+  //                            << "    Shift Apply At Caf Level = " << rec.sbnd_frames.frameApplyAtCaf << " ns\n";
+  //    
+  //    //shift reference frame for CRT objects: crt trk, crt sp, crt sp match, crt trk match
+  //    SBNDShiftCRTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
 
-      //shift reference frame for PMT objects: opflash, opt0
-      SBNDShiftPMTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
-    }
-  }
+  //    //shift reference frame for PMT objects: opflash, opt0
+  //    SBNDShiftPMTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
+  //  }
+  //}
 
   // Get metadata information for header
   unsigned int run = evt.run();

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -327,8 +327,8 @@ class CAFMaker : public art::EDProducer {
   void FixPMTReferenceTimes(StandardRecord &rec, double PMT_reference_time);
   void FixCRTReferenceTimes(StandardRecord &rec, double CRTT0_reference_time, double CRTT1_reference_time);
 
-  //void SBNDShiftCRTReference(StandardRecord &rec, double SBNDFrame) const;
-  //void SBNDShiftPMTReference(StandardRecord &rec, double SBNDFrame) const;
+  void SBNDShiftCRTReference(StandardRecord &rec, double SBNDFrame) const;
+  void SBNDShiftPMTReference(StandardRecord &rec, double SBNDFrame) const;
 
   /// Equivalent of FindManyP except a return that is !isValid() prints a
   /// messsage and aborts if StrictMode is true.
@@ -516,43 +516,43 @@ void CAFMaker::BlindEnergyParameters(StandardRecord* brec) {
   }
 }
 
-//void CAFMaker::SBNDShiftCRTReference(StandardRecord &rec, double SBNDFrame) const {
-//
-//  //CRT Space Point
-//  for (SRCRTSpacePoint &sp: rec.crt_spacepoints){
-//    sp.time += SBNDFrame; //ns
-//  }
-//  
-//  //CRT Track
-//  for (SRSBNDCRTTrack &trk: rec.sbnd_crt_tracks){
-//    trk.time += SBNDFrame; //ns
-//  }
-//
-//  //TODO: CRT Space Point and Track Match
-//  for (SRSlice &slc: rec.slc){
-//    for (SRPFP &pfp: slc.reco.pfp){
-//      if(!std::isnan(pfp.trk.crtspacepoint.score)) pfp.trk.crtspacepoint.spacepoint.time += SBNDFrame;
-//
-//      if(!std::isnan(pfp.trk.crtsbndtrack.score)) pfp.trk.crtsbndtrack.track.time += SBNDFrame;
-//    }
-//  }
-//}
-//
-//void CAFMaker::SBNDShiftPMTReference(StandardRecord &rec, double SBNDFrame) const {
-//
-//  double SBNDFrame_us = SBNDFrame / 1000.0; //convert ns to us
-//
-//  //Op Flash
-//  for (SROpFlash &opf: rec.opflashes) {
-//    opf.time += SBNDFrame_us;
-//    opf.firsttime += SBNDFrame_us;
-//  }
-//  
-//  //OpT0 match to slice
-//  for (SRSlice &s: rec.slc) {
-//    s.opt0.time += SBNDFrame_us;
-//  }
-//}
+void CAFMaker::SBNDShiftCRTReference(StandardRecord &rec, double SBNDFrame) const {
+
+  //CRT Space Point
+  for (SRCRTSpacePoint &sp: rec.crt_spacepoints){
+    sp.time += SBNDFrame; //ns
+  }
+  
+  //CRT Track
+  for (SRSBNDCRTTrack &trk: rec.sbnd_crt_tracks){
+    trk.time += SBNDFrame; //ns
+  }
+
+  //TODO: CRT Space Point and Track Match
+  for (SRSlice &slc: rec.slc){
+    for (SRPFP &pfp: slc.reco.pfp){
+      if(!std::isnan(pfp.trk.crtspacepoint.score)) pfp.trk.crtspacepoint.spacepoint.time += SBNDFrame;
+
+      if(!std::isnan(pfp.trk.crtsbndtrack.score)) pfp.trk.crtsbndtrack.track.time += SBNDFrame;
+    }
+  }
+}
+
+void CAFMaker::SBNDShiftPMTReference(StandardRecord &rec, double SBNDFrame) const {
+
+  double SBNDFrame_us = SBNDFrame / 1000.0; //convert ns to us
+
+  //Op Flash
+  for (SROpFlash &opf: rec.opflashes) {
+    opf.time += SBNDFrame_us;
+    opf.firsttime += SBNDFrame_us;
+  }
+  
+  //OpT0 match to slice
+  for (SRSlice &s: rec.slc) {
+    s.opt0.time += SBNDFrame_us;
+  }
+}
 
 void CAFMaker::FixPMTReferenceTimes(StandardRecord &rec, double PMT_reference_time) {
   // Fix the flashes
@@ -2586,28 +2586,21 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   FixPMTReferenceTimes(rec, PMT_reference_time);
 
   // TODO: TPC?
-  
-  //// SBND: Fix the Reference time in data depending on the stream
-  //// For more information, see: 
-  //// https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=43090
+ 
 
-  //if (isRealData && (fDet == kSBND) && fSubRunPOT > 0)
-  //{
-  //  // Fill trigger info
-  //  FillTriggerSBND(srsbndtiminginfo, srtrigger);
+  if (isRealData && (fDet == kSBND))
+  {
+    // Fill trigger info
+    FillTriggerSBND(srsbndtiminginfo, srtrigger);
 
-  //  // Shift timing reference frame
-  //  if (!std::isnan(rec.sbnd_frames.frameApplyAtCaf) && (rec.sbnd_frames.frameApplyAtCaf != 0.0)){
-  //    mf::LogInfo("CAFMaker") << "Setting Reference Timing for timing object in SBND \n"
-  //                            << "    Shift Apply At Caf Level = " << rec.sbnd_frames.frameApplyAtCaf << " ns\n";
-  //    
-  //    //shift reference frame for CRT objects: crt trk, crt sp, crt sp match, crt trk match
-  //    SBNDShiftCRTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
+    //// Legacy: Timing correction is being done at decoding/reconstruction level
+    //// SBND: Fix the Reference time in data depending on the stream
+    ////shift reference frame for CRT objects: crt trk, crt sp, crt sp match, crt trk match
+    //SBNDShiftCRTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
 
-  //    //shift reference frame for PMT objects: opflash, opt0
-  //    SBNDShiftPMTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
-  //  }
-  //}
+    ////shift reference frame for PMT objects: opflash, opt0
+    //SBNDShiftPMTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
+  }
 
   // Get metadata information for header
   unsigned int run = evt.run();

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -2656,11 +2656,9 @@ void CAFMaker::produce(art::Event& evt) noexcept {
     // Fill trigger info
     FillTriggerSBND(srsbndtiminginfo, srtrigger);
 
-    //// Legacy: Timing correction is being done at decoding/reconstruction level
-    //// SBND: Fix the Reference time in data depending on the stream
+    //// Legacy code: Timing correction is now done at decoding/reconstruction level
     ////shift reference frame for CRT objects: crt trk, crt sp, crt sp match, crt trk match
     //SBNDShiftCRTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
-
     ////shift reference frame for PMT objects: opflash, opt0
     //SBNDShiftPMTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
   }

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -2655,12 +2655,6 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   {
     // Fill trigger info
     FillTriggerSBND(srsbndtiminginfo, srtrigger);
-
-    //// Legacy code: Timing correction is now done at decoding/reconstruction level
-    ////shift reference frame for CRT objects: crt trk, crt sp, crt sp match, crt trk match
-    //SBNDShiftCRTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
-    ////shift reference frame for PMT objects: opflash, opt0
-    //SBNDShiftPMTReference(rec, rec.sbnd_frames.frameApplyAtCaf);
   }
 
   // Get metadata information for header

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -192,14 +192,22 @@ namespace caf
                         caf::SRSBNDFrameShiftInfo &srsbndframe,
                         bool allowEmpty)
   {
-    std::cout << "FIX ME: FillSBNDFrameShiftInfo" << std::endl;
-    //srsbndframe.timingType = frame.TimingType();
-    //srsbndframe.frameTdcCrtt1 = frame.FrameTdcCrtt1();
-    //srsbndframe.frameTdcBes = frame.FrameTdcBes();
-    //srsbndframe.frameTdcRwm = frame.FrameTdcRwm();
-    //srsbndframe.frameHltCrtt1 = frame.FrameHltCrtt1();
-    //srsbndframe.frameHltBeamGate = frame.FrameHltBeamGate();
-    //srsbndframe.frameApplyAtCaf = frame.FrameApplyAtCaf();
+    srsbndframe.frameCrtt1         = frame.FrameCrtt1();
+    srsbndframe.timingTypeCrtt1    = frame.TimingTypeCrtt1();
+    srsbndframe.timingChannelCrtt1 = frame.TimingChannelCrtt1();
+
+    srsbndframe.frameBeamGate         = frame.FrameBeamGate();
+    srsbndframe.timingTypeBeamGate    = frame.TimingTypeBeamGate();
+    srsbndframe.timingChannelBeamGate = frame.TimingChannelBeamGate();
+
+    srsbndframe.frameEtrig         = frame.FrameEtrig();
+    srsbndframe.timingTypeEtrig    = frame.TimingTypeEtrig();
+    srsbndframe.timingChannelEtrig = frame.TimingChannelEtrig();
+
+    srsbndframe.frameDefault         = frame.FrameDefault();
+    srsbndframe.timingTypeDefault    = frame.TimingTypeDefault();
+    srsbndframe.timingChannelDefault = frame.TimingChannelDefault();
+
   }
 
   void FillSBNDTimingInfo(const sbnd::timing::TimingInfo &timing,

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -192,13 +192,14 @@ namespace caf
                         caf::SRSBNDFrameShiftInfo &srsbndframe,
                         bool allowEmpty)
   {
-    srsbndframe.timingType = frame.TimingType();
-    srsbndframe.frameTdcCrtt1 = frame.FrameTdcCrtt1();
-    srsbndframe.frameTdcBes = frame.FrameTdcBes();
-    srsbndframe.frameTdcRwm = frame.FrameTdcRwm();
-    srsbndframe.frameHltCrtt1 = frame.FrameHltCrtt1();
-    srsbndframe.frameHltBeamGate = frame.FrameHltBeamGate();
-    srsbndframe.frameApplyAtCaf = frame.FrameApplyAtCaf();
+    std::cout << "FIX ME: FillSBNDFrameShiftInfo" << std::endl;
+    //srsbndframe.timingType = frame.TimingType();
+    //srsbndframe.frameTdcCrtt1 = frame.FrameTdcCrtt1();
+    //srsbndframe.frameTdcBes = frame.FrameTdcBes();
+    //srsbndframe.frameTdcRwm = frame.FrameTdcRwm();
+    //srsbndframe.frameHltCrtt1 = frame.FrameHltCrtt1();
+    //srsbndframe.frameHltBeamGate = frame.FrameHltBeamGate();
+    //srsbndframe.frameApplyAtCaf = frame.FrameApplyAtCaf();
   }
 
   void FillSBNDTimingInfo(const sbnd::timing::TimingInfo &timing,

--- a/sbncode/CAFMaker/FillTrigger.cxx
+++ b/sbncode/CAFMaker/FillTrigger.cxx
@@ -39,13 +39,21 @@ namespace caf
   }
 
   void FillTriggerSBND(caf::SRSBNDTimingInfo& timingInfo, caf::SRTrigger& triggerInfo){
-      
-    triggerInfo.global_trigger_time = timingInfo.hltEtrig;
-    triggerInfo.beam_gate_time_abs = timingInfo.hltBeamGate;
-    std::cout << "triggerInfo.global_trigger_det_time: " << triggerInfo.global_trigger_det_time << std::endl;
-	std::cout << "triggerInfo.beam_gate_det_time: " << triggerInfo.beam_gate_det_time << std::endl;
-    double diff_ts = triggerInfo.global_trigger_det_time - triggerInfo.beam_gate_det_time;
-	std::cout << "diff_ts: " << diff_ts << std::endl;
+
+    if (timingInfo.hltEtrig != std::numeric_limits<uint64_t>::max()) triggerInfo.global_trigger_time = timingInfo.hltEtrig;
+    if (timingInfo.hltBeamGate != std::numeric_limits<uint64_t>::max()) triggerInfo.beam_gate_time_abs = timingInfo.hltBeamGate;
+
+    double diff_ts = std::numeric_limits<double>::max();
+
+    if ((triggerInfo.global_trigger_time != std::numeric_limits<uint64_t>::max()) & (triggerInfo.beam_gate_time_abs != std::numeric_limits<uint64_t>::max())){
+
+      if (triggerInfo.global_trigger_time > triggerInfo.beam_gate_time_abs){
+        diff_ts = triggerInfo.global_trigger_time - triggerInfo.beam_gate_time_abs;
+      }
+      else{
+        diff_ts = (triggerInfo.beam_gate_time_abs - triggerInfo.global_trigger_time)*(double)-1;
+      }
+    }
     triggerInfo.trigger_within_gate = diff_ts;
   }
 

--- a/sbncode/CAFMaker/FillTrigger.cxx
+++ b/sbncode/CAFMaker/FillTrigger.cxx
@@ -61,7 +61,7 @@ namespace caf
         diff_ts = triggerInfo.global_trigger_time - triggerInfo.beam_gate_time_abs;
       }
       else{
-        diff_ts = (triggerInfo.beam_gate_time_abs - triggerInfo.global_trigger_time)*(double)-1;
+        diff_ts = -1.0 * (triggerInfo.beam_gate_time_abs - triggerInfo.global_trigger_time);
       }
     }
     triggerInfo.trigger_within_gate = diff_ts;

--- a/sbncode/CAFMaker/FillTrigger.cxx
+++ b/sbncode/CAFMaker/FillTrigger.cxx
@@ -55,7 +55,7 @@ namespace caf
 
     double diff_ts = std::numeric_limits<double>::max();
 
-    if ((triggerInfo.global_trigger_time != std::numeric_limits<uint64_t>::max()) & (triggerInfo.beam_gate_time_abs != std::numeric_limits<uint64_t>::max())){
+    if ((triggerInfo.global_trigger_time != std::numeric_limits<uint64_t>::max()) && (triggerInfo.beam_gate_time_abs != std::numeric_limits<uint64_t>::max())){
 
       if (triggerInfo.global_trigger_time > triggerInfo.beam_gate_time_abs){
         diff_ts = triggerInfo.global_trigger_time - triggerInfo.beam_gate_time_abs;


### PR DESCRIPTION
## Description 

- Timing reconstruction is refactored in this PR, affecting the decode/reconstruction workflow of CRT/PMT/XA.
- After the refactoring, the @FrameShiftModule@ runs first in the decode chain, outputs timing products to be used at PMT/XA decoder and CRTStrip reconstruction.
- Relevant PMT reconstruction modules at Reco1/Reco2 are updated.
- The timing correction applied at CAFMakeer is undone. This should ressolve this issue: https://github.com/SBNSoftware/sbncode/issues/567
- Details and validation plots can before in the linked docdb.

### Link(s) to docdb describing changes (optional)

https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=45982

### Relevant PR links (optional)

This PR needs the XA decoder PR in sbndcode to go in first:
https://github.com/SBNSoftware/sbndcode/pull/847 

This PR needs to be merged together with this group of PRs:
- sbndcode: https://github.com/SBNSoftware/sbndcode/pull/915
- sbncode: https://github.com/SBNSoftware/sbncode/pull/637
- sbnobj: https://github.com/SBNSoftware/sbnobj/pull/170
- sbnanaobj:https://github.com/SBNSoftware/sbnanaobj/pull/188

### Checklists

- [x] Have you added a label? (bug/enhancement/physics etc.)
- [x] Have you assigned at least 1 reviewer?
- [ ] Is this PR related to an open issue / project?
- [x] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [x] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [ ] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.
