### PR TITLE
Add install_headers() to CMakeLists.txt

### DIFF
--- a/sbncode/CAFMaker/RecoUtils/CMakeLists.txt
+++ b/sbncode/CAFMaker/RecoUtils/CMakeLists.txt
@@ -12,3 +12,4 @@ art_make_library( LIBRARY_NAME caf_RecoUtils
                     larsim::MCCheater_ParticleInventoryService_service
                     larcorealg::Geometry
                 )
+install_headers()


### PR DESCRIPTION
Header file missing from cvmfs, noticed during mrb build
