### PR TITLE
Feature/blip energy drift correction

### DIFF
--- a/sbncode/CAFMaker/FillBlip.cxx
+++ b/sbncode/CAFMaker/FillBlip.cxx
@@ -19,6 +19,9 @@ namespace caf
             NewBlip.energy = CurrentBlip.Energy/1000.; //convert to GeV
             NewBlip.energyESTAR = CurrentBlip.EnergyESTAR/1000.; //convert to GeV
             NewBlip.energyPSTAR = CurrentBlip.EnergyPSTAR/1000.; //convert to GeV
+            NewBlip.energyNoDriftCorr = CurrentBlip.EnergyNoDriftCorr/1000.; //convert to GeV
+            NewBlip.energyESTARnoDriftCorr = CurrentBlip.EnergyESTARNoDriftCorr/1000.; //convert to GeV
+            NewBlip.energyPSTARnoDriftCorr = CurrentBlip.EnergyPSTARNoDriftCorr/1000.; //convert to GeV
             NewBlip.proxTrkDist = CurrentBlip.ProxTrkDist; 
             NewBlip.proxTrkID = CurrentBlip.ProxTrkID;
             NewBlip.inCylinder = CurrentBlip.inCylinder;

--- a/sbncode/CAFMaker/FillBlip.cxx
+++ b/sbncode/CAFMaker/FillBlip.cxx
@@ -19,9 +19,9 @@ namespace caf
             NewBlip.energy = CurrentBlip.Energy/1000.; //convert to GeV
             NewBlip.energyESTAR = CurrentBlip.EnergyESTAR/1000.; //convert to GeV
             NewBlip.energyPSTAR = CurrentBlip.EnergyPSTAR/1000.; //convert to GeV
-            NewBlip.energyNoDriftCorrection = CurrentBlip.EnergyNoDriftCorr/1000.; //convert to GeV
-            NewBlip.energyESTARnoDriftCorrection = CurrentBlip.EnergyESTARNoDriftCorr/1000.; //convert to GeV
-            NewBlip.energyPSTARnoDriftCorrection = CurrentBlip.EnergyPSTARNoDriftCorr/1000.; //convert to GeV
+            NewBlip.energyNoDriftCorr = CurrentBlip.EnergyNoDriftCorrection/1000.; //convert to GeV
+            NewBlip.energyESTARnoDriftCorr = CurrentBlip.EnergyESTARNoDriftCorrection/1000.; //convert to GeV
+            NewBlip.energyPSTARnoDriftCorr = CurrentBlip.EnergyPSTARNoDriftCorrection/1000.; //convert to GeV
             NewBlip.proxTrkDist = CurrentBlip.ProxTrkDist; 
             NewBlip.proxTrkID = CurrentBlip.ProxTrkID;
             NewBlip.inCylinder = CurrentBlip.inCylinder;

--- a/sbncode/CAFMaker/FillBlip.cxx
+++ b/sbncode/CAFMaker/FillBlip.cxx
@@ -19,9 +19,9 @@ namespace caf
             NewBlip.energy = CurrentBlip.Energy/1000.; //convert to GeV
             NewBlip.energyESTAR = CurrentBlip.EnergyESTAR/1000.; //convert to GeV
             NewBlip.energyPSTAR = CurrentBlip.EnergyPSTAR/1000.; //convert to GeV
-            NewBlip.energyNoDriftCorr = CurrentBlip.EnergyNoDriftCorr/1000.; //convert to GeV
-            NewBlip.energyESTARnoDriftCorr = CurrentBlip.EnergyESTARNoDriftCorr/1000.; //convert to GeV
-            NewBlip.energyPSTARnoDriftCorr = CurrentBlip.EnergyPSTARNoDriftCorr/1000.; //convert to GeV
+            NewBlip.energyNoDriftCorrection = CurrentBlip.EnergyNoDriftCorr/1000.; //convert to GeV
+            NewBlip.energyESTARnoDriftCorrection = CurrentBlip.EnergyESTARNoDriftCorr/1000.; //convert to GeV
+            NewBlip.energyPSTARnoDriftCorrection = CurrentBlip.EnergyPSTARNoDriftCorr/1000.; //convert to GeV
             NewBlip.proxTrkDist = CurrentBlip.ProxTrkDist; 
             NewBlip.proxTrkID = CurrentBlip.ProxTrkID;
             NewBlip.inCylinder = CurrentBlip.inCylinder;


### PR DESCRIPTION
Adding additional blip energy variables so analyzers have access to a drift corrected energy, as well as an explicitly not drift corrected one.

All drift corrections are anchored to the event timestamp, so the beam blips will come out with the right energy. Any out-of-time blip activity will be mis-corrected, so the noDriftCorrection variables are saved as new variables.