### PR TITLE
WireMod for SBND Gen 2 Production

### DIFF
--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -93,6 +93,7 @@
 #include "lardataobj/RecoBase/PFParticle.h"
 #include "lardataobj/RecoBase/Slice.h"
 #include "lardataobj/RecoBase/Track.h"
+#include "lardataobj/RecoBase/TrackHitMeta.h"
 #include "lardataobj/RecoBase/Vertex.h"
 #include "lardataobj/RecoBase/Shower.h"
 #include "lardataobj/RecoBase/MCSFitResult.h"
@@ -1495,7 +1496,7 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   }
 
   // Prep truth-to-reco-matching info
-  std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> id_to_ide_map;
+  std::map<int, std::vector<sbn::ReadoutIDE>>  id_to_ide_map;
   std::map<int, std::vector<art::Ptr<recob::Hit>>> id_to_truehit_map;
   std::map<int, caf::HitsEnergy> id_to_hit_energy_map;
 
@@ -2255,8 +2256,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
       FindManyPStrict<recob::Vertex>(fmPFPart, evt,
              fParams.PFParticleLabel() + slice_tag_suff);
 
-    art::FindManyP<recob::Hit> fmTrackHit =
-      FindManyPStrict<recob::Hit>(slcTracks, evt,
+    art::FindManyP<recob::Hit, recob::TrackHitMeta> fmTrackHit =
+      FindManyPDStrict<recob::Hit, recob::TrackHitMeta>(slcTracks, evt,
           fParams.RecoTrackLabel() + slice_tag_suff);
 
     art::FindManyP<recob::Hit> fmShowerHit =
@@ -2532,10 +2533,10 @@ void CAFMaker::produce(art::Event& evt) noexcept {
            FillTrackDazzle(fmTrackDazzle.at(iPart).front(), trk);
         }
         if (fmCalo.isValid()) {
-          FillTrackCalo(fmCalo.at(iPart), fmTrackHit.at(iPart),
+          FillTrackCalo(fmCalo.at(iPart), *thisTrack[0], fmTrackHit.at(iPart), fmTrackHit.data(iPart),
               (fParams.FillHitsNeutrinoSlices() && NeutrinoSlice) || fParams.FillHitsAllSlices(),
               fParams.TrackHitFillRRStartCut(), fParams.TrackHitFillRREndCut(),
-              dprop, trk);
+              dprop, *sce, trk);
         }
         
         if (fmCRTHitMatch.isValid() && fDet == kICARUS) {

--- a/sbncode/CAFMaker/CAFMaker_module.cc
+++ b/sbncode/CAFMaker/CAFMaker_module.cc
@@ -65,7 +65,7 @@
 #include "art/Framework/Services/System/TriggerNamesService.h"
 #include "nurandom/RandomUtils/NuRandomService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
-#include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "larcore/CoreUtils/ServiceUtil.h"
 #include "larevt/SpaceCharge/SpaceCharge.h"
@@ -1502,8 +1502,8 @@ void CAFMaker::produce(art::Event& evt) noexcept {
   if ( !isRealData ) {
     art::ServiceHandle<cheat::BackTrackerService> bt_serv;
 
-    id_to_ide_map = PrepSimChannels(simchannels, wireReadout);
-    id_to_truehit_map = PrepTrueHits(hits, clock_data, *bt_serv);
+    id_to_ide_map = sbn::PrepSimChannels(simchannels, wireReadout);
+    id_to_truehit_map = sbn::PrepTrueHits(hits, clock_data, *bt_serv);
     id_to_hit_energy_map = SetupIDHitEnergyMap(hits, clock_data, *bt_serv);
   }
 

--- a/sbncode/CAFMaker/CMakeLists.txt
+++ b/sbncode/CAFMaker/CMakeLists.txt
@@ -30,6 +30,7 @@ art_make_library( LIBRARY_NAME sbncode_CAFMaker
                   larcorealg::Geometry
                   larcore::Geometry_Geometry_service
                   larcorealg::GeoAlgo
+                  lardataalg::headers
                   larsim::MCCheater_BackTrackerService_service
                   nusimdata::SimulationBase
                   larsim::MCCheater_ParticleInventoryService_service
@@ -71,6 +72,7 @@ cet_build_plugin ( CAFMaker art::module
                hep_concurrency::hep_concurrency
                lardataobj::RecoBase
                nurandom::RandomUtils_NuRandomService_service
+               lardata::DetectorPropertiesService
                lardata::DetectorClocksService
                BASENAME_ONLY
             )

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -1002,6 +1002,7 @@ namespace caf
         FillPlaneLikePID(particle_id, srtrack.likepid[plane_id]);
       }
     }
+  }
   
     // Helper function: get the e field
   double GetEfield(const detinfo::DetectorPropertiesData& dprop, spacecharge::SpaceCharge const& sce, const geo::Point_t& loc) {

--- a/sbncode/CAFMaker/FillReco.cxx
+++ b/sbncode/CAFMaker/FillReco.cxx
@@ -1002,12 +1002,31 @@ namespace caf
         FillPlaneLikePID(particle_id, srtrack.likepid[plane_id]);
       }
     }
+  
+    // Helper function: get the e field
+  double GetEfield(const detinfo::DetectorPropertiesData& dprop, spacecharge::SpaceCharge const& sce, const geo::Point_t& loc) {
+
+    double EField = dprop.Efield();
+    if (sce.EnableSimEfieldSCE()) {
+      // Gets fractional E field distortions w.r.t. the nominal field on x-axis
+      geo::Vector_t EFieldOffsets = sce.GetEfieldOffsets(loc);
+      // Add 1 in X direction as this is the direction of the drift field, not caring if it is +x or -x direction, since we only want |E|
+      EFieldOffsets += geo::Vector_t{1, 0, 0};
+      // Convert to Absolute E Field from relative
+      EFieldOffsets *= EField;
+      // We only care about the magnitude for recombination
+      EField = EFieldOffsets.r();
+    }
+    return EField;
   }
 
   void FillTrackPlaneCalo(const anab::Calorimetry &calo, 
+        const recob::Track& track,
         const std::vector<art::Ptr<recob::Hit>> &hits,
+        const std::vector<const recob::TrackHitMeta*>& thms,
         bool fill_calo_points, float fillhit_rrstart, float fillhit_rrend, 
         const detinfo::DetectorPropertiesData &dprop,
+        const spacecharge::SpaceCharge &sce,
         caf::SRTrackCalo &srcalo) {
 
     // Collect info from Calorimetry
@@ -1046,7 +1065,8 @@ namespace caf
 
         // lookup the wire -- the Calorimery object makes this
         // __way__ harder than it should be
-        for (const art::Ptr<recob::Hit> &h: hits) {
+        for (unsigned i_hit = 0; i_hit < hits.size(); i_hit++) {
+          const art::Ptr<recob::Hit> &h = hits[i_hit];
           if (h.key() == tps[i]) {
             p.wire = h->WireID().Wire;
             p.tpc = h->WireID().TPC;
@@ -1058,6 +1078,19 @@ namespace caf
             p.mult = h->Multiplicity();
             p.start = h->StartTick();
             p.end = h->EndTick();
+
+
+            // Get the trajectory point index from this hit. Again -- this is too hard. 
+            //
+            // Use this to get the (SCE corrected) efield and the angle to the drift direction
+            unsigned traj_point_index = thms.at(i_hit)->Index();
+            if (track.HasValidPoint(traj_point_index)) {
+              float costh_drift = track.DirectionAtPoint(traj_point_index).X();
+              float phi  = acos(abs(costh_drift));
+              float efield = GetEfield(dprop, sce, track.LocationAtPoint(traj_point_index));
+              p.efield = efield;
+              p.phi = phi;
+            }
           }
         }
 
@@ -1111,9 +1144,12 @@ namespace caf
   }
 
   void FillTrackCalo(const std::vector<art::Ptr<anab::Calorimetry>> &calos,
+                     const recob::Track& track,
                      const std::vector<art::Ptr<recob::Hit>> &hits,
+                     const std::vector<const recob::TrackHitMeta*>& thms,
                      bool fill_calo_points, float fillhit_rrstart, float fillhit_rrend,
                      const detinfo::DetectorPropertiesData &dprop,
+                     const spacecharge::SpaceCharge &sce,
                      caf::SRTrack& srtrack,
                      bool allowEmpty)
   {
@@ -1126,7 +1162,7 @@ namespace caf
       if (calo.PlaneID()) {
         unsigned plane_id = calo.PlaneID().Plane;
         assert(plane_id < 3);
-        FillTrackPlaneCalo(calo, hits, fill_calo_points, fillhit_rrstart, fillhit_rrend, dprop, srtrack.calo[plane_id]);
+        FillTrackPlaneCalo(calo, track, hits, thms, fill_calo_points, fillhit_rrstart, fillhit_rrend, dprop, sce, srtrack.calo[plane_id]);
       }
     }
 

--- a/sbncode/CAFMaker/FillReco.h
+++ b/sbncode/CAFMaker/FillReco.h
@@ -5,15 +5,18 @@
 
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "larsim/MCCheater/ParticleInventoryService.h"
-#include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
 
 // LArSoft includes
 #include "larcorealg/Geometry/fwd.h"
+
+#include "larevt/SpaceCharge/SpaceCharge.h"
 
 #include "lardataobj/RecoBase/PFParticle.h"
 #include "lardataobj/RecoBase/Shower.h"
 #include "lardataobj/RecoBase/Slice.h"
 #include "lardataobj/RecoBase/Track.h"
+#include "lardataobj/RecoBase/TrackHitMeta.h"
 #include "lardataobj/RecoBase/Vertex.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/SpacePoint.h"
@@ -237,9 +240,12 @@ namespace caf
                         bool allowEmpty = false);
 
   void FillTrackPlaneCalo(const anab::Calorimetry &calo, 
+                     const recob::Track& track,
                      const std::vector<art::Ptr<recob::Hit>> &hits,
+                     const std::vector<const recob::TrackHitMeta*>& thms,
                      bool fill_calo_points, float fillhit_rrstart, float fillhit_rrend, 
                      const detinfo::DetectorPropertiesData &dprop,
+                     spacecharge::SpaceCharge const& sce,
                      caf::SRTrackCalo &srcalo);
 
   void FillTrackScatterClosestApproach(const art::Ptr<sbn::ScatterClosestApproach> closestapproach,
@@ -255,9 +261,12 @@ namespace caf
                         bool allowEmpty = false);
 
   void FillTrackCalo(const std::vector<art::Ptr<anab::Calorimetry>> &calos,
+                     const recob::Track& track,
                      const std::vector<art::Ptr<recob::Hit>> &hits,
+                     const std::vector<const recob::TrackHitMeta*>& thms,
                      bool fill_calo_points, float fillhit_rrstart, float fillhit_rrend,
                      const detinfo::DetectorPropertiesData &dprop,
+                     spacecharge::SpaceCharge const& sce,
                      caf::SRTrack& srtrack,
                      bool allowEmpty = false);
 

--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -5,7 +5,6 @@
 #include "larcorealg/Geometry/WireReadoutGeom.h"
 #include "larevt/SpaceCharge/SpaceCharge.h"
 #include "larcore/CoreUtils/ServiceUtil.h"
-#include "RecoUtils/RecoUtils.h"
 
 #include "CLHEP/Random/RandGauss.h"
 
@@ -701,7 +700,7 @@ namespace caf {
     }
     // get the wall
     if (entry_point > 0) {
-      srparticle.wallin = GetWallCross(active_volumes.at(cryostat_index), particle.Position(entry_point).Vect(), particle.Position(entry_point-1).Vect());
+      srparticle.wallin = sbn::GetWallCross(active_volumes.at(cryostat_index), particle.Position(entry_point).Vect(), particle.Position(entry_point-1).Vect());
     }
 
     int exit_point = -1;
@@ -781,7 +780,7 @@ namespace caf {
       exit_point++; // to avoid exactly the same start and end positions when single index is inside the active volumne
     }
     if (exit_point >= 0 && ((unsigned)exit_point) < particle.NumberTrajectoryPoints() - 1) {
-      srparticle.wallout = GetWallCross(active_volumes.at(cryostat_index), particle.Position(exit_point).Vect(), particle.Position(exit_point+1).Vect());
+      srparticle.wallout = sbn::GetWallCross(active_volumes.at(cryostat_index), particle.Position(exit_point).Vect(), particle.Position(exit_point+1).Vect());
     }
 
     // other truth information
@@ -802,8 +801,8 @@ namespace caf {
     srparticle.endp = (exit_point >= 0) ? particle.Momentum(exit_point).Vect() : TVector3(-9999, -9999, -9999);
     srparticle.endE = (exit_point >= 0) ? particle.Momentum(exit_point).E() : -9999.;
 
-    srparticle.start_process = GetG4ProcessID(particle.Process());
-    srparticle.end_process = GetG4ProcessID(particle.EndProcess());
+    srparticle.start_process = sbn::GetG4ProcessID(particle.Process());
+    srparticle.end_process = sbn::GetG4ProcessID(particle.EndProcess());
 
     srparticle.G4ID = particle.TrackId();
     srparticle.parent = particle.Mother();
@@ -869,37 +868,6 @@ namespace caf {
       for (const sim::TrackIDE ide : backtracker.HitToTrackIDEs(clockData, h)) {
         const int ide_trackID = CAFRecoUtils::GetShowerPrimary(ide.trackID);
         ret[ide_trackID].totE += ide.energy;
-      }
-    }
-    return ret;
-  }
-
-  std::map<int, std::vector<art::Ptr<recob::Hit>>> PrepTrueHits(const std::vector<art::Ptr<recob::Hit>> &allHits, 
-    const detinfo::DetectorClocksData &clockData, const cheat::BackTrackerService &backtracker) {
-    std::map<int, std::vector<art::Ptr<recob::Hit>>> ret;
-    for (const art::Ptr<recob::Hit> h: allHits) {
-      for (int ID: backtracker.HitToTrackIds(clockData, *h)) {
-        ret[abs(ID)].push_back(h);
-      }
-    }
-    return ret;
-  }
-
-  std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels, const geo::WireReadoutGeom &wireReadout) {
-    std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> ret;
-
-    for (const art::Ptr<sim::SimChannel> sc : simchannels) {
-      // Lookup the wire of this channel
-      raw::ChannelID_t channel = sc->Channel();
-      std::vector<geo::WireID> maybewire = wireReadout.ChannelToWire(channel);
-      geo::WireID thisWire; // Default constructor makes invalid wire
-      if (maybewire.size()) thisWire = maybewire[0];
-
-      for (const auto &item : sc->TDCIDEMap()) {
-        for (const sim::IDE &ide: item.second) {
-          // indexing initializes empty vector
-          ret[abs(ide.trackID)].push_back({thisWire, &ide});
-        }
       }
     }
     return ret;
@@ -1255,135 +1223,6 @@ bool FRFillNueCC(const simb::MCTruth &mctruth,
 
   return true;
 }
-
-caf::Wall_t caf::GetWallCross(const geo::BoxBoundedGeo &volume, const TVector3 p0, const TVector3 p1) {
-  TVector3 direction = (p1 - p0) * ( 1. / (p1 - p0).Mag());
-  std::vector<TVector3> intersections = volume.GetIntersections(p0, direction);
-
-  /*
-   * There are either two, or one, or zero intersection points.
-   * As per larcorealg/Geometry/BoxBoundedGeo.h documentation:
-   * If the return std::vector is empty the trajectory does not intersect with the box.
-   * Normally the return value should have one (if the trajectory originates in the box) or two (else) entries.
-   * If the return value has two entries the first represents the entry point and the second the exit point
-   */
-
-  if( intersections.empty() ) return caf::kWallNone;
-
-  // get the intersection point closer to p0
-  TVector3 closestIntersection;
-  double minDistance2 = std::numeric_limits<double>::max();
-
-  for( TVector3 const & point : intersections ) {
-    const double d2 = (point - p0).Mag2();
-    if( d2 > minDistance2 ) continue;
-    minDistance2 = d2;
-    closestIntersection = point;
-  }
-
-  double eps = 1e-3;
-  if (abs(closestIntersection.X() - volume.MinX()) < eps) {
-    return caf::kWallLeft;
-  }
-  else if (abs(closestIntersection.X() - volume.MaxX()) < eps) {
-    return caf::kWallRight;
-  }
-  else if (abs(closestIntersection.Y() - volume.MinY()) < eps) {
-    return caf::kWallBottom;
-  }
-  else if (abs(closestIntersection.Y() - volume.MaxY()) < eps) {
-    return caf::kWallTop;
-  }
-  else if (abs(closestIntersection.Z() - volume.MinZ()) < eps) {
-    return caf::kWallFront;
-  }
-  else if (abs(closestIntersection.Z() - volume.MaxZ()) < eps) {
-    return caf::kWallBack;
-  }
-  else assert(false);
-
-  return caf::kWallNone;
-}//GetWallCross
-
-//------------------------------------------
-
-caf::g4_process_ caf::GetG4ProcessID(const std::string &process_name) {
-#define MATCH_PROCESS(name) if (process_name == #name) {return caf::kG4 ## name;}
-#define MATCH_PROCESS_NAMED(strname, id) if (process_name == #strname) {return caf::kG4 ## id;}
-  MATCH_PROCESS(primary)
-  MATCH_PROCESS(CoupledTransportation)
-  MATCH_PROCESS(FastScintillation)
-  MATCH_PROCESS(Decay)
-  MATCH_PROCESS(anti_neutronInelastic)
-  MATCH_PROCESS(neutronInelastic)
-  MATCH_PROCESS(anti_protonInelastic)
-  MATCH_PROCESS(protonInelastic)
-  MATCH_PROCESS(hadInelastic)
-  MATCH_PROCESS_NAMED(kaon+Inelastic, kaonpInelastic)
-  MATCH_PROCESS_NAMED(kaon-Inelastic, kaonmInelastic)
-  MATCH_PROCESS_NAMED(kaon+Inelastic, kaonpInelastic)
-  MATCH_PROCESS_NAMED(kaon-Inelastic, kaonmInelastic)
-  MATCH_PROCESS_NAMED(sigma+Inelastic, sigmapInelastic)
-  MATCH_PROCESS_NAMED(sigma-Inelastic, sigmamInelastic)
-  MATCH_PROCESS_NAMED(pi+Inelastic, pipInelastic)
-  MATCH_PROCESS_NAMED(pi-Inelastic, pimInelastic)
-  MATCH_PROCESS_NAMED(xi+Inelastic, xipInelastic)
-  MATCH_PROCESS_NAMED(xi-Inelastic, ximInelastic)
-  MATCH_PROCESS(kaon0LInelastic)
-  MATCH_PROCESS(kaon0SInelastic)
-  MATCH_PROCESS(lambdaInelastic)
-  MATCH_PROCESS_NAMED(anti-lambdaInelastic, anti_lambdaInelastic)
-  MATCH_PROCESS(He3Inelastic)
-  MATCH_PROCESS(ionInelastic)
-  MATCH_PROCESS(xi0Inelastic)
-  MATCH_PROCESS(alphaInelastic)
-  MATCH_PROCESS(tInelastic)
-  MATCH_PROCESS(dInelastic)
-  MATCH_PROCESS(anti_neutronElastic)
-  MATCH_PROCESS(neutronElastic)
-  MATCH_PROCESS(anti_protonElastic)
-  MATCH_PROCESS(protonElastic)
-  MATCH_PROCESS(hadElastic)
-  MATCH_PROCESS_NAMED(kaon+Elastic, kaonpElastic)
-  MATCH_PROCESS_NAMED(kaon-Elastic, kaonmElastic)
-  MATCH_PROCESS_NAMED(pi+Elastic, pipElastic)
-  MATCH_PROCESS_NAMED(pi-Elastic, pimElastic)
-  MATCH_PROCESS(conv)
-  MATCH_PROCESS(phot)
-  MATCH_PROCESS(annihil)
-  MATCH_PROCESS(nCapture)
-  MATCH_PROCESS(nKiller)
-  MATCH_PROCESS(muMinusCaptureAtRest)
-  MATCH_PROCESS(muIoni)
-  MATCH_PROCESS(eBrem)
-  MATCH_PROCESS(CoulombScat)
-  MATCH_PROCESS(hBertiniCaptureAtRest)
-  MATCH_PROCESS(hFritiofCaptureAtRest)
-  MATCH_PROCESS(photonNuclear)
-  MATCH_PROCESS(muonNuclear)
-  MATCH_PROCESS(electronNuclear)
-  MATCH_PROCESS(positronNuclear)
-  MATCH_PROCESS(compt)
-  MATCH_PROCESS(eIoni)
-  MATCH_PROCESS(muBrems)
-  MATCH_PROCESS(hIoni)
-  MATCH_PROCESS(ionIoni)
-  MATCH_PROCESS(hBrems)
-  MATCH_PROCESS(muPairProd)
-  MATCH_PROCESS(hPairProd)
-  MATCH_PROCESS(LArVoxelReadoutScoringProcess)
-  MATCH_PROCESS(Transportation)
-  MATCH_PROCESS(msc)
-  MATCH_PROCESS(StepLimiter)
-  MATCH_PROCESS(RadioactiveDecayBase)
-  std::cerr << "Error: Process name with no match (" << process_name << ")\n";
-  assert(false);
-  return caf::kG4UNKNOWN; // unreachable in debug mode
-#undef MATCH_PROCESS
-#undef MATCH_PROCESS_NAMED
-
-}//GetG4ProcessID
-//-------------------------------------------
 
 float ContainedLength(const TVector3 &v0, const TVector3 &v1,
                        const std::vector<geoalgo::AABox> &boxes) {

--- a/sbncode/CAFMaker/FillTrue.cxx
+++ b/sbncode/CAFMaker/FillTrue.cxx
@@ -135,7 +135,7 @@ namespace caf {
   }//FillTrackTruth
 
   // Assumes truth matching and calo-points are filled
-  void FillTrackCaloTruth(const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> &id_to_ide_map,
+  void FillTrackCaloTruth(const std::map<int, std::vector<sbn::ReadoutIDE>> &id_to_ide_map,
                           const std::vector<simb::MCParticle> &mc_particles,
                           const geo::GeometryCore& geometry,
                           const geo::WireReadoutGeom& wireReadout,
@@ -162,10 +162,10 @@ namespace caf {
 
     // Load the hits
     // match on the channel, which is unique
-    const std::vector<std::pair<geo::WireID, const sim::IDE*>> &match_ides = id_to_ide_map.at(srtrack.truth.p.G4ID);
+    const std::vector<sbn::ReadoutIDE> &match_ides = id_to_ide_map.at(srtrack.truth.p.G4ID);
     std::map<unsigned, std::vector<const sim::IDE *>> chan_2_ides;
-    for (auto const &ide_pair: match_ides) {
-      chan_2_ides[wireReadout.PlaneWireToChannel(ide_pair.first)].push_back(ide_pair.second);
+    for (auto const &ide_p: match_ides) {
+      chan_2_ides[wireReadout.PlaneWireToChannel(ide_p.wire)].push_back(ide_p.ide);
     }
 
     // pre-compute partial ranges
@@ -633,15 +633,15 @@ namespace caf {
   void FillTrueG4Particle(const simb::MCParticle &particle,
         const std::vector<geo::BoxBoundedGeo> &active_volumes,
         const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
-        const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE *>>> &id_to_ide_map,
+        const std::map<int, std::vector<sbn::ReadoutIDE>> &id_to_ide_map,
         const std::map<int, std::vector<art::Ptr<recob::Hit>>> &id_to_truehit_map,
         const cheat::BackTrackerService &backtracker,
         const cheat::ParticleInventoryService &inventory_service,
         const std::vector<art::Ptr<simb::MCTruth>> &neutrinos,
                           caf::SRTrueParticle &srparticle) {
 
-    std::vector<std::pair<geo::WireID, const sim::IDE *>> empty;
-    const std::vector<std::pair<geo::WireID, const sim::IDE *>> &particle_ides = id_to_ide_map.count(particle.TrackId()) ? id_to_ide_map.at(particle.TrackId()) : empty;
+    std::vector<sbn::ReadoutIDE> empty;
+    const std::vector<sbn::ReadoutIDE> &particle_ides = id_to_ide_map.count(particle.TrackId()) ? id_to_ide_map.at(particle.TrackId()) : empty;
 
     std::vector<art::Ptr<recob::Hit>> emptyHits;
     const std::vector<art::Ptr<recob::Hit>> &particle_hits = id_to_truehit_map.count(particle.TrackId()) ? id_to_truehit_map.at(particle.TrackId()) : emptyHits;
@@ -661,9 +661,9 @@ namespace caf {
       }
     }
 
-    for (auto const &ide_pair: particle_ides) {
-      const geo::WireID &w = ide_pair.first;
-      const sim::IDE *ide = ide_pair.second;
+    for (auto const &ide_p: particle_ides) {
+      const geo::WireID &w = ide_p.wire;
+      const sim::IDE *ide = ide_p.ide;
 
       if(w.Plane >= 0 && w.Plane < 3 && w.Cryostat < 2){
         srparticle.plane[w.Cryostat][w.Plane].visE += ide->energy / 1000. /* MeV -> GeV*/;

--- a/sbncode/CAFMaker/FillTrue.h
+++ b/sbncode/CAFMaker/FillTrue.h
@@ -128,12 +128,6 @@ namespace caf
                     CLHEP::HepRandomEngine &rand,
                     std::vector<caf::SRFakeReco> &srfakereco);
 
-<<<<<<< HEAD
-  std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels, const geo::WireReadoutGeom &wireReadout);
-  std::map<int, std::vector<art::Ptr<recob::Hit>>> PrepTrueHits(const std::vector<art::Ptr<recob::Hit>> &allHits,
-    const detinfo::DetectorClocksData &clockData, const cheat::BackTrackerService &backtracker);
-=======
->>>>>>> 46e144f5 (Refactor CAF helper functions utilized in CaloSkimmer into RecoUtils.)
   std::map<int, caf::HitsEnergy> SetupIDHitEnergyMap(const std::vector<art::Ptr<recob::Hit>> &allHits, const detinfo::DetectorClocksData &clockData,
     const cheat::BackTrackerService &backtracker);
 

--- a/sbncode/CAFMaker/FillTrue.h
+++ b/sbncode/CAFMaker/FillTrue.h
@@ -33,19 +33,14 @@
 #include "sbnanaobj/StandardRecord/StandardRecord.h"
 #include "sbnanaobj/StandardRecord/SRMeVPrtl.h"
 
+#include "RecoUtils/RecoUtils.h"
+
 namespace caf
 {
   struct HitsEnergy {
     int nHits;
     float totE;
   };
-
-  // Helpers
-  caf::Wall_t GetWallCross( const geo::BoxBoundedGeo &volume,
-        const TVector3 p0,
-        const TVector3 p1);
-
-  caf::g4_process_ GetG4ProcessID(const std::string &name);
 
   void FillSRGlobal(const sbn::evwgh::EventWeightParameterSet& pset,
                     caf::SRGlobal& srglobal,
@@ -133,9 +128,12 @@ namespace caf
                     CLHEP::HepRandomEngine &rand,
                     std::vector<caf::SRFakeReco> &srfakereco);
 
+<<<<<<< HEAD
   std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels, const geo::WireReadoutGeom &wireReadout);
   std::map<int, std::vector<art::Ptr<recob::Hit>>> PrepTrueHits(const std::vector<art::Ptr<recob::Hit>> &allHits,
     const detinfo::DetectorClocksData &clockData, const cheat::BackTrackerService &backtracker);
+=======
+>>>>>>> 46e144f5 (Refactor CAF helper functions utilized in CaloSkimmer into RecoUtils.)
   std::map<int, caf::HitsEnergy> SetupIDHitEnergyMap(const std::vector<art::Ptr<recob::Hit>> &allHits, const detinfo::DetectorClocksData &clockData,
     const cheat::BackTrackerService &backtracker);
 

--- a/sbncode/CAFMaker/FillTrue.h
+++ b/sbncode/CAFMaker/FillTrue.h
@@ -68,7 +68,7 @@ namespace caf
   void FillTrueG4Particle(const simb::MCParticle &particle,
         const std::vector<geo::BoxBoundedGeo> &active_volumes,
         const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
-        const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE *>>> &id_to_ide_map,
+        const std::map<int, std::vector<sbn::ReadoutIDE>> &id_to_ide_map,
         const std::map<int, std::vector<art::Ptr<recob::Hit>>> &id_to_truehit_map,
         const cheat::BackTrackerService &backtracker,
         const cheat::ParticleInventoryService &inventory_service,
@@ -98,7 +98,7 @@ namespace caf
                       caf::SRTrack& srtrack,
                       bool allowEmpty = false);
 
-  void FillTrackCaloTruth(const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> &id_to_ide_map,
+  void FillTrackCaloTruth(const std::map<int, std::vector<sbn::ReadoutIDE>> &id_to_ide_map,
                           const std::vector<simb::MCParticle> &mc_particles,
                           const geo::GeometryCore & geometry,
                           const geo::WireReadoutGeom& wireReadout,

--- a/sbncode/CAFMaker/RecoUtils/RecoUtils.cc
+++ b/sbncode/CAFMaker/RecoUtils/RecoUtils.cc
@@ -107,3 +107,151 @@ int CAFRecoUtils::GetShowerPrimary(const int g4ID)
 
   return primary_id;
 }
+
+std::map<int, std::vector<sbn::ReadoutIDE>> sbn::PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels, const geo::WireReadoutGeom &wireReadout) {
+    std::map<int, std::vector<sbn::ReadoutIDE>> ret;
+
+    for (const art::Ptr<sim::SimChannel> sc : simchannels) {
+      // Lookup the wire of this channel
+      raw::ChannelID_t channel = sc->Channel();
+      std::vector<geo::WireID> maybewire = wireReadout.ChannelToWire(channel);
+      geo::WireID thisWire; // Default constructor makes invalid wire
+      if (maybewire.size()) thisWire = maybewire[0];
+
+      for (const auto &item : sc->TDCIDEMap()) {
+        for (const sim::IDE &ide: item.second) {
+          // indexing initializes empty vector
+          ret[abs(ide.trackID)].push_back({thisWire, item.first, &ide});
+        }
+      }
+    }
+    return ret;
+}
+
+std::map<int, std::vector<art::Ptr<recob::Hit>>> sbn::PrepTrueHits(const std::vector<art::Ptr<recob::Hit>> &allHits, 
+  const detinfo::DetectorClocksData &clockData, const cheat::BackTrackerService &backtracker) {
+  std::map<int, std::vector<art::Ptr<recob::Hit>>> ret;
+  for (const art::Ptr<recob::Hit> h: allHits) {
+    for (int ID: backtracker.HitToTrackIds(clockData, *h)) {
+      ret[abs(ID)].push_back(h);
+    }
+  }
+  return ret;
+}
+
+caf::Wall_t sbn::GetWallCross(const geo::BoxBoundedGeo &volume, const TVector3 p0, const TVector3 p1) {
+  TVector3 direction = (p1 - p0) * ( 1. / (p1 - p0).Mag());
+  std::vector<TVector3> intersections = volume.GetIntersections(p0, direction);
+
+  assert(intersections.size() == 2);
+
+  // get the intersection point closer to p0
+  int intersection_i = ((intersections[0] - p0).Mag() < (intersections[1] - p0).Mag()) ? 0 : 1;
+
+  double eps = 1e-3;
+  if (abs(intersections[intersection_i].X() - volume.MinX()) < eps) {
+    //std::cout << "Left\n";
+    return caf::kWallLeft;
+  }
+  else if (abs(intersections[intersection_i].X() - volume.MaxX()) < eps) {
+    //std::cout << "Right\n";
+    return caf::kWallRight;
+  }
+  else if (abs(intersections[intersection_i].Y() - volume.MinY()) < eps) {
+    //std::cout << "Bottom\n";
+    return caf::kWallBottom;
+  }
+  else if (abs(intersections[intersection_i].Y() - volume.MaxY()) < eps) {
+    //std::cout << "Top\n";
+    return caf::kWallTop;
+  }
+  else if (abs(intersections[intersection_i].Z() - volume.MinZ()) < eps) {
+    //std::cout << "Front\n";
+    return caf::kWallFront;
+  }
+  else if (abs(intersections[intersection_i].Z() - volume.MaxZ()) < eps) {
+    //std::cout << "Back\n";
+    return caf::kWallBack;
+  }
+  else assert(false);
+  //std::cout << "None\n";
+
+  return caf::kWallNone;
+}//GetWallCross
+
+//------------------------------------------
+caf::g4_process_ sbn::GetG4ProcessID(const std::string &process_name) {
+#define MATCH_PROCESS(name) if (process_name == #name) {return caf::kG4 ## name;}
+#define MATCH_PROCESS_NAMED(strname, id) if (process_name == #strname) {return caf::kG4 ## id;}
+  MATCH_PROCESS(primary)
+  MATCH_PROCESS(CoupledTransportation)
+  MATCH_PROCESS(FastScintillation)
+  MATCH_PROCESS(Decay)
+  MATCH_PROCESS(anti_neutronInelastic)
+  MATCH_PROCESS(neutronInelastic)
+  MATCH_PROCESS(anti_protonInelastic)
+  MATCH_PROCESS(protonInelastic)
+  MATCH_PROCESS(hadInelastic)
+  MATCH_PROCESS_NAMED(kaon+Inelastic, kaonpInelastic)
+  MATCH_PROCESS_NAMED(kaon-Inelastic, kaonmInelastic)
+  MATCH_PROCESS_NAMED(kaon+Inelastic, kaonpInelastic)
+  MATCH_PROCESS_NAMED(kaon-Inelastic, kaonmInelastic)
+  MATCH_PROCESS_NAMED(sigma+Inelastic, sigmapInelastic)
+  MATCH_PROCESS_NAMED(sigma-Inelastic, sigmamInelastic)
+  MATCH_PROCESS_NAMED(pi+Inelastic, pipInelastic)
+  MATCH_PROCESS_NAMED(pi-Inelastic, pimInelastic)
+  MATCH_PROCESS_NAMED(xi+Inelastic, xipInelastic)
+  MATCH_PROCESS_NAMED(xi-Inelastic, ximInelastic)
+  MATCH_PROCESS(kaon0LInelastic)
+  MATCH_PROCESS(kaon0SInelastic)
+  MATCH_PROCESS(lambdaInelastic)
+  MATCH_PROCESS_NAMED(anti-lambdaInelastic, anti_lambdaInelastic)
+  MATCH_PROCESS(He3Inelastic)
+  MATCH_PROCESS(ionInelastic)
+  MATCH_PROCESS(xi0Inelastic)
+  MATCH_PROCESS(alphaInelastic)
+  MATCH_PROCESS(tInelastic)
+  MATCH_PROCESS(dInelastic)
+  MATCH_PROCESS(anti_neutronElastic)
+  MATCH_PROCESS(neutronElastic)
+  MATCH_PROCESS(anti_protonElastic)
+  MATCH_PROCESS(protonElastic)
+  MATCH_PROCESS(hadElastic)
+  MATCH_PROCESS_NAMED(kaon+Elastic, kaonpElastic)
+  MATCH_PROCESS_NAMED(kaon-Elastic, kaonmElastic)
+  MATCH_PROCESS_NAMED(pi+Elastic, pipElastic)
+  MATCH_PROCESS_NAMED(pi-Elastic, pimElastic)
+  MATCH_PROCESS(conv)
+  MATCH_PROCESS(phot)
+  MATCH_PROCESS(annihil)
+  MATCH_PROCESS(nCapture)
+  MATCH_PROCESS(nKiller)
+  MATCH_PROCESS(muMinusCaptureAtRest)
+  MATCH_PROCESS(muIoni)
+  MATCH_PROCESS(eBrem)
+  MATCH_PROCESS(CoulombScat)
+  MATCH_PROCESS(hBertiniCaptureAtRest)
+  MATCH_PROCESS(hFritiofCaptureAtRest)
+  MATCH_PROCESS(photonNuclear)
+  MATCH_PROCESS(muonNuclear)
+  MATCH_PROCESS(electronNuclear)
+  MATCH_PROCESS(positronNuclear)
+  MATCH_PROCESS(compt)
+  MATCH_PROCESS(eIoni)
+  MATCH_PROCESS(muBrems)
+  MATCH_PROCESS(hIoni)
+  MATCH_PROCESS(ionIoni)
+  MATCH_PROCESS(hBrems)
+  MATCH_PROCESS(muPairProd)
+  MATCH_PROCESS(hPairProd)
+  MATCH_PROCESS(LArVoxelReadoutScoringProcess)
+  MATCH_PROCESS(Transportation)
+  MATCH_PROCESS(msc)
+  MATCH_PROCESS(StepLimiter)
+  MATCH_PROCESS(RadioactiveDecayBase)
+  std::cerr << "Error: Process name with no match (" << process_name << ")\n";
+  assert(false);
+  return caf::kG4UNKNOWN; // unreachable in debug mode
+#undef MATCH_PROCESS
+#undef MATCH_PROCESS_NAMED
+}//GetG4ProcessID

--- a/sbncode/CAFMaker/RecoUtils/RecoUtils.h
+++ b/sbncode/CAFMaker/RecoUtils/RecoUtils.h
@@ -24,11 +24,13 @@
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Track.h"
 #include "lardataobj/RecoBase/Shower.h"
+#include "sbnanaobj/StandardRecord/SREnums.h"
 //#include "lardataobj/AnalysisBase/MVAPIDResult.h"
 //#include "lardataobj/AnalysisBase/ParticleID.h"
 #include "larsim/MCCheater/BackTrackerService.h"
 #include "larsim/MCCheater/ParticleInventoryService.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/WireReadoutGeom.h"
 
 // c++
 #include <vector>
@@ -36,6 +38,25 @@
 
 // ROOT
 #include "TTree.h"
+
+namespace sim {
+  class IDE;
+}
+
+namespace sbn {
+  struct ReadoutIDE {
+    geo::WireID wire;              ///< Wire on a given plane closest to the drift path of the charge.
+    unsigned short tick = 0;       ///< Time tick at which the charge passes closest to the wire.
+    const sim::IDE *ide = nullptr; ///< Deposited charge information.
+  };
+  
+  // Helpers
+  std::map<int, std::vector<sbn::ReadoutIDE>> PrepSimChannels(const std::vector<art::Ptr<sim::SimChannel>> &simchannels, const geo::WireReadoutGeom &wireReadout);
+  std::map<int, std::vector<art::Ptr<recob::Hit>>> PrepTrueHits(const std::vector<art::Ptr<recob::Hit>> &allHits,
+    const detinfo::DetectorClocksData &clockData, const cheat::BackTrackerService &backtracker);
+  caf::Wall_t GetWallCross( const geo::BoxBoundedGeo &volume, const TVector3 p0, const TVector3 p1);
+  caf::g4_process_ GetG4ProcessID(const std::string &name);
+}
 
 namespace CAFRecoUtils{
 
@@ -47,4 +68,7 @@ namespace CAFRecoUtils{
 
   int GetShowerPrimary(const int g4ID);
 }
+
+
+
 #endif

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -48,3 +48,5 @@ execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/Supera/setup.sh icarus
 add_subdirectory(Supera)
 
 add_subdirectory(LArG4)
+
+add_subdirectory(WireMod)

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -21,6 +21,7 @@ add_subdirectory(CosmicID)
 add_subdirectory(DetSim)
 add_subdirectory(Cluster3D)
 add_subdirectory(HitFinder)
+add_subdirectory(WireMod)
 
 # Supera
 #

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -48,5 +48,3 @@ execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/Supera/setup.sh icarus
 add_subdirectory(Supera)
 
 add_subdirectory(LArG4)
-
-add_subdirectory(WireMod)

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(GeometryTools)
 add_subdirectory(CosmicID)
 add_subdirectory(DetSim)
 add_subdirectory(Cluster3D)
+add_subdirectory(WireMod)
 add_subdirectory(HitFinder)
 add_subdirectory(WireMod)
 

--- a/sbncode/CMakeLists.txt
+++ b/sbncode/CMakeLists.txt
@@ -22,7 +22,6 @@ add_subdirectory(DetSim)
 add_subdirectory(Cluster3D)
 add_subdirectory(WireMod)
 add_subdirectory(HitFinder)
-add_subdirectory(WireMod)
 
 # Supera
 #

--- a/sbncode/Calibration/CMakeLists.txt
+++ b/sbncode/Calibration/CMakeLists.txt
@@ -25,7 +25,7 @@ cet_build_plugin( TrackCaloSkimmer art::module
                             sbncode_CAFMaker
                             sbnobj::Common_Calibration_dict
                             larevt::SpaceCharge
-			    caf_RecoUtils
+                            caf_RecoUtils
 )
 
 cet_build_plugin(TrackCaloSkimmerSelectStoppingTrack art::tool

--- a/sbncode/Calibration/CMakeLists.txt
+++ b/sbncode/Calibration/CMakeLists.txt
@@ -25,6 +25,7 @@ cet_build_plugin( TrackCaloSkimmer art::module
                             sbncode_CAFMaker
                             sbnobj::Common_Calibration_dict
                             larevt::SpaceCharge
+			    caf_RecoUtils
 )
 
 cet_build_plugin(TrackCaloSkimmerSelectStoppingTrack art::tool

--- a/sbncode/Calibration/TrackCaloSkimmer.h
+++ b/sbncode/Calibration/TrackCaloSkimmer.h
@@ -69,7 +69,7 @@
 #include "ITCSSelectionTool.h"
 
 // Useful functions
-#include "sbncode/CAFMaker/RecoUtils/RecoUtils.h"
+#include "sbncode/CAFMaker/RecoUtils/RecoUtils.h" // sbn::ReadoutIDE, sbn::PrepTrueHits()...
 
 namespace sbn {
   class TrackCaloSkimmer;
@@ -120,7 +120,6 @@ private:
     int ID;
   };
 
-
   // Represents a "Snippet" of ADCs shared by a set of hits on a wire
   struct Snippet {
     geo::WireID wire;
@@ -169,7 +168,7 @@ private:
     const std::vector<art::Ptr<simb::MCParticle>> &mcparticles,
     const std::vector<geo::BoxBoundedGeo> &active_volumes,
     const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
-    const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> id_to_ide_map,
+    const std::map<int, std::vector<sbn::ReadoutIDE>> id_to_ide_map,
     const std::map<int, std::vector<art::Ptr<recob::Hit>>> id_to_truehit_map,
     const detinfo::DetectorPropertiesData &dprop,
     const geo::GeometryCore *geo,

--- a/sbncode/Calibration/TrackCaloSkimmer.h
+++ b/sbncode/Calibration/TrackCaloSkimmer.h
@@ -51,8 +51,8 @@
 
 #include "larevt/SpaceCharge/SpaceCharge.h"
 #include "larevt/SpaceChargeServices/SpaceChargeService.h"
-#include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "larcorealg/Geometry/fwd.h"
 
@@ -67,6 +67,9 @@
 #include "sbnobj/SBND/CRT/CRTSpacePoint.hh"
 
 #include "ITCSSelectionTool.h"
+
+// Useful functions
+#include "sbncode/CAFMaker/RecoUtils/RecoUtils.h"
 
 namespace sbn {
   class TrackCaloSkimmer;

--- a/sbncode/Calibration/TrackCaloSkimmer_module.cc
+++ b/sbncode/Calibration/TrackCaloSkimmer_module.cc
@@ -11,12 +11,10 @@
 ////////////////////////////////////////////////////////////////////////
 
 #include "TrackCaloSkimmer.h"
+#include "sbnobj/SBND/CRT/CRTTrack.hh"
+#include "sbnanaobj/StandardRecord/SREnums.h"
 
 #include "art/Utilities/make_tool.h"
-
-// Useful functions
-#include "sbncode/CAFMaker/FillTrue.h"
-#include "sbncode/CAFMaker/RecoUtils/RecoUtils.h"
 
 #include "larcore/Geometry/WireReadout.h"
 #include "larcore/Geometry/Geometry.h"
@@ -291,15 +289,15 @@ void sbn::TrackCaloSkimmer::analyze(art::Event const& e)
 
   // Prep truth-to-reco-matching info
   //
-  // Use helper functions from CAFMaker/FillTrue
-  std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> id_to_ide_map;
+  // Use helper functions from CAFMaker/RecoUtils
+  std::map<int, std::vector<sbn::ReadoutIDE>> id_to_ide_map;
   std::map<int, std::vector<art::Ptr<recob::Hit>>> id_to_truehit_map;
   const cheat::BackTrackerService *bt = NULL;
 
   if (simchannels.size()) {
     art::ServiceHandle<cheat::BackTrackerService> bt_serv;
-    id_to_ide_map = caf::PrepSimChannels(simchannels, *wireReadout);
-    id_to_truehit_map = caf::PrepTrueHits(allHits, clock_data, *bt_serv.get());
+    id_to_ide_map = sbn::PrepSimChannels(simchannels, *wireReadout);
+    id_to_truehit_map = sbn::PrepTrueHits(allHits, clock_data, *bt_serv.get());
     bt = bt_serv.get();
   }
 
@@ -659,7 +657,7 @@ sbn::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
 
   // get the wall
   if (entry_point > 0) {
-    trueparticle.wallin = (int)caf::GetWallCross(active_volumes.at(cryostat_index), particle.Position(entry_point).Vect(), particle.Position(entry_point-1).Vect());
+    trueparticle.wallin = (int)sbn::GetWallCross(active_volumes.at(cryostat_index), particle.Position(entry_point).Vect(), particle.Position(entry_point-1).Vect());
   }
 
   int exit_point = -1;
@@ -727,7 +725,7 @@ sbn::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
     exit_point = particle.NumberTrajectoryPoints() - 1;
   }
   if (exit_point >= 0 && ((unsigned)exit_point) < particle.NumberTrajectoryPoints() - 1) {
-    trueparticle.wallout = (int)caf::GetWallCross(active_volumes.at(cryostat_index), particle.Position(exit_point).Vect(), particle.Position(exit_point+1).Vect());
+    trueparticle.wallout = (int)sbn::GetWallCross(active_volumes.at(cryostat_index), particle.Position(exit_point).Vect(), particle.Position(exit_point+1).Vect());
   }
 
   // other truth information
@@ -748,8 +746,8 @@ sbn::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
   trueparticle.endp = ConvertTVector((exit_point >= 0) ? particle.Momentum(exit_point).Vect() : TVector3(-9999, -9999, -9999));
   trueparticle.endE = (exit_point >= 0) ? particle.Momentum(exit_point).E() : -9999.;
   
-  trueparticle.start_process = (int)caf::GetG4ProcessID(particle.Process());
-  trueparticle.end_process = (int)caf::GetG4ProcessID(particle.EndProcess());
+  trueparticle.start_process = (int)sbn::GetG4ProcessID(particle.Process());
+  trueparticle.end_process = (int)sbn::GetG4ProcessID(particle.EndProcess());
   
   trueparticle.G4ID = particle.TrackId();
   trueparticle.parent = particle.Mother();

--- a/sbncode/Calibration/TrackCaloSkimmer_module.cc
+++ b/sbncode/Calibration/TrackCaloSkimmer_module.cc
@@ -580,14 +580,14 @@ geo::Point_t WireToTrajectoryPosition(const geo::Point_t &loc, const geo::TPCID 
 sbn::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
     const std::vector<geo::BoxBoundedGeo> &active_volumes,
     const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
-    const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE *>>> &id_to_ide_map,
+    const std::map<int, std::vector<sbn::ReadoutIDE>> &id_to_ide_map,
     const std::map<int, std::vector<art::Ptr<recob::Hit>>> &id_to_truehit_map, 
     const detinfo::DetectorPropertiesData &dprop,
     const geo::GeometryCore *geo,
     const geo::WireReadoutGeom *wireReadout) {
 
-  std::vector<std::pair<geo::WireID, const sim::IDE *>> empty;
-  const std::vector<std::pair<geo::WireID, const sim::IDE *>> &particle_ides = id_to_ide_map.count(particle.TrackId()) ? id_to_ide_map.at(particle.TrackId()) : empty;
+  std::vector<sbn::ReadoutIDE> empty;
+  const std::vector<sbn::ReadoutIDE> &particle_ides = id_to_ide_map.count(particle.TrackId()) ? id_to_ide_map.at(particle.TrackId()) : empty;
   
   std::vector<art::Ptr<recob::Hit>> emptyHits;
   const std::vector<art::Ptr<recob::Hit>> &particle_hits = id_to_truehit_map.count(particle.TrackId()) ? id_to_truehit_map.at(particle.TrackId()) : emptyHits;
@@ -604,9 +604,9 @@ sbn::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
   trueparticle.plane0nhit = 0;
   trueparticle.plane1nhit = 0;
   trueparticle.plane2nhit = 0;
-  for (auto const &ide_pair: particle_ides) {
-    const geo::WireID &w = ide_pair.first;
-    const sim::IDE *ide = ide_pair.second;
+  for (auto const &ide_p: particle_ides) {
+    const geo::WireID &w = ide_p.wire;
+    const sim::IDE *ide = ide_p.ide;
     
     if (w.Plane == 0) {
       trueparticle.plane0VisE += ide->energy / 1000. /* MeV -> GeV*/;
@@ -755,10 +755,11 @@ sbn::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
   // Organize deposition info into per-wire true "Hits" -- key is the Channel Number
   std::map<unsigned, sbn::TrueHit> truehits; 
 
-  for (auto const &ide_pair: particle_ides) {
-    const geo::WireID &w = ide_pair.first;
+  for (auto const &ide_part: particle_ides) {
+    const geo::WireID &w = ide_part.wire;
     unsigned c = wireReadout->PlaneWireToChannel(w);
-    const sim::IDE *ide = ide_pair.second;
+    const sim::IDE *ide = ide_part.ide;
+    unsigned short tick = ide_part.tick;
 
     // Set stuff
     truehits[c].cryo = w.Cryostat;
@@ -773,6 +774,8 @@ sbn::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
     truehits[c].p.x = (truehits[c].p.x*old_elec + ide->x*ide->numElectrons) / new_elec;
     truehits[c].p.y = (truehits[c].p.y*old_elec + ide->y*ide->numElectrons) / new_elec;
     truehits[c].p.z = (truehits[c].p.z*old_elec + ide->z*ide->numElectrons) / new_elec;
+
+    truehits[c].time = (truehits[c].time*old_elec + tick*ide->numElectrons) / new_elec;
 
     // Also get the position with space charge un-done
     geo::Point_t ide_p(ide->x, ide->y, ide->z);
@@ -789,10 +792,10 @@ sbn::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
   }
 
   // Compute widths
-  for (auto const &ide_pair: particle_ides) {
-    const geo::WireID &w = ide_pair.first;
+  for (auto const &ide_part: particle_ides) {
+    const geo::WireID &w = ide_part.wire;
     unsigned c = wireReadout->PlaneWireToChannel(w);
-    const sim::IDE *ide = ide_pair.second;
+    const sim::IDE *ide = ide_part.ide;
 
     geo::Point_t ide_p(ide->x, ide->y, ide->z);
     geo::Point_t ide_p_scecorr = WireToTrajectoryPosition(ide_p, w);
@@ -817,8 +820,6 @@ sbn::TrueParticle TrueParticleInfo(const simb::MCParticle &particle,
 
   // Compute the time of each hit
   for (sbn::TrueHit &h: truehits_v) {
-    h.time = dprop.ConvertXToTicks(h.p.x, h.plane, h.tpc, h.cryo);
-
     double xdrift = abs(h.p.x - wireReadout->Plane(geo::PlaneID(h.cryo, h.tpc, 0)).GetCenter().X());
     h.tdrift = xdrift / dprop.DriftVelocity(); 
   }
@@ -1045,7 +1046,7 @@ void sbn::TrackCaloSkimmer::FillTrackTruth(const detinfo::DetectorClocksData &cl
     const std::vector<art::Ptr<simb::MCParticle>> &mcparticles,
     const std::vector<geo::BoxBoundedGeo> &active_volumes,
     const std::vector<std::vector<geo::BoxBoundedGeo>> &tpc_volumes,
-    const std::map<int, std::vector<std::pair<geo::WireID, const sim::IDE*>>> id_to_ide_map,
+    const std::map<int, std::vector<sbn::ReadoutIDE>> id_to_ide_map,
     const std::map<int, std::vector<art::Ptr<recob::Hit>>> id_to_truehit_map,
     const detinfo::DetectorPropertiesData &dprop,
     const geo::GeometryCore *geo,

--- a/sbncode/WireMod/CMakeLists.txt
+++ b/sbncode/WireMod/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Utility)

--- a/sbncode/WireMod/Utility/CMakeLists.txt
+++ b/sbncode/WireMod/Utility/CMakeLists.txt
@@ -1,0 +1,45 @@
+cet_make_library(
+  LIBRARY_NAME
+    sbncode_WireMod_Utility
+
+  SOURCE
+    WireModUtility.cc
+
+  LIBRARIES
+    ${ART_FRAMEWORK_CORE}
+    ${MF_MESSAGELOGGER}
+    ${Boost_SYSTEM_LIBRARY}
+    ${ROOT_BASIC_LIB_LIST}
+    ${ROOT_HIST}
+    art_root_io::TFileService_service
+    larcorealg::Geometry
+    larcore::Geometry_Geometry_service
+    lardataobj::AnalysisBase
+    lardataobj::RawData
+    lardataobj::RecoBase
+    lardataalg::DetectorInfo 
+    lardata::RecoObjects
+    lardata::Utilities
+    larreco::RecoAlg
+    ${LARRECO_LIB}
+    ${LARDATA_LIB}
+    ${ART_FRAMEWORK_CORE}
+    ${ART_FRAMEWORK_PRINCIPAL}
+    ${ART_FRAMEWORK_SERVICES_REGISTRY}
+    ${ART_FRAMEWORK_SERVICES_OPTIONAL}
+    ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
+    ${ART_FRAMEWORK_SERVICES_OPTIONAL_TFILESERVICE_SERVICE}
+    ${MF_MESSAGELOGGER}
+    ${FHICLCPP}
+    ${CLHEP}
+    ${ROOT_GEOM}
+    ${ROOT_XMLIO}
+    ${ROOT_GDML}
+    ${ROOT_BASIC_LIB_LIST}
+    ${ROOT_HIST}
+    BASENAME_ONLY
+)
+
+install_headers()
+install_source()
+

--- a/sbncode/WireMod/Utility/WireModUtility.cc
+++ b/sbncode/WireMod/Utility/WireModUtility.cc
@@ -1,0 +1,654 @@
+#include "sbncode/WireMod/Utility/WireModUtility.hh"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
+
+//--- CalcROIProperties ---
+sys::WireModUtility::ROIProperties_t sys::WireModUtility::CalcROIProperties(recob::Wire const& wire, size_t const& roi_idx)
+{
+  // get the ROI
+  recob::Wire::RegionsOfInterest_t::datarange_t const& roi = wire.SignalROI().get_ranges()[roi_idx];
+
+  // initialize the return value
+  ROIProperties_t roi_vals;
+  roi_vals.channel = wire.Channel();
+  roi_vals.view    = wire.View();
+  roi_vals.begin   = roi.begin_index();
+  roi_vals.end     = roi.end_index();
+  roi_vals.center  = 0;
+  roi_vals.total_q = 0;
+  roi_vals.sigma   = 0;
+
+  // loop over the roi and find the charge-weighted center and total charge
+  auto const& roi_data = roi.data();
+  for (size_t i_t = 0; i_t < roi_data.size(); ++i_t)
+  {
+    roi_vals.center += roi_data[i_t]*(i_t+roi_vals.begin);
+    roi_vals.total_q += roi_data[i_t];
+  }
+  roi_vals.center = roi_vals.center/roi_vals.total_q;
+
+  // get the width (again charge-weighted)
+  // if the ROI is only one tick set the cent to the middle of the tick and width to 0.5
+  for (size_t i_t = 0; i_t<roi_data.size(); ++i_t)
+  {
+    roi_vals.sigma += roi_data[i_t]*(i_t+roi_vals.begin-roi_vals.center)*(i_t+roi_vals.begin-roi_vals.center);
+  }
+  roi_vals.sigma = std::sqrt(roi_vals.sigma/roi_vals.total_q);
+  if (roi_vals.end-roi_vals.begin == 1)
+  {
+    roi_vals.center += 0.5;
+    roi_vals.sigma   = 0.5;
+  }
+  
+  // return the calc'd properies
+  return roi_vals;
+}
+
+//--- GetTargetROIs ---
+std::vector<std::pair<unsigned int, unsigned int>> sys::WireModUtility::GetTargetROIs(sim::SimEnergyDeposit const& shifted_edep, double offset)
+{
+  // initialize return value
+  // the pairs are <channel number, tick time>
+  std::vector<std::pair<unsigned int, unsigned int>> target_roi_vec;
+
+  // if the SimEnergyDeposit isn't inside the TPC then it's not going to match a wire
+  geo::TPCGeo const* curTPCGeomPtr = geometry->PositionToTPCptr(shifted_edep.MidPoint());
+  if (curTPCGeomPtr == nullptr)
+    return target_roi_vec;
+
+  // iterate over planes
+  for (auto const& plane : wireReadout->Iterate<geo::PlaneGeo>(curTPCGeomPtr->ID())) {
+    // check the wire exists in this plane
+    int wireNumber = int(0.5 + plane.WireCoordinate(shifted_edep.MidPoint()));
+    if ((wireNumber < 0) || (wireNumber >= (int)plane.Nwires()))
+      continue;
+    
+    // reconstruct the wireID from the position
+    geo::WireID edep_wireID = plane.NearestWireID(shifted_edep.MidPoint());
+ 
+    // if the deposition is inside the range where it would leave a signal on the wire, look for the ROI there
+    if (planeXInWindow(shifted_edep.X(), plane, *curTPCGeomPtr, offset + tickOffset))
+      target_roi_vec.emplace_back(wireReadout->PlaneWireToChannel(edep_wireID), std::round(planeXToTick(shifted_edep.X(), plane, *curTPCGeomPtr, offset + tickOffset)));
+  }
+  /*
+  for (size_t i_p = 0; i_p < curTPCGeomPtr->Nplanes(); ++i_p)
+  {
+    // check the wire exists in this plane
+    int wireNumber = int(0.5 + curTPCGeomPtr->Plane(i_p).WireCoordinate(shifted_edep.MidPoint()));
+    if ((wireNumber < 0) || (wireNumber >= (int) curTPCGeomPtr->Plane(i_p).Nwires()))
+      continue;
+    
+    // reconstruct the wireID from the position
+    geo::WireID edep_wireID = curTPCGeomPtr->Plane(i_p).NearestWireID(shifted_edep.MidPoint());
+ 
+    // if the deposition is inside the range where it would leave a signal on the wire, look for the ROI there
+    if (planeXInWindow(shifted_edep.X(), i_p, *curTPCGeomPtr, offset + tickOffset))
+      target_roi_vec.emplace_back(geometry->PlaneWireToChannel(edep_wireID), std::round(planeXToTick(shifted_edep.X(), i_p, *curTPCGeomPtr, offset + tickOffset)));
+  }
+  */
+
+  return target_roi_vec;
+}
+
+//--- GetHitTargetROIs ---
+std::vector<std::pair<unsigned int, unsigned int>> sys::WireModUtility::GetHitTargetROIs(recob::Hit const& hit)
+{
+  // initialize return value
+  // the pairs are <channel number, tick time>
+  std::vector<std::pair<unsigned int, unsigned int>> target_roi_vec;
+
+  int hit_wire = hit.Channel();
+  int hit_tick = int(round(hit.PeakTime()));
+
+  if (hit_tick < tickOffset || hit_tick >= readoutWindowTicks + tickOffset)
+    return target_roi_vec;
+
+
+  target_roi_vec.emplace_back((unsigned int) hit_wire, (unsigned int) hit_tick);
+
+  return target_roi_vec;
+}
+
+//--- FillROIMatchedIDEMap ---
+void sys::WireModUtility::FillROIMatchedIDEMap(std::vector<sim::SimChannel> const& simchVec, std::vector<recob::Wire> const& wireVec, double offset)
+{
+}
+
+//--- FillROIMatchedEdepMap ---
+void sys::WireModUtility::FillROIMatchedEdepMap(std::vector<sim::SimEnergyDeposit> const& edepVec, std::vector<recob::Wire> const& wireVec, double offset)
+{
+  // clear the map in case it was already set
+  ROIMatchedEdepMap.clear();
+
+  // get the channel from each wire and set up a map between them
+  std::unordered_map<unsigned int,unsigned int> wireChannelMap;
+  for (size_t i_w = 0; i_w < wireVec.size(); ++i_w)
+    wireChannelMap[wireVec[i_w].Channel()] = i_w;
+
+  // loop over the energy deposits
+  for (size_t i_e = 0; i_e < edepVec.size(); ++i_e)
+  {
+    // get the ROIs
+    // <channel number, tick time>
+    std::vector<std::pair<unsigned int, unsigned int>> target_rois = GetTargetROIs(edepVec[i_e], offset);
+    
+    // loop over ROI and match the energy deposits with wires
+    for (auto const& target_roi : target_rois)
+    {
+      // if we can't find the wire, skip it
+      if (wireChannelMap.find(target_roi.first) == wireChannelMap.end())
+        continue;
+
+      // get the wire
+      auto const& target_wire = wireVec.at(wireChannelMap[target_roi.first]);
+
+      // if there are no ticks in in the wire skip it
+      // likewise if there's nothing in the region of interst
+      if (not target_wire.SignalROI().is_valid()              ||
+          target_wire.SignalROI().empty()                     ||
+          target_wire.SignalROI().n_ranges() == 0             ||
+          target_wire.SignalROI().size() <= target_roi.second ||
+          target_wire.SignalROI().is_void(target_roi.second)   )
+        continue;
+
+      // how far into the range is the ROI?
+      auto range_number = target_wire.SignalROI().find_range_iterator(target_roi.second) - target_wire.SignalROI().begin_range();
+
+      // popluate the map
+      ROIMatchedEdepMap[std::make_pair(target_wire.Channel(),range_number)].push_back(i_e);
+    }
+  }
+}
+
+//--- FillROIMatchedHitMap ---
+void sys::WireModUtility::FillROIMatchedHitMap(std::vector<recob::Hit> const& hitVec, std::vector<recob::Wire> const& wireVec)
+{
+  // clear the map in case it was already set
+  ROIMatchedHitMap.clear();
+
+  // get the channel from each wire and set up a map between them
+  std::unordered_map<unsigned int,unsigned int> wireChannelMap;
+  for (size_t i_w = 0; i_w < wireVec.size(); ++i_w)
+    wireChannelMap[wireVec[i_w].Channel()] = i_w;
+
+  // loop over hits
+  for (size_t i_h = 0; i_h < hitVec.size(); ++i_h)
+  {
+    // get the ROIs
+    // <channel number, tick time>
+    std::vector<std::pair<unsigned int, unsigned int>> target_rois = GetHitTargetROIs(hitVec[i_h]);
+
+    // loop over ROI and match the energy deposits with wires
+    for (auto const& target_roi : target_rois)
+    {
+      // if we can't find the wire, skip it
+      if (wireChannelMap.find(target_roi.first) == wireChannelMap.end())
+        continue;
+
+      auto const& target_wire = wireVec.at(wireChannelMap[target_roi.first]);
+
+      // if there are no ticks in in the wire skip it
+      // likewise if there's nothing in the region of interst
+      if (not target_wire.SignalROI().is_valid()              ||
+          target_wire.SignalROI().empty()                     ||
+          target_wire.SignalROI().n_ranges() == 0             ||
+          target_wire.SignalROI().size() <= target_roi.second ||
+          target_wire.SignalROI().is_void(target_roi.second)   )
+        continue;
+
+      // which range is it?
+      auto range_number = target_wire.SignalROI().find_range_iterator(target_roi.second) - target_wire.SignalROI().begin_range();
+
+      // pupluate the map
+      ROIMatchedHitMap[std::make_pair(target_wire.Channel(),range_number)].push_back(i_h);
+    }
+  }
+}
+
+//--- CalcSubROIProperties ---
+std::vector<sys::WireModUtility::SubROIProperties_t> sys::WireModUtility::CalcSubROIProperties(sys::WireModUtility::ROIProperties_t const& roi_properties, std::vector<const recob::Hit*> const& hitPtrVec)
+{
+  std::vector<sys::WireModUtility::SubROIProperties_t> subroi_properties_vec;
+  sys::WireModUtility::SubROIProperties_t subroi_properties;
+  subroi_properties.channel = roi_properties.channel;
+  subroi_properties.view    = roi_properties.view;
+
+  // if this ROI doesn't contain any hits, define subROI based on ROI properities
+  // otherwise, define subROIs based on hits
+  if (hitPtrVec.size() == 0)
+  {
+    subroi_properties.key     = std::make_pair(roi_properties.key, 0);
+    subroi_properties.total_q = roi_properties.total_q;
+    subroi_properties.center  = roi_properties.center;
+    subroi_properties.sigma   = roi_properties.sigma;
+    subroi_properties_vec.push_back(subroi_properties);
+  } else
+  {
+    for (unsigned int i_h=0; i_h < hitPtrVec.size(); ++i_h)
+    {
+      auto hit_ptr = hitPtrVec[i_h];
+      subroi_properties.key     = std::make_pair(roi_properties.key, i_h);
+      subroi_properties.total_q = hit_ptr->Integral();
+      subroi_properties.center  = hit_ptr->PeakTime();
+      subroi_properties.sigma   = hit_ptr->RMS();
+      subroi_properties_vec.push_back(subroi_properties);
+    }
+  }
+
+  return subroi_properties_vec;
+}
+
+//--- MatchEdepsToSubROIs ---
+std::map<sys::WireModUtility::SubROI_Key_t, std::vector<const sim::SimEnergyDeposit*>> sys::WireModUtility::MatchEdepsToSubROIs(std::vector<sys::WireModUtility::SubROIProperties_t> const& subROIPropVec, 
+                                                                                                                  std::vector<const sim::SimEnergyDeposit*> const& edepPtrVec, double offset)
+{
+  // for each TrackID, which EDeps are associated with it? keys are TrackIDs
+  std::map<int, std::vector<const sim::SimEnergyDeposit*>> TrackIDMatchedEDepMap;
+
+  // total energy of EDeps matched to the ROI (not strictly necessary, but useful for understanding/development
+  double total_energy = 0.0;
+
+  // loop over edeps, fill TrackIDMatchedEDepMap and calculate total energy
+  for (auto const& edep_ptr : edepPtrVec)
+  {
+    TrackIDMatchedEDepMap[edep_ptr->TrackID()].push_back(edep_ptr);
+    total_energy += edep_ptr->E();
+  }
+
+  // calculate EDep properties by TrackID
+  std::map<int, sys::WireModUtility::TruthProperties_t> TrackIDMatchedPropertyMap;
+  for (auto const& track_edeps : TrackIDMatchedEDepMap)
+    TrackIDMatchedPropertyMap[track_edeps.first] = CalcPropertiesFromEdeps(track_edeps.second, offset);
+
+  // map it all out
+  std::map<unsigned int, std::vector<unsigned int>> EDepMatchedSubROIMap;        // keys are indexes of edepPtrVec, values are vectors of indexes of subROIPropVec
+  std::map<int, std::unordered_set<unsigned int>>   TrackIDMatchedSubROIMap;     // keys are TrackIDs, values are sets of indexes of subROIPropVec
+  std::map<unsigned int, std::vector<unsigned int>> SubROIMatchedEDepMap;        // keys are indexes of subROIPropVec, values are vectors of indexes of edepPtrVec
+  std::map<unsigned int, std::map<int, double>>     SubROIMatchedTrackEnergyMap; // keys are indexes of subROIPropVec, values are maps of TrackIDs to matched energy (in MeV)
+
+  // loop over EDeps
+  for (unsigned int i_e = 0; i_e < edepPtrVec.size(); ++i_e)
+  {
+    // get EDep properties
+    auto edep_ptr  = edepPtrVec[i_e];
+    const geo::TPCGeo& curTPCGeom = geometry->PositionToTPC(edep_ptr->MidPoint());
+    const auto plane0 = wireReadout->FirstPlane(curTPCGeom.ID());
+    double ticksPercm = detPropData.GetXTicksCoefficient(); // this should be by TPCID, but isn't building right now
+    double zeroTick = detPropData.ConvertXToTicks(0, plane0.ID());
+    auto edep_tick = ticksPercm * edep_ptr->X() + (zeroTick + offset) + tickOffset;
+    edep_tick = detPropData.ConvertXToTicks(edep_ptr->X(), plane0.ID()) + offset + tickOffset;
+
+    // loop over subROIs
+    unsigned int closest_hit = std::numeric_limits<unsigned int>::max();
+    float min_dist = std::numeric_limits<float>::max();
+    for (unsigned int i_h = 0; i_h < subROIPropVec.size(); ++i_h)
+    {
+      auto subroi_prop = subROIPropVec[i_h];
+      if (edep_tick > subroi_prop.center-subroi_prop.sigma && edep_tick < subroi_prop.center+subroi_prop.sigma)
+      {
+        EDepMatchedSubROIMap[i_e].push_back(i_h);
+        TrackIDMatchedSubROIMap[edep_ptr->TrackID()].emplace(i_h);
+      }
+      float hit_dist = std::abs(edep_tick - subroi_prop.center) / subroi_prop.sigma;
+      if (hit_dist < min_dist)
+      {
+        closest_hit = i_h;
+        min_dist = hit_dist;
+      }
+    }
+
+    // if EDep is less than 2.5 units away from closest subROI, assign it to that subROI
+    if (min_dist < 5) // try 5 for testing purposes
+    {
+      auto i_h = closest_hit;
+      SubROIMatchedEDepMap[i_h].push_back(i_e);
+      SubROIMatchedTrackEnergyMap[i_h][edep_ptr->TrackID()] += edep_ptr->E();
+    }
+  }
+
+  // convert to desired format (possibly a better way to do this...?)
+  std::map<SubROI_Key_t, std::vector<const sim::SimEnergyDeposit*>> ReturnMap;
+  for (auto it_h = SubROIMatchedEDepMap.begin(); it_h != SubROIMatchedEDepMap.end(); ++it_h)
+  {
+    auto key = subROIPropVec[it_h->first].key;
+    for (auto const& i_e : it_h->second)
+    {
+      ReturnMap[key].push_back(edepPtrVec[i_e]);
+    }
+  }
+
+  return ReturnMap;
+}
+
+//--- CalcPropertiesFromEdeps ---
+sys::WireModUtility::TruthProperties_t sys::WireModUtility::CalcPropertiesFromEdeps(std::vector<const sim::SimEnergyDeposit*> const& edepPtrVec, double offset)
+{
+  //split the edeps by TrackID
+  std::map< int, std::vector<const sim::SimEnergyDeposit*> > edepptrs_by_trkid;
+  std::map< int, double > energy_per_trkid;
+  for(auto const& edep_ptr : edepPtrVec)
+  {
+    edepptrs_by_trkid[edep_ptr->TrackID()].push_back(edep_ptr);
+    energy_per_trkid[edep_ptr->TrackID()]+=edep_ptr->E();
+  }
+
+  int trkid_max     = std::numeric_limits<int>::min();
+  double energy_max = std::numeric_limits<double>::min();
+  for(auto const& e_p_id : energy_per_trkid)
+  {
+    if(e_p_id.second > energy_max)
+    {
+      trkid_max = e_p_id.first;
+      energy_max = e_p_id.second;
+    }
+  }
+
+  auto edepPtrVecMaxE = edepptrs_by_trkid[trkid_max];
+  
+  //first, let's loop over all edeps and get an average weight scale...
+  sys::WireModUtility::TruthProperties_t edep_props;
+  double total_energy_all = 0.0;
+  sys::WireModUtility::ScaleValues_t scales_e_weighted[3];
+  for(size_t i_p = 0; i_p < 3; ++i_p)
+  {
+    scales_e_weighted[i_p].r_Q     = 0.0;
+    scales_e_weighted[i_p].r_sigma = 0.0;
+  }
+
+  for(auto const edep_ptr : edepPtrVec)
+  {
+    if (edep_ptr->StepLength() == 0)
+      continue;
+
+    edep_props.x = edep_ptr->X();
+    edep_props.y = edep_ptr->Y();
+    edep_props.z = edep_ptr->Z();
+
+    edep_props.dxdr = (edep_ptr->EndX() - edep_ptr->StartX()) / edep_ptr->StepLength();
+    edep_props.dydr = (edep_ptr->EndY() - edep_ptr->StartY()) / edep_ptr->StepLength();
+    edep_props.dzdr = (edep_ptr->EndZ() - edep_ptr->StartZ()) / edep_ptr->StepLength();
+    edep_props.dedr = edep_ptr->E() / edep_ptr->StepLength();
+
+    total_energy_all += edep_ptr->E();
+
+    const geo::TPCGeo& curTPCGeom = geometry->PositionToTPC(edep_ptr->MidPoint());
+    for (auto const& plane : wireReadout->Iterate<geo::PlaneGeo>(curTPCGeom.ID())) {
+      int i_p = plane.ID().Plane;
+      auto scales = GetViewScaleValues(edep_props, plane.View());
+      scales_e_weighted[i_p].r_Q     += edep_ptr->E()*scales.r_Q;
+      scales_e_weighted[i_p].r_sigma += edep_ptr->E()*scales.r_sigma; 
+    }
+  }
+
+  for(size_t i_p = 0; i_p < 3; ++i_p)
+  {
+    if (total_energy_all > 0)
+    {
+      scales_e_weighted[i_p].r_Q     = scales_e_weighted[i_p].r_Q / total_energy_all;
+      scales_e_weighted[i_p].r_sigma = scales_e_weighted[i_p].r_sigma / total_energy_all;
+    }
+    if (scales_e_weighted[i_p].r_Q == 0)
+      scales_e_weighted[i_p].r_Q = 1;
+    if (scales_e_weighted[i_p].r_sigma == 0)
+      scales_e_weighted[i_p].r_sigma = 1;
+  }
+
+  TruthProperties_t edep_col_properties;
+
+  //copy in the scales that were calculated before
+  for(size_t i_p = 0; i_p < 3; ++i_p)
+  {
+    edep_col_properties.scales_avg[i_p].r_Q = scales_e_weighted[i_p].r_Q;
+    edep_col_properties.scales_avg[i_p].r_sigma = scales_e_weighted[i_p].r_sigma;
+  }
+
+  // calculations happen here
+  edep_col_properties.x              = 0.;
+  edep_col_properties.x_rms          = 0.;
+  edep_col_properties.x_rms_noWeight = 0.;
+  edep_col_properties.x_min          = std::numeric_limits<float>::max();
+  edep_col_properties.x_max          = std::numeric_limits<float>::min();
+
+  edep_col_properties.y    = 0.;
+  edep_col_properties.z    = 0.;
+  edep_col_properties.dxdr = 0.;
+  edep_col_properties.dydr = 0.;
+  edep_col_properties.dzdr = 0.;
+  edep_col_properties.dedr = 0.;
+
+  double total_energy = 0.0;
+  for (auto const& edep_ptr : edepPtrVecMaxE)
+  {
+    edep_col_properties.x += edep_ptr->X()*edep_ptr->E();
+    edep_col_properties.x_min = (edep_ptr->X() < edep_col_properties.x_min) ? edep_ptr->X() : edep_col_properties.x_min;
+    edep_col_properties.x_max = (edep_ptr->X() > edep_col_properties.x_max) ? edep_ptr->X() : edep_col_properties.x_max;
+    total_energy += edep_ptr->E();
+    edep_col_properties.y += edep_ptr->Y()*edep_ptr->E();
+    edep_col_properties.z += edep_ptr->Z()*edep_ptr->E();
+
+    if (edep_ptr->StepLength() == 0)
+      continue;
+
+    edep_col_properties.dxdr += edep_ptr->E()*(edep_ptr->EndX() - edep_ptr->StartX()) / edep_ptr->StepLength();
+    edep_col_properties.dydr += edep_ptr->E()*(edep_ptr->EndY() - edep_ptr->StartY()) / edep_ptr->StepLength();
+    edep_col_properties.dzdr += edep_ptr->E()*(edep_ptr->EndZ() - edep_ptr->StartZ()) / edep_ptr->StepLength();
+    edep_col_properties.dedr += edep_ptr->E()*edep_ptr->E() / edep_ptr->StepLength();
+  }
+
+  if (total_energy > 0)
+  {
+    edep_col_properties.x    = edep_col_properties.x / total_energy;
+    edep_col_properties.y    = edep_col_properties.y / total_energy;
+    edep_col_properties.z    = edep_col_properties.z / total_energy;
+    edep_col_properties.dxdr = edep_col_properties.dxdr / total_energy;
+    edep_col_properties.dydr = edep_col_properties.dydr / total_energy;
+    edep_col_properties.dzdr = edep_col_properties.dzdr / total_energy;
+    edep_col_properties.dedr = edep_col_properties.dedr / total_energy;
+  }
+
+  for (auto const& edep_ptr : edepPtrVecMaxE)
+  {
+    edep_col_properties.x_rms          += (edep_ptr->X()-edep_col_properties.x)*(edep_ptr->X()-edep_col_properties.x)*edep_ptr->E();
+    edep_col_properties.x_rms_noWeight += (edep_ptr->X()-edep_col_properties.x)*(edep_ptr->X()-edep_col_properties.x);
+  }
+  edep_col_properties.x_rms_noWeight = std::sqrt(edep_col_properties.x_rms_noWeight);
+
+  if (total_energy > 0)
+    edep_col_properties.x_rms = std::sqrt(edep_col_properties.x_rms/total_energy);
+
+  const geo::TPCGeo& tpcGeom = geometry->PositionToTPC({edep_col_properties.x, edep_col_properties.y, edep_col_properties.z});
+  const auto plane0 = wireReadout->FirstPlane(tpcGeom.ID());
+  double ticksPercm = detPropData.GetXTicksCoefficient(); // this should be by TPCID, but isn't building right now
+  edep_col_properties.tick              = detPropData.ConvertXToTicks(edep_col_properties.x    , plane0.ID()) + offset + tickOffset;
+  edep_col_properties.tick_rms          = ticksPercm*edep_col_properties.x_rms;
+  edep_col_properties.tick_rms_noWeight = ticksPercm*edep_col_properties.x_rms_noWeight;
+  edep_col_properties.tick_min          = detPropData.ConvertXToTicks(edep_col_properties.x_min, plane0.ID()) + offset + tickOffset;
+  edep_col_properties.tick_max          = detPropData.ConvertXToTicks(edep_col_properties.x_max, plane0.ID()) + offset + tickOffset;
+  edep_col_properties.total_energy      = total_energy;
+  
+
+  return edep_col_properties; 
+}
+
+//--- GetScaleValues ---
+sys::WireModUtility::ScaleValues_t sys::WireModUtility::GetScaleValues(sys::WireModUtility::TruthProperties_t const& truth_props, sys::WireModUtility::ROIProperties_t const& roi_vals)
+{
+  sys::WireModUtility::ScaleValues_t scales;
+  sys::WireModUtility::ScaleValues_t channelScales = GetChannelScaleValues(truth_props, roi_vals.channel);
+  sys::WireModUtility::ScaleValues_t viewScales    = GetViewScaleValues(truth_props, roi_vals.view);
+  scales.r_Q     = channelScales.r_Q     * viewScales.r_Q;
+  scales.r_sigma = channelScales.r_sigma * viewScales.r_sigma;
+  return scales;
+}
+
+//--- GetChannelScaleValues ---
+sys::WireModUtility::ScaleValues_t sys::WireModUtility::GetChannelScaleValues(sys::WireModUtility::TruthProperties_t const& truth_props, raw::ChannelID_t const& channel)
+{
+  // initialize return
+  sys::WireModUtility::ScaleValues_t scales;
+  scales.r_Q     = 1.0;
+  scales.r_sigma = 1.0;
+  
+  // try to get geo
+  // if not in a TPC return default values
+  double const truth_coords[3] = {truth_props.x, truth_props.y, truth_props.z};
+  geo::TPCGeo const* curTPCGeomPtr = geometry->PositionToTPCptr(geo::vect::makePointFromCoords(truth_coords));
+  if (curTPCGeomPtr == nullptr)
+    return scales;
+
+  if (applyChannelScale)
+  {
+    if (spline_Charge_Channel == nullptr ||
+        spline_Sigma_Channel  == nullptr  )
+      throw cet::exception("WireModUtility")
+        << "Tried to apply channel scale factor, but could not find splines. Check that you have set those in the utility.";
+    scales.r_Q     *= spline_Charge_Channel->Eval(channel);
+    scales.r_sigma *= spline_Sigma_Channel ->Eval(channel);
+  }
+
+  return scales;
+}
+
+//--- GetViewScaleValues ---
+sys::WireModUtility::ScaleValues_t sys::WireModUtility::GetViewScaleValues(sys::WireModUtility::TruthProperties_t const& truth_props, geo::View_t const& view)
+{
+  // initialize return
+  sys::WireModUtility::ScaleValues_t scales;
+  scales.r_Q     = 1.0;
+  scales.r_sigma = 1.0;
+  
+  double temp_scale=1.0;
+  
+  // try to get geo
+  // if not in a TPC return default values
+  double const truth_coords[3] = {truth_props.x, truth_props.y, truth_props.z};
+  geo::TPCGeo const* curTPCGeomPtr = geometry->PositionToTPCptr(geo::vect::makePointFromCoords(truth_coords));
+  if (curTPCGeomPtr == nullptr)
+    return scales;
+
+  // get the plane number by the view
+  auto const& plane_obj = wireReadout->Plane(curTPCGeomPtr->ID(), view);
+  unsigned int plane = plane_obj.ID().Plane;
+
+  if (applyXScale)
+  {
+    if (splines_Charge_X[plane] == nullptr || 
+        splines_Sigma_X [plane] == nullptr  )
+      throw cet::exception("WireModUtility")
+        << "Tried to apply X scale factor, but could not find splines. Check that you have set those in the utility.";
+    scales.r_Q     *= splines_Charge_X[plane]->Eval(truth_props.x);
+    scales.r_sigma *= splines_Sigma_X [plane]->Eval(truth_props.x);
+  }
+  
+  if (applyYZScale)
+  {
+    if (graph2Ds_Charge_YZ[plane] == nullptr || 
+        graph2Ds_Sigma_YZ [plane] == nullptr  )
+      throw cet::exception("WireModUtility")
+        << "Tried to apply YZ scale factor, but could not find graphs. Check that you have set those in the utility.";
+    temp_scale = graph2Ds_Charge_YZ[plane]->Interpolate(truth_props.z, truth_props.y);
+    if(temp_scale>0.001) scales.r_Q *= temp_scale;
+
+    temp_scale  = graph2Ds_Sigma_YZ [plane]->Interpolate(truth_props.z, truth_props.y);
+    if(temp_scale>0.001) scales.r_sigma *= temp_scale;
+  }
+
+  if (applyXZAngleScale)
+  {
+    if (splines_Charge_XZAngle[plane] == nullptr || 
+        splines_Sigma_XZAngle [plane] == nullptr  )
+      throw cet::exception("WireModUtility")
+        << "Tried to apply XZ-angle scale factor, but could not find splines. Check that you have set those in the utility.";
+    scales.r_Q     *= splines_Charge_XZAngle[plane]->Eval(ThetaXZ_PlaneRel(truth_props.dxdr, truth_props.dydr, truth_props.dzdr, plane_obj.ThetaZ()));
+    scales.r_sigma *= splines_Sigma_XZAngle [plane]->Eval(ThetaXZ_PlaneRel(truth_props.dxdr, truth_props.dydr, truth_props.dzdr, plane_obj.ThetaZ()));
+  }
+  if (applyYZAngleScale)
+  {
+    if (splines_Charge_YZAngle[plane] == nullptr || 
+        splines_Sigma_YZAngle [plane] == nullptr  )
+      throw cet::exception("WireModUtility")
+        << "Tried to apply YZ-angle scale factor, but could not find splines. Check that you have set those in the utility.";
+    scales.r_Q     *= splines_Charge_YZAngle[plane]->Eval(ThetaYZ_PlaneRel(truth_props.dxdr, truth_props.dydr, truth_props.dzdr, plane_obj.ThetaZ()));
+    scales.r_sigma *= splines_Sigma_YZAngle [plane]->Eval(ThetaYZ_PlaneRel(truth_props.dxdr, truth_props.dydr, truth_props.dzdr, plane_obj.ThetaZ()));
+  }
+
+  if(applydEdXScale)
+  {
+    if (splines_Charge_dEdX[plane] == nullptr || 
+        splines_Sigma_dEdX [plane] == nullptr  )
+      throw cet::exception("WireModUtility")
+        << "Tried to apply dEdX scale factor, but could not find splines. Check that you have set those in the utility.";
+    scales.r_Q     *= splines_Charge_dEdX[plane]->Eval(truth_props.dedr);
+    scales.r_sigma *= splines_Sigma_dEdX [plane]->Eval(truth_props.dedr);
+  }
+
+  return scales;
+}
+
+//--- ModifyROI ---
+void sys::WireModUtility::ModifyROI(std::vector<float> & roi_data,
+                                    sys::WireModUtility::ROIProperties_t const& roi_prop,
+                                    std::vector<sys::WireModUtility::SubROIProperties_t> const& subROIPropVec,
+                                    std::map<sys::WireModUtility::SubROI_Key_t, sys::WireModUtility::ScaleValues_t> const& subROIScaleMap)
+{
+  // do you want a bunch of messages?
+  bool verbose = false;
+  
+  // initialize some values
+  double q_orig = 0.0;
+  double q_mod  = 0.0;
+  double scale_ratio = 1.0;
+
+  // loop over the ticks
+  for(size_t i_t = 0; i_t < roi_data.size(); ++i_t)
+  {
+    // reset your values
+    q_orig = 0.0;
+    q_mod  = 0.0;
+    scale_ratio = 1.0;
+
+    // loop over the subs
+    for (auto const& subroi_prop : subROIPropVec)
+    {
+      // get your scale vals
+      auto scale_vals = subROIScaleMap.find(subroi_prop.key)->second;
+
+      q_orig += gausFunc(i_t + roi_prop.begin, subroi_prop.center,                      subroi_prop.sigma,                  subroi_prop.total_q);
+      q_mod  += gausFunc(i_t + roi_prop.begin, subroi_prop.center, scale_vals.r_sigma * subroi_prop.sigma, scale_vals.r_Q * subroi_prop.total_q);
+
+      if (verbose)
+        std::cout << "    Incrementing q_orig by gausFunc(" << i_t + roi_prop.begin << ", " << subroi_prop.center << ", " <<                      subroi_prop.sigma << ", " <<                  subroi_prop.total_q << ")" << '\n'
+                  << "    Incrementing q_mod  by gausFunc(" << i_t + roi_prop.begin << ", " << subroi_prop.center << ", " << scale_vals.r_sigma * subroi_prop.sigma << ", " << scale_vals.r_Q * subroi_prop.total_q << ")" << std::endl;
+    }
+
+    // do some sanity checks
+    if        (isnan(q_orig))
+    {
+      if (verbose)
+        std::cout << "WARNING: obtained q_orig = NaN... setting scale to 1" << std::endl;
+      scale_ratio = 1.0;
+    } else if (isnan(q_mod)) {
+      if (verbose)
+        std::cout << "WARNING: obtained q_mod = NaN... setting scale to 0" << std::endl;
+      scale_ratio = 0.0;
+    } else {
+      scale_ratio = q_mod / q_orig;
+    }
+    if(isnan(scale_ratio) || isinf(scale_ratio))
+    {
+      if (verbose)
+        std::cout << "WARNING: obtained scale_ratio = " << q_mod << " / " << q_orig << " = NAN/Inf... setting to 1" << std::endl;
+      scale_ratio = 1.0;
+    }
+
+    roi_data[i_t] = scale_ratio * roi_data[i_t];
+    if (verbose)
+      std::cout << "\t tick " << i_t << ":"
+                <<  " data="   << roi_data[i_t]
+                << ", q_orig=" << q_orig
+                << ", q_mod="  << q_mod
+                << ", ratio="  << scale_ratio << std::endl;
+  }
+
+  // we're done now
+  return;
+}

--- a/sbncode/WireMod/Utility/WireModUtility.cc
+++ b/sbncode/WireMod/Utility/WireModUtility.cc
@@ -108,11 +108,6 @@ std::vector<std::pair<unsigned int, unsigned int>> sys::WireModUtility::GetHitTa
   return target_roi_vec;
 }
 
-//--- FillROIMatchedIDEMap ---
-void sys::WireModUtility::FillROIMatchedIDEMap(std::vector<sim::SimChannel> const& simchVec, std::vector<recob::Wire> const& wireVec, double offset)
-{
-}
-
 //--- FillROIMatchedEdepMap ---
 void sys::WireModUtility::FillROIMatchedEdepMap(std::vector<sim::SimEnergyDeposit> const& edepVec, std::vector<recob::Wire> const& wireVec, double offset)
 {
@@ -367,7 +362,6 @@ sys::WireModUtility::TruthProperties_t sys::WireModUtility::CalcPropertiesFromEd
     edep_props.dydr = (edep_ptr->EndY() - edep_ptr->StartY()) / edep_ptr->StepLength();
     edep_props.dzdr = (edep_ptr->EndZ() - edep_ptr->StartZ()) / edep_ptr->StepLength();
 
-    edep_props.dqdr = edep_ptr->NumElectrons() / edep_ptr->StepLength();
     edep_props.dedr = edep_ptr->E() / edep_ptr->StepLength();
 
     total_energy_all += edep_ptr->E();
@@ -416,7 +410,6 @@ sys::WireModUtility::TruthProperties_t sys::WireModUtility::CalcPropertiesFromEd
   edep_col_properties.dydr = 0.;
   edep_col_properties.dzdr = 0.;
 
-  edep_col_properties.dqdr = 0.;
   edep_col_properties.dedr = 0.;
 
   double total_energy = 0.0;
@@ -436,7 +429,6 @@ sys::WireModUtility::TruthProperties_t sys::WireModUtility::CalcPropertiesFromEd
     edep_col_properties.dydr += edep_ptr->E()*(edep_ptr->EndY() - edep_ptr->StartY()) / edep_ptr->StepLength();
     edep_col_properties.dzdr += edep_ptr->E()*(edep_ptr->EndZ() - edep_ptr->StartZ()) / edep_ptr->StepLength();
 
-    edep_col_properties.dqdr += edep_ptr->E()*edep_ptr->NumElectrons() / edep_ptr->StepLength();
     edep_col_properties.dedr += edep_ptr->E()*edep_ptr->E() / edep_ptr->StepLength();
   }
 
@@ -449,7 +441,6 @@ sys::WireModUtility::TruthProperties_t sys::WireModUtility::CalcPropertiesFromEd
     edep_col_properties.dydr = edep_col_properties.dydr / total_energy;
     edep_col_properties.dzdr = edep_col_properties.dzdr / total_energy;
 
-    edep_col_properties.dqdr = edep_col_properties.dqdr / total_energy;
     edep_col_properties.dedr = edep_col_properties.dedr / total_energy;
   }
 

--- a/sbncode/WireMod/Utility/WireModUtility.cc
+++ b/sbncode/WireMod/Utility/WireModUtility.cc
@@ -366,6 +366,8 @@ sys::WireModUtility::TruthProperties_t sys::WireModUtility::CalcPropertiesFromEd
     edep_props.dxdr = (edep_ptr->EndX() - edep_ptr->StartX()) / edep_ptr->StepLength();
     edep_props.dydr = (edep_ptr->EndY() - edep_ptr->StartY()) / edep_ptr->StepLength();
     edep_props.dzdr = (edep_ptr->EndZ() - edep_ptr->StartZ()) / edep_ptr->StepLength();
+
+    edep_props.dqdr = edep_ptr->NumElectrons() / edep_ptr->StepLength();
     edep_props.dedr = edep_ptr->E() / edep_ptr->StepLength();
 
     total_energy_all += edep_ptr->E();
@@ -413,6 +415,8 @@ sys::WireModUtility::TruthProperties_t sys::WireModUtility::CalcPropertiesFromEd
   edep_col_properties.dxdr = 0.;
   edep_col_properties.dydr = 0.;
   edep_col_properties.dzdr = 0.;
+
+  edep_col_properties.dqdr = 0.;
   edep_col_properties.dedr = 0.;
 
   double total_energy = 0.0;
@@ -431,6 +435,8 @@ sys::WireModUtility::TruthProperties_t sys::WireModUtility::CalcPropertiesFromEd
     edep_col_properties.dxdr += edep_ptr->E()*(edep_ptr->EndX() - edep_ptr->StartX()) / edep_ptr->StepLength();
     edep_col_properties.dydr += edep_ptr->E()*(edep_ptr->EndY() - edep_ptr->StartY()) / edep_ptr->StepLength();
     edep_col_properties.dzdr += edep_ptr->E()*(edep_ptr->EndZ() - edep_ptr->StartZ()) / edep_ptr->StepLength();
+
+    edep_col_properties.dqdr += edep_ptr->E()*edep_ptr->NumElectrons() / edep_ptr->StepLength();
     edep_col_properties.dedr += edep_ptr->E()*edep_ptr->E() / edep_ptr->StepLength();
   }
 
@@ -442,6 +448,8 @@ sys::WireModUtility::TruthProperties_t sys::WireModUtility::CalcPropertiesFromEd
     edep_col_properties.dxdr = edep_col_properties.dxdr / total_energy;
     edep_col_properties.dydr = edep_col_properties.dydr / total_energy;
     edep_col_properties.dzdr = edep_col_properties.dzdr / total_energy;
+
+    edep_col_properties.dqdr = edep_col_properties.dqdr / total_energy;
     edep_col_properties.dedr = edep_col_properties.dedr / total_energy;
   }
 
@@ -571,7 +579,7 @@ sys::WireModUtility::ScaleValues_t sys::WireModUtility::GetViewScaleValues(sys::
     scales.r_sigma *= splines_Sigma_YZAngle [plane]->Eval(ThetaYZ_PlaneRel(truth_props.dxdr, truth_props.dydr, truth_props.dzdr, plane_obj.ThetaZ()));
   }
 
-  if(applydEdXScale)
+  if (applydEdXScale)
   {
     if (splines_Charge_dEdX[plane] == nullptr || 
         splines_Sigma_dEdX [plane] == nullptr  )
@@ -579,6 +587,45 @@ sys::WireModUtility::ScaleValues_t sys::WireModUtility::GetViewScaleValues(sys::
         << "Tried to apply dEdX scale factor, but could not find splines. Check that you have set those in the utility.";
     scales.r_Q     *= splines_Charge_dEdX[plane]->Eval(truth_props.dedr);
     scales.r_sigma *= splines_Sigma_dEdX [plane]->Eval(truth_props.dedr);
+  }
+
+  if (applyXXZAngleScale)
+  {
+    if (graph2Ds_Charge_XXZAngle[plane] == nullptr || 
+        graph2Ds_Sigma_XXZAngle [plane] == nullptr  )
+      throw cet::exception("WireModUtility")
+        << "Tried to apply XXZAngle scale factor, but could not find graphs. Check that you have set those in the utility.";
+    temp_scale = graph2Ds_Charge_XXZAngle[plane]->Interpolate(truth_props.x, ThetaXZ_PlaneRel(truth_props.dxdr, truth_props.dydr, truth_props.dzdr, plane_obj.ThetaZ()));
+    if(temp_scale>0.001) scales.r_Q *= temp_scale;
+
+    temp_scale = graph2Ds_Sigma_XXZAngle [plane]->Interpolate(truth_props.x, ThetaXZ_PlaneRel(truth_props.dxdr, truth_props.dydr, truth_props.dzdr, plane_obj.ThetaZ()));
+    if(temp_scale>0.001) scales.r_sigma *= temp_scale;
+  }
+
+  if (applyXdQdXScale)
+  {
+    if (graph2Ds_Charge_XdQdX[plane] == nullptr || 
+        graph2Ds_Sigma_XdQdX [plane] == nullptr  )
+      throw cet::exception("WireModUtility")
+        << "Tried to apply XdQdX scale factor, but could not find graphs. Check that you have set those in the utility.";
+    temp_scale = graph2Ds_Charge_XdQdX[plane]->Interpolate(truth_props.x, truth_props.dqdr); 
+    if(temp_scale>0.001) scales.r_Q *= temp_scale;
+
+    temp_scale = graph2Ds_Sigma_XdQdX [plane]->Interpolate(truth_props.x, truth_props.dqdr); 
+    if(temp_scale>0.001) scales.r_sigma *= temp_scale;
+  }
+
+  if (applyXZAngledQdXScale)
+  {
+    if (graph2Ds_Charge_XZAngledQdX[plane] == nullptr || 
+        graph2Ds_Sigma_XZAngledQdX [plane] == nullptr  )
+      throw cet::exception("WireModUtility")
+        << "Tried to apply XZAngledQdX scale factor, but could not find graphs. Check that you have set those in the utility.";
+    temp_scale = graph2Ds_Charge_XZAngledQdX[plane]->Interpolate(ThetaXZ_PlaneRel(truth_props.dxdr, truth_props.dydr, truth_props.dzdr, plane_obj.ThetaZ()), truth_props.dqdr);
+    if(temp_scale>0.001) scales.r_Q *= temp_scale;
+
+    temp_scale = graph2Ds_Sigma_XZAngledQdX [plane]->Interpolate(ThetaXZ_PlaneRel(truth_props.dxdr, truth_props.dydr, truth_props.dzdr, plane_obj.ThetaZ()), truth_props.dqdr);
+    if(temp_scale>0.001) scales.r_sigma *= temp_scale;
   }
 
   return scales;

--- a/sbncode/WireMod/Utility/WireModUtility.hh
+++ b/sbncode/WireMod/Utility/WireModUtility.hh
@@ -1,0 +1,228 @@
+#ifndef sbncode_WireMod_Utility_WireModUtility_hh
+#define sbncode_WireMod_Utility_WireModUtility_hh
+
+//std includes
+#include <vector>
+
+//ROOT includes
+#include "TFile.h"
+#include "TSpline.h"
+#include "TGraph2D.h"
+#include "TNtuple.h"
+
+//Framework includes
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/Geometry/WireReadoutGeom.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
+#include "lardataobj/RecoBase/Track.h"
+#include "lardataobj/RecoBase/TrackHitMeta.h"
+#include "lardataobj/RecoBase/Hit.h"
+#include "lardataobj/RecoBase/Wire.h"
+#include "lardataobj/Simulation/SimEnergyDeposit.h"
+#include "lardataobj/Simulation/SimChannel.h"
+#include "larcoreobj/SimpleTypesAndConstants/PhysicalConstants.h"
+#include "nusimdata/SimulationBase/MCParticle.h"
+#include "nusimdata/SimulationBase/MCTruth.h"
+
+#include <limits>
+#include <memory>
+
+namespace sys {
+  class WireModUtility{
+    // for now make everything public, though it's probably a good idea to think about what doesn't need to be
+    public:
+      // detector constants, should be set by geometry service
+      // the notes at the end refer to their old names in the MircoBooNE code which preceded this
+      // TODO: how best to initialize the splines/graphs?
+      const geo::GeometryCore* geometry;                  // save the TPC geometry
+      const geo::WireReadoutGeom* wireReadout;            // new for LarSoft v10
+      const detinfo::DetectorPropertiesData& detPropData; // save the detector property data
+      bool   applyChannelScale;                           // do we scale with channel?
+      bool   applyXScale;                                 // do we scale with X?
+      bool   applyYZScale;                                // do we scale with YZ?
+      bool   applyXZAngleScale;                           // do we scale with XZ angle?
+      bool   applyYZAngleScale;                           // do we scale with YZ angle?
+      bool   applydEdXScale;                              // do we scale with dEdx?
+      double readoutWindowTicks;                          // how many ticks are in the readout window?
+      double tickOffset;                                  // do we want an offset in the ticks?
+
+      TSpline3* spline_Charge_Channel;                    // the spline for the charge correction by channel
+      TSpline3* spline_Sigma_Channel;                     // the spline for the width correction by channel
+      std::vector<TSpline3*> splines_Charge_X;            // the splines for the charge correction in X
+      std::vector<TSpline3*> splines_Sigma_X;             // the splines for the width correction in X
+      std::vector<TSpline3*> splines_Charge_XZAngle;      // the splines for the charge correction in XZ angle
+      std::vector<TSpline3*> splines_Sigma_XZAngle;       // the splines for the width correction in XZ angle
+      std::vector<TSpline3*> splines_Charge_YZAngle;      // the splines for the charge correction in YZ angle
+      std::vector<TSpline3*> splines_Sigma_YZAngle;       // the splines for the width correction in YZ angle
+      std::vector<TSpline3*> splines_Charge_dEdX;         // the splines for the charge correction in dEdX
+      std::vector<TSpline3*> splines_Sigma_dEdX;          // the splines for the width correction in dEdX
+      std::vector<TGraph2D*> graph2Ds_Charge_YZ;          // the graphs for the charge correction in YZ
+      std::vector<TGraph2D*> graph2Ds_Sigma_YZ;           // the graphs for the width correction in YZ
+
+      // lets try making a constructor here
+      // assume we can get a geometry service, a detector clcok, and a detector properties
+      // pass the CryoStat and TPC IDs because it's IDs all the way down
+      // set some optional args fpr the booleans, the readout window, and the offset
+      WireModUtility(const geo::GeometryCore* geom, 
+                     const geo::WireReadoutGeom* wireRead,
+                     const detinfo::DetectorPropertiesData& detProp,
+                     const bool& arg_ApplyChannelScale = false, 
+                     const bool& arg_ApplyXScale = true,
+                     const bool& arg_ApplyYZScale = true,
+                     const bool& arg_ApplyXZAngleScale = true,
+                     const bool& arg_ApplyYZAngleScale = true,
+                     const bool& arg_ApplydEdXScale = true,
+                     const double& arg_TickOffset = 0)
+      : geometry(geom),
+        wireReadout(wireRead),
+        detPropData(detProp),
+        applyChannelScale(arg_ApplyChannelScale),
+        applyXScale(arg_ApplyXScale),
+        applyYZScale(arg_ApplyYZScale),
+        applyXZAngleScale(arg_ApplyXZAngleScale),
+        applyYZAngleScale(arg_ApplyYZAngleScale),
+        applydEdXScale(arg_ApplydEdXScale),
+        readoutWindowTicks(detProp.ReadOutWindowSize()),                                               // the default A2795 (ICARUS TPC readout board) readout window is 4096 samples
+        tickOffset(arg_TickOffset)                                                                     // tick offset is for MC truth, default to zero and set only as necessary
+      {
+      }
+
+      // typedefs
+      typedef std::pair<unsigned int,unsigned int>  ROI_Key_t;
+      typedef std::pair<ROI_Key_t, unsigned int> SubROI_Key_t;
+
+      typedef struct ROIProperties
+      {
+        ROI_Key_t key;
+        raw::ChannelID_t channel;
+        geo::View_t view;
+        float begin;
+        float end;
+        float total_q;
+        float center;   //charge weighted center of ROI
+        float sigma;    //charge weighted RMS of ROI
+      } ROIProperties_t;
+
+      typedef struct SubROIProperties
+      {
+        SubROI_Key_t key;
+        raw::ChannelID_t channel;
+        geo::View_t view;
+        float total_q;
+        float center;
+        float sigma;
+      } SubROIProperties_t;
+
+      typedef struct ScaleValues
+      {
+        double r_Q;
+        double r_sigma;
+      } ScaleValues_t;
+
+      typedef struct TruthProperties
+      {
+        float x;
+        float x_rms;
+        float x_rms_noWeight;
+        float tick;
+        float tick_rms;
+        float tick_rms_noWeight;
+        float total_energy;
+        float x_min;
+        float x_max;
+        float tick_min;
+        float tick_max;
+        float y;
+        float z;
+        double dxdr;
+        double dydr;
+        double dzdr;
+        double dedr;
+        ScaleValues_t scales_avg[3];
+      } TruthProperties_t;
+
+      // internal containers
+      std::map< ROI_Key_t,std::vector<size_t> > ROIMatchedEdepMap;
+      std::map< ROI_Key_t,std::vector<size_t> > ROIMatchedHitMap;
+
+      // some useful functions
+      // geometries
+      // TODO is this the most efficient for new v10 iterators?
+      double planeXToTick(double xPos, const geo::PlaneGeo& plane, const geo::TPCGeo& tpcGeom, double offset = 0) {
+          return detPropData.ConvertXToTicks(xPos, plane.ID()) + offset;
+      }
+
+      bool planeXInWindow(double xPos, const geo::PlaneGeo& plane, const geo::TPCGeo& tpcGeom, double offset = 0)
+      {
+        double tick = planeXToTick(xPos, plane, tpcGeom, offset);
+        return (tick > 0 && tick <= detPropData.ReadOutWindowSize());
+      }
+      
+      // for this function: in the future if we want to use non-gaussian functions make this take a vector of parameters
+      // the another wiremod utility could overwrite the ``fitFunc'' with some non-standard function
+      // would require a fair bit of remodling (ie q and sigma would need to be replace with, eg, funcVar[0] and funcVar[1] and probs a bunch of loops)
+      // so lets worry about that later
+      double gausFunc(double t, double mean, double sigma, double a = 1.0)
+      {
+        return (a / (sigma * std::sqrt(2 * util::pi()))) * std::exp(-0.5 * std::pow((t - mean)/sigma, 2));
+      }
+
+      double FoldAngle(double theta)
+      {
+        return (std::abs(theta) > 0.5 * util::pi()) ? util::pi() - std::abs(theta) : std::abs(theta);
+      }
+
+      double ThetaXZ_PlaneRel(double dxdr, double dydr, double dzdr, double planeAngle)
+      {
+        double planeAngleRad = planeAngle * (util::pi() / 180.0);
+        double sinPlaneAngle = std::sin(planeAngleRad);
+        double cosPlaneAngle = std::cos(planeAngleRad);
+
+        //double dydrPlaneRel = dydr * cosPlaneAngle - dzdr * sinPlaneAngle; // don't need to rotate Y for this angle
+        double dzdrPlaneRel = dzdr * cosPlaneAngle + dydr * sinPlaneAngle;
+
+        double theta = std::atan2(dxdr, dzdrPlaneRel);
+        return FoldAngle(theta);
+      }
+
+      double ThetaYZ_PlaneRel(double dxdr, double dydr, double dzdr, double planeAngle)
+      {
+        double planeAngleRad = planeAngle * (util::pi() / 180.0);
+        double sinPlaneAngle = std::sin(planeAngleRad);
+        double cosPlaneAngle = std::cos(planeAngleRad);
+
+        double dydrPlaneRel = dydr * cosPlaneAngle - dzdr * sinPlaneAngle;
+        double dzdrPlaneRel = dzdr * cosPlaneAngle + dydr * sinPlaneAngle;
+
+        double theta = std::atan2(dydrPlaneRel, dzdrPlaneRel);
+        return FoldAngle(theta);
+      }
+      
+      // theste are set in the .cc file
+      ROIProperties_t CalcROIProperties(recob::Wire const&, size_t const&);
+
+      std::vector<std::pair<unsigned int, unsigned int>> GetTargetROIs(sim::SimEnergyDeposit const&, double offset);
+      std::vector<std::pair<unsigned int, unsigned int>> GetHitTargetROIs(recob::Hit const&);
+
+      void FillROIMatchedEdepMap(std::vector<sim::SimEnergyDeposit> const&, std::vector<recob::Wire> const&, double offset);
+      void FillROIMatchedHitMap(std::vector<recob::Hit> const&, std::vector<recob::Wire> const&);
+      void FillROIMatchedIDEMap(std::vector<sim::SimChannel> const& simchVec, std::vector<recob::Wire> const& wireVec, double offset);
+
+      std::vector<SubROIProperties_t> CalcSubROIProperties(ROIProperties_t const&, std::vector<const recob::Hit*> const&);
+
+      std::map<SubROI_Key_t, std::vector<const sim::SimEnergyDeposit*>> MatchEdepsToSubROIs(std::vector<SubROIProperties_t> const&, std::vector<const sim::SimEnergyDeposit*> const&, double offset);
+
+      TruthProperties_t CalcPropertiesFromEdeps(std::vector<const sim::SimEnergyDeposit*> const&, double offset);
+
+      ScaleValues_t GetScaleValues(TruthProperties_t const&, ROIProperties_t const&);
+      ScaleValues_t GetChannelScaleValues(TruthProperties_t const&, raw::ChannelID_t const&);
+      ScaleValues_t GetViewScaleValues(TruthProperties_t const&, geo::View_t const&);
+
+      void ModifyROI(std::vector<float> &,
+                     ROIProperties_t const &,
+                     std::vector<SubROIProperties_t> const&,
+                     std::map<SubROI_Key_t, ScaleValues_t> const&);
+  }; // end class
+} // end namespace
+
+#endif // sbncode_WireMod_Utility_WireModUtility_hh

--- a/sbncode/WireMod/Utility/WireModUtility.hh
+++ b/sbncode/WireMod/Utility/WireModUtility.hh
@@ -19,7 +19,6 @@
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Wire.h"
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
-#include "lardataobj/Simulation/SimChannel.h"
 #include "larcoreobj/SimpleTypesAndConstants/PhysicalConstants.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
@@ -223,7 +222,6 @@ namespace sys {
 
       void FillROIMatchedEdepMap(std::vector<sim::SimEnergyDeposit> const&, std::vector<recob::Wire> const&, double offset);
       void FillROIMatchedHitMap(std::vector<recob::Hit> const&, std::vector<recob::Wire> const&);
-      void FillROIMatchedIDEMap(std::vector<sim::SimChannel> const& simchVec, std::vector<recob::Wire> const& wireVec, double offset);
 
       std::vector<SubROIProperties_t> CalcSubROIProperties(ROIProperties_t const&, std::vector<const recob::Hit*> const&);
 

--- a/sbncode/WireMod/Utility/WireModUtility.hh
+++ b/sbncode/WireMod/Utility/WireModUtility.hh
@@ -43,6 +43,9 @@ namespace sys {
       bool   applyXZAngleScale;                           // do we scale with XZ angle?
       bool   applyYZAngleScale;                           // do we scale with YZ angle?
       bool   applydEdXScale;                              // do we scale with dEdx?
+      bool   applyXXZAngleScale;                          // do we scale with X vs XZ angle?
+      bool   applyXdQdXScale;                             // do we scale with X vs dQ/dX?
+      bool   applyXZAngledQdXScale;                       // do we scale with XZ angle vs dQ/dX?
       double readoutWindowTicks;                          // how many ticks are in the readout window?
       double tickOffset;                                  // do we want an offset in the ticks?
 
@@ -59,6 +62,13 @@ namespace sys {
       std::vector<TGraph2D*> graph2Ds_Charge_YZ;          // the graphs for the charge correction in YZ
       std::vector<TGraph2D*> graph2Ds_Sigma_YZ;           // the graphs for the width correction in YZ
 
+      std::vector<TGraph2D*> graph2Ds_Charge_XXZAngle;    // the graphs for the charge correction in X vs XZ angle
+      std::vector<TGraph2D*> graph2Ds_Sigma_XXZAngle;     // the graphs for the width correction in X vs XZ angle
+      std::vector<TGraph2D*> graph2Ds_Charge_XdQdX;       // the graphs for charge correction in X vs dQ/dX
+      std::vector<TGraph2D*> graph2Ds_Sigma_XdQdX;        // the graphs for width correction in X vs dQ/dX
+      std::vector<TGraph2D*> graph2Ds_Charge_XZAngledQdX; // the graphs for charge correction in XZ angle vs dQ/dX
+      std::vector<TGraph2D*> graph2Ds_Sigma_XZAngledQdX;  // the graphs for width correction in XZ angle vs dQ/dX
+
       // lets try making a constructor here
       // assume we can get a geometry service, a detector clcok, and a detector properties
       // pass the CryoStat and TPC IDs because it's IDs all the way down
@@ -72,6 +82,9 @@ namespace sys {
                      const bool& arg_ApplyXZAngleScale = true,
                      const bool& arg_ApplyYZAngleScale = true,
                      const bool& arg_ApplydEdXScale = true,
+                     const bool& arg_ApplyXXZAngleScale = false,
+                     const bool& arg_ApplyXdQdXScale = false,
+                     const bool& arg_ApplyXZAngledQdXScale = false,
                      const double& arg_TickOffset = 0)
       : geometry(geom),
         wireReadout(wireRead),
@@ -82,6 +95,9 @@ namespace sys {
         applyXZAngleScale(arg_ApplyXZAngleScale),
         applyYZAngleScale(arg_ApplyYZAngleScale),
         applydEdXScale(arg_ApplydEdXScale),
+        applyXXZAngleScale(arg_ApplyXXZAngleScale),
+        applyXdQdXScale(arg_ApplyXdQdXScale),
+        applyXZAngledQdXScale(arg_ApplyXZAngledQdXScale),
         readoutWindowTicks(detProp.ReadOutWindowSize()),                                               // the default A2795 (ICARUS TPC readout board) readout window is 4096 samples
         tickOffset(arg_TickOffset)                                                                     // tick offset is for MC truth, default to zero and set only as necessary
       {
@@ -137,6 +153,7 @@ namespace sys {
         double dxdr;
         double dydr;
         double dzdr;
+        double dqdr;
         double dedr;
         ScaleValues_t scales_avg[3];
       } TruthProperties_t;


### PR DESCRIPTION
### Description 
Add WireMod utility functions for SBND Gen 2. This also brings in refactor of RecoUtils. The WireMod utility should be identical to the SBND Gen 1 production based on v10_06_00_10. Develop PR to follow.

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
