### PR TITLE
Adding "safe-guards" to avoid segfault in the GaussHitFinderSBN module

### DIFF
--- a/sbncode/HitFinder/GaussHitFinderSBN_module.cc
+++ b/sbncode/HitFinder/GaussHitFinderSBN_module.cc
@@ -388,14 +388,8 @@ namespace hit {
                 fPeakFitterTool->findPeakParameters(
                   range.data(), mergedCands, peakParamsVec, chi2PerNDF, NDF);
 
-                // If the chi2 is infinite then there is a real problem so we bail
-                if (!(chi2PerNDF < std::numeric_limits<double>::infinity())) {
-                  chi2PerNDF = 2. * fChi2NDF.at(plane);
-                  NDF = 2;
-                }
-
-                // If the chi2 is also low (low-er than -inf) we bail
-                if (!(chi2PerNDF > -std::numeric_limits<double>::infinity())) {
+                // If the chi2 is not finite then there is a real problem so we bail
+                if (!std::isfinite(chi2PerNDF)) {
                   chi2PerNDF = 2. * fChi2NDF.at(plane);
                   NDF = 2;
                 }

--- a/sbncode/HitFinder/GaussHitFinderSBN_module.cc
+++ b/sbncode/HitFinder/GaussHitFinderSBN_module.cc
@@ -497,7 +497,8 @@ namespace hit {
                 }
 
                 // Another protection: if peak is outside of the range, 
-                // we skip this hit: this should however be avoided before... see LL407-411
+                // skip the hit creation
+                // For details on this issue refer to SBN DocDB 47092
                 if ((peakMean < startT) || (peakMean >= endT)) continue;
 
                 // Extract errors
@@ -547,11 +548,13 @@ namespace hit {
                 if (HitsumStartItr > HitsumEndItr) continue;
 
                 //avoid ranges out of ROI if it happens
-                if (HitsumStartItr < sumStartItr) HitsumStartItr = sumStartItr;
+                if (HitsumStartItr < sumStartItr) HitsumStartItr = sumStartItr; // COMMENT [1] below
+                if (HitsumEndItr > sumEndItr) HitsumEndItr = sumEndItr;         // COMMENT [1] below
 
-                if (HitsumEndItr > sumEndItr) HitsumEndItr = sumEndItr;
-
-                // This prevents L577 and L579 to make any possible boundaty flip
+                // COMMENT [1] 
+                // This line prevents the two checks [1] before to
+                // make any possible boundary flip
+                // For details on this issue refer to SBN DocDB 47092
                 if (HitsumStartItr > HitsumEndItr) continue;
 
                 // ### Sum of ADC counts

--- a/sbncode/HitFinder/GaussHitFinderSBN_module.cc
+++ b/sbncode/HitFinder/GaussHitFinderSBN_module.cc
@@ -69,6 +69,18 @@ namespace hit {
     void beginJob(art::ProcessingFrame const&) override;
 
     std::vector<double> FillOutHitParameterVector(const std::vector<double>& input);
+    
+    template<class T>
+    inline std::vector<T> getValueOrListOf(fhicl::ParameterSet const& pset, std::string const& key) {
+
+      auto const& wireReadoutGeom = art::ServiceHandle<geo::WireReadout const>()->Get();
+      const unsigned int N_PLANES = wireReadoutGeom.Nplanes();
+
+      if (pset.is_key_to_sequence(key))
+        return pset.get<std::vector<T>>(key);
+      else
+        return std::vector<T>(N_PLANES, pset.get<T>(key));
+    } // getValueOrListOf()
 
     const bool fFilterHits;
     const bool fFillHists;
@@ -76,14 +88,14 @@ namespace hit {
     const std::string fCalDataModuleLabel;
     const std::string fAllHitsInstanceName;
 
-    const std::vector<int> fLongMaxHitsVec;    ///<Maximum number hits on a really long pulse train
-    const std::vector<int> fLongPulseWidthVec; ///<Sets width of hits used to describe long pulses
+    const std::vector<int> fLongMaxHitsVec;     ///< Maximum number hits on a really long pulse train
+    const std::vector<int> fLongPulseWidthVec;  ///< Sets width of hits used to describe long pulses
 
-    const size_t fMaxMultiHit; ///<maximum hits for multi fit
-    const int fAreaMethod;     ///<Type of area calculation
+    const std::vector<size_t> fMaxMultiHit;     ///< Maximum hits for multi fit
+    const int fAreaMethod;                      ///< Type of area calculation
     const std::vector<double>
-      fAreaNormsVec;       ///<factors for converting area to same units as peak height
-    const double fChi2NDF; ///maximum Chisquared / NDF allowed for a hit to be saved
+      fAreaNormsVec;                            ///< Factors for converting area to same units as peak height
+    const std::vector<double> fChi2NDF;         ///< Maximum Chisquared / NDF allowed for a hit to be saved
 
     const std::vector<float> fPulseHeightCuts;
     const std::vector<float> fPulseWidthCuts;
@@ -116,10 +128,10 @@ namespace hit {
     , fLongMaxHitsVec(pset.get<std::vector<int>>("LongMaxHits", std::vector<int>() = {25, 25, 25}))
     , fLongPulseWidthVec(
         pset.get<std::vector<int>>("LongPulseWidth", std::vector<int>() = {16, 16, 16}))
-    , fMaxMultiHit(pset.get<int>("MaxMultiHit"))
+    , fMaxMultiHit(getValueOrListOf<size_t>(pset, "MaxMultiHit"))
     , fAreaMethod(pset.get<int>("AreaMethod"))
     , fAreaNormsVec(FillOutHitParameterVector(pset.get<std::vector<double>>("AreaNorms")))
-    , fChi2NDF(pset.get<double>("Chi2NDF"))
+    , fChi2NDF(getValueOrListOf<double>(pset, "Chi2NDF"))
     , fPulseHeightCuts(
         pset.get<std::vector<float>>("PulseHeightCuts", std::vector<float>() = {3.0, 3.0, 3.0}))
     , fPulseWidthCuts(
@@ -365,13 +377,19 @@ namespace hit {
               // #######################################################
               // ### If # requested Gaussians is too large then punt ###
               // #######################################################
-              if (mergedCands.size() <= fMaxMultiHit) {
+              if (mergedCands.size() <= fMaxMultiHit.at(plane)) {
                 fPeakFitterTool->findPeakParameters(
                   range.data(), mergedCands, peakParamsVec, chi2PerNDF, NDF);
 
                 // If the chi2 is infinite then there is a real problem so we bail
                 if (!(chi2PerNDF < std::numeric_limits<double>::infinity())) {
-                  chi2PerNDF = 2. * fChi2NDF;
+                  chi2PerNDF = 2. * fChi2NDF.at(plane);
+                  NDF = 2;
+                }
+
+                // If the chi2 is also low (low-er than -inf) we bail
+                if (!(chi2PerNDF > -std::numeric_limits<double>::infinity())) {
+                  chi2PerNDF = 2. * fChi2NDF.at(plane);
                   NDF = 2;
                 }
 
@@ -384,7 +402,7 @@ namespace hit {
               // ###   depend on the fhicl parameter fLongPulseWidth ###
               // ### Also do this if chi^2 is too large              ###
               // #######################################################
-              if (mergedCands.size() > fMaxMultiHit || nGausForFit * chi2PerNDF > fChi2NDF) {
+              if (mergedCands.size() > fMaxMultiHit.at(plane) || nGausForFit * chi2PerNDF > fChi2NDF.at(plane)) {
                 int longPulseWidth = fLongPulseWidthVec.at(plane);
                 int nHitsThisPulse = (endT - startT) / longPulseWidth;
 
@@ -401,7 +419,7 @@ namespace hit {
                 peakParamsVec.clear();
                 nGausForFit = nHitsThisPulse;
                 NDF = 1.;
-                chi2PerNDF = chi2PerNDF > fChi2NDF ? chi2PerNDF : -1.;
+                chi2PerNDF = chi2PerNDF > fChi2NDF.at(plane) ? chi2PerNDF : -1.;
 
                 for (int hitIdx = 0; hitIdx < nHitsThisPulse; hitIdx++) {
                   // This hit parameters
@@ -445,13 +463,12 @@ namespace hit {
               float nsigmaADC(2.0);
               float newright(0);
               float newleft(0);
+
               for (const auto& peakParams : peakParamsVec) {
                 // Extract values for this hit
                 float peakAmp = peakParams.peakAmplitude;
                 float peakMean = peakParams.peakCenter;
                 float peakWidth = peakParams.peakSigma;
-
-                //std::cout<<" ans hits "<<numHits<<" gaus "<<nGausForFit<<std::endl;
 
                 //ANS get prev and next
                 if (numHits == 0) {
@@ -465,12 +482,10 @@ namespace hit {
                 if (numHits < nGausForFit - 1) {
                   nextpeak = (peakParamsVec.at(numHits + 1)).peakCenter;
                   nextpeakSig = (peakParamsVec.at(numHits + 1)).peakSigma;
-                  //std::cout<<" ans size "<<peakParamsVec.size()<<" hit "<<numHits<<" next peak "<<nextpeak<<" sig "<<nextpeakSig<<std::endl;
                 }
                 if (numHits > 0) {
                   prevpeak = (peakParamsVec.at(numHits - 1)).peakCenter;
                   prevpeakSig = (peakParamsVec.at(numHits - 1)).peakSigma;
-                  //std::cout<<" ans size "<<peakParamsVec.size()<<"hit "<<numHits<<" prev peak "<<prevpeak<<" sig "<<prevpeakSig<<std::endl;
                 }
 
                 // Place one bit of protection here
@@ -479,6 +494,10 @@ namespace hit {
                             << ", start tick: " << startT << std::endl;
                   continue;
                 }
+
+                // Another protection: if peak is outside of the range, 
+                // we skip this hit: this should however be avoided before... see LL407-411
+                if ((peakMean < startT) || (peakMean >= endT)) continue;
 
                 // Extract errors
                 float peakAmpErr = peakParams.peakAmplitudeError;
@@ -531,6 +550,9 @@ namespace hit {
 
                 if (HitsumEndItr > sumEndItr) HitsumEndItr = sumEndItr;
 
+                // This prevents L577 and L579 to make any possible boundaty flip
+                if (HitsumStartItr > HitsumEndItr) continue;
+
                 // ### Sum of ADC counts
                 float ROIsumADC = std::accumulate(sumStartItr, sumEndItr, 0.);
                 float HitsumADC = std::accumulate(HitsumStartItr, HitsumEndItr, 0.);
@@ -568,6 +590,11 @@ namespace hit {
 
                 numHits++;
               } // <---End loop over gaussians
+
+              // THIS IS NOT USED
+              // THIS IS NOT USED
+              // THIS IS NOT USED
+              // THIS IS NOT USED
 
               // Should we filter hits?
               if (filteredHitCol && !filteredHitVec.empty()) {
@@ -627,11 +654,11 @@ namespace hit {
 //
                 if (fFillHists) fChi2->Fill(chi2PerNDF);
               }
-            } //<---End loop over merged candidate hits
-          }   //<---End looping over ROI's
-        );    //end tbb parallel for
-      }       //<---End looping over all the wires
-    );        //end tbb parallel for
+            } //< End loop over merged candidate hits
+          }   //< End looping over ROI's
+        );    //< End tbb::parallel_for(ROI)
+      }       //< End looping over all the wires
+    );        //< End tbb::parallel_for(channelROI)
 
     for (size_t i = 0; i < hitstruct_vec.size(); i++) {
       allHitCol.emplace_back(hitstruct_vec[i].hit_tbb, hitstruct_vec[i].channelROI_tbb);

--- a/sbncode/HitFinder/GaussHitFinderSBN_module.cc
+++ b/sbncode/HitFinder/GaussHitFinderSBN_module.cc
@@ -592,11 +592,6 @@ namespace hit {
                 numHits++;
               } // <---End loop over gaussians
 
-              // THIS IS NOT USED
-              // THIS IS NOT USED
-              // THIS IS NOT USED
-              // THIS IS NOT USED
-
               // Should we filter hits?
               if (filteredHitCol && !filteredHitVec.empty()) {
                 // #######################################################################
@@ -647,12 +642,12 @@ namespace hit {
                 }
 
                 // Copy the hits we want to keep to the filtered hit collection
-//                for (const auto& filteredHit : filteredHitVec)
-//                  if (!fHitFilterAlg || fHitFilterAlg->IsGoodHit(filteredHit)) {
-//                    hitstruct tmp{std::move(filteredHit), channelROI};
-//                    filthitstruct_vec.push_back(std::move(tmp));
-//                  }
-//
+              //  for (const auto& filteredHit : filteredHitVec)
+              //    if (!fHitFilterAlg || fHitFilterAlg->IsGoodHit(filteredHit)) {
+              //      hitstruct tmp{std::move(filteredHit), channelROI};
+              //      filthitstruct_vec.push_back(std::move(tmp));
+              //    }
+
                 if (fFillHists) fChi2->Fill(chi2PerNDF);
               }
             } //< End loop over merged candidate hits

--- a/sbncode/HitFinder/hitfindermodules_sbn.fcl
+++ b/sbncode/HitFinder/hitfindermodules_sbn.fcl
@@ -11,17 +11,17 @@ gauss_hitfinder:
 {
     module_type:          "GaussHitFinderSBN"
     CalDataModuleLabel:   "caldata"
-    MaxMultiHit:          5                  # maximum hits for multi gaussia fit attempt
-    AreaMethod:           0                  # 0 = area by integral, 1 = area by gaussian area formula
-    AreaNorms:            [ 1.0, 1.0, 1.0 ]  # normalizations that put signal area in
-                                             # same scale as peak height.
-    TryNplus1Fits:        false              # Don't try to refit with extra peak if bad chisq
-    LongMaxHits:          [ 25, 25, 25]      # max number hits in long pulse trains
-    LongPulseWidth:       [ 10, 10, 10]      # max widths for hits in long pulse trains
-    Chi2NDF:              500.               # maximum Chisquared / NDF allowed to store fit, if fail
-                                             # will use "long" pulse method to return hit
-    AllHitsInstanceName:  ""                 # If non-null then this will be the instance name of all hits output to event
-                                             # in this case there will be two hit collections, one filtered and one containing all hits
+    MaxMultiHit:          5                       #< Maximum hits for multi gaussian fit attempt
+    AreaMethod:           0                       #< 0 = area by integral, 1 = area by gaussian area formula
+    AreaNorms:            [ 1.0, 1.0, 1.0 ]       #< Normalizations that put signal area in
+                                                  #< same scale as peak height.
+    TryNplus1Fits:        false                   #< Don't try to refit with extra peak if bad chisq
+    LongMaxHits:          [ 25, 25, 25]           #< Max number hits in long pulse trains
+    LongPulseWidth:       [ 5, 5, 5]              #< Max widths for hits in long pulse trains
+    Chi2NDF:              500.                    #< Maximum Chisquared / NDF allowed to store fit
+                                                  #< Will use "long" pulse method to return hit
+    AllHitsInstanceName:  ""                      #< If non-null then this will be the instance name of all hits output to event
+                                                  #< In this case there will be two hit collections, one filtered and one containing all hits
 
     # Candididate peak finding done by tool, one tool instantiated per plane (but could be other divisions too)
     HitFinderToolVec:
@@ -39,7 +39,7 @@ gauss_hitfinder:
     HitFilterAlg:
     {
         AlgName: "HitFilterAlg"
-        MinPulseHeight: [5.0, 5.0, 5.0]      #minimum hit peak amplitude per plane
+        MinPulseHeight: [2.0, 2.0, 2.0]      #minimum hit peak amplitude per plane
         MinPulseSigma:  [1.0, 1.0, 1.0]      #minimum hit rms per plane
     }
                                              # In addition to the filter alg we can also filter hits on the same pulse train


### PR DESCRIPTION
# The issue

The introduction of the `NextADCThreshold` parameter in LArSoft/larreco#92 highlighted some minor bugs in the `GaussHitFinderSBN` module that made the code segfault for some edge case. 

This PR aims at adding some safeguards to the code preventing the segfault to happen. 

# Description

The changes happens in three points of the code

1. After the `peakFitterTool` returns the peak parameters for each "candidate hit". Here we added a check for all "not finite" bounds, whereas the old version of the code was only checking for the positive side. Since the $\chi^2/\mathrm{ndf}$ is computed from all the fitted hits, $-\infty$ values were possible, and treated as "not pathological". This fixes those cases. 
2. After all candidates have been fitted and failed fits treated accordingly, when computing the boundaries of the hits we added a check (line 501) making sure the start/end points where still withing the ROI range. 
3. Finally after all the safe-guards at the end of the module are applied, we make sure (line 555) that no "boundary flip" has happened (i.e. start > end) 