### PR TITLE
sbncode/OpDet: don't declare PDMapAlgSimple in header so link library works correctly, add geant4reweight targets.

### DIFF
--- a/sbncode/OpDet/CMakeLists.txt
+++ b/sbncode/OpDet/CMakeLists.txt
@@ -8,6 +8,7 @@ cet_make_library(
 
 cet_build_plugin(PDMapAlgSimple art::tool LIBRARIES PRIVATE
             art::Utilities
+            sbncode::OpDet_PDMapAlg
 )
 
 install_headers()

--- a/sbncode/OpDet/PDMapAlg.h
+++ b/sbncode/OpDet/PDMapAlg.h
@@ -13,7 +13,6 @@
 #define SBN_OpDet_PDMapAlg_H
 
 //#include "fhiclcpp/ParameterSet.h"
-//#include "art/Utilities/ToolMacros.h"
 
 #include <string>
 
@@ -55,7 +54,6 @@ namespace opdet {
   };
 
 
-  DEFINE_ART_CLASS_TOOL(PDMapAlgSimple)
   */
 } // namespace
 

--- a/sbncode/SBNEventWeight/Calculators/Geant4/CMakeLists.txt
+++ b/sbncode/SBNEventWeight/Calculators/Geant4/CMakeLists.txt
@@ -14,8 +14,8 @@ art_make_library(
     larcore::Geometry_Geometry_service
     cetlib_except::cetlib_except
     Geant4::G4ptl
-    ReweightBaseLib
-    PropBaseLib
+    geant4reweight::ReweightBaseLib
+    geant4reweight::PropBaseLib
     ROOT::Tree
 )
 


### PR DESCRIPTION
## Description 
This fixes the cetmodules error from linking a tool library to another tool library found when building with `spack mpd`
```
CMake Error at /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/CetProcessLiblist.cmake:68 (message):


  target sbndcode_OpDetSim_sbndPDMapAlg_tool cannot link to target
  sbncode::OpDet_PDMapAlgSimple_tool of CMake type "MODULE_LIBRARY".

  Separate implementation from plugin registration code (e.g.  X.cc vs
  X_<plugin-suffix>.cc) (strongly recommended), specify PUBLIC dependencies
  to basic_plugin() (temporary solution only), or set sbndcode_MODULE_PLUGINS
  to FALSE (not recommended)
Call Stack (most recent call first):
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/CetProcessLiblist.cmake:24 (_cet_convert_target_arg)
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/CetProcessLiblist.cmake:12 (cet_convert_target_args)
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/CetMakeLibrary.cmake:295 (cet_process_liblist)
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/BasicPlugin.cmake:312 (cet_make_library)
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/compat/art/art::tool.cmake:35 (basic_plugin)
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/BasicPlugin.cmake:373 (art::tool)
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/BasicPlugin.cmake:373 (cmake_language)
  sbndcode/sbndcode/OpDetSim/CMakeLists.txt:2 (cet_build_plugin)


CMake Error at /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/CetMakeLibrary.cmake:456 (target_link_libraries):
  Target "sbncode::OpDet_PDMapAlgSimple_tool" of type MODULE_LIBRARY may not
  be linked into another target.  One may link only to INTERFACE, OBJECT,
  STATIC or SHARED libraries, or to executables with the ENABLE_EXPORTS
  property set.
Call Stack (most recent call first):
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/BasicPlugin.cmake:312 (cet_make_library)
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/compat/art/art::tool.cmake:35 (basic_plugin)
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/BasicPlugin.cmake:373 (art::tool)
  /scratch/gartung/devtest/mpddev/local/.spack-env/view/Modules/BasicPlugin.cmake:373 (cmake_language)
  sbndcode/sbndcode/OpDetSim/CMakeLists.txt:2 (cet_build_plugin)
  ```

Can be tested with or without https://github.com/SBNSoftware/sbndcode/pull/945