### PR TITLE
Update Supera and LArCV2 dependencies to significantly reduce run-tim…

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -253,7 +253,7 @@ libdir	fq_dir		lib
 ####################################
 product			version		qual	flags		<table_format=2>
 genie_xsec		v3_04_00	-
-larcv2			v2_2_6		-
+larcv2			v2_4_1		-
 larsoft			v10_06_00_02	-
 sbnalg		        v10_06_00_12	-
 sbndaq_artdaq_core	v1_10_06	-


### PR DESCRIPTION
### Description 
Please provide a detailed description of the changes this pull request introduces. If available, also link to a docdb link where the issue/change have been presented on/discussed.

- [X] Have you added a label? (bug/enhancement/physics etc.)
- [X] Have you assigned at least 1 reviewer?
- [X] Is this PR related to an open issue / project?
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [X] Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)? If so, please link it in the description.
- [X] Are you submitting this PR on behalf of someone else who made the code changes? If so, please mention them in the description.

Addresses issue #656. The Supera run-time was dominating stage1 processing of ICARUS Overlay MC, costing more than 10 minutes per event in some cases. 

@francois-drielsma has debugged and found a significant hot spot in the LArCV2 dependence, along with some sub-leading hot spots. This fix is implemented as a migration to Supera v1.0.0 and LArCV2 v2.1.4.

The feature branch compiles and has reduced run time on a test event from 800+ seconds down to 17 seconds. 